### PR TITLE
Add V2 API endpoints for 2FA, sessions, and GDPR consent

### DIFF
--- a/httpdocs/routes.php
+++ b/httpdocs/routes.php
@@ -296,6 +296,9 @@ $router->add('GET', '/api/v2/users/{id}', 'Nexus\Controllers\Api\UsersApiControl
 $router->add('GET', '/api/v2/users/{id}/listings', 'Nexus\Controllers\Api\UsersApiController@listings');
 $router->add('GET', '/api/v2/users/me/notifications', 'Nexus\Controllers\Api\UsersApiController@notificationPreferences');
 $router->add('PUT', '/api/v2/users/me/notifications', 'Nexus\Controllers\Api\UsersApiController@updateNotificationPreferences');
+$router->add('GET', '/api/v2/users/me/consent', 'Nexus\Controllers\Api\UsersApiController@getConsent');
+$router->add('PUT', '/api/v2/users/me/consent', 'Nexus\Controllers\Api\UsersApiController@updateConsent');
+$router->add('POST', '/api/v2/users/me/gdpr-request', 'Nexus\Controllers\Api\UsersApiController@createGdprRequest');
 $router->add('GET', '/api/v2/members/nearby', 'Nexus\Controllers\Api\UsersApiController@nearby');
 
 // ============================================

--- a/httpdocs/routes.php
+++ b/httpdocs/routes.php
@@ -286,6 +286,7 @@ $router->add('GET', '/api/v2/users', function () {
 });
 $router->add('GET', '/api/v2/users/me', 'Nexus\Controllers\Api\UsersApiController@me');
 $router->add('PUT', '/api/v2/users/me', 'Nexus\Controllers\Api\UsersApiController@update');
+$router->add('GET', '/api/v2/users/me/preferences', 'Nexus\Controllers\Api\UsersApiController@getPreferences');
 $router->add('PUT', '/api/v2/users/me/preferences', 'Nexus\Controllers\Api\UsersApiController@updatePreferences');
 $router->add('PUT', '/api/v2/users/me/theme', 'Nexus\Controllers\Api\UsersApiController@updateTheme');
 $router->add('POST', '/api/v2/users/me/avatar', 'Nexus\Controllers\Api\UsersApiController@updateAvatar');
@@ -299,6 +300,7 @@ $router->add('PUT', '/api/v2/users/me/notifications', 'Nexus\Controllers\Api\Use
 $router->add('GET', '/api/v2/users/me/consent', 'Nexus\Controllers\Api\UsersApiController@getConsent');
 $router->add('PUT', '/api/v2/users/me/consent', 'Nexus\Controllers\Api\UsersApiController@updateConsent');
 $router->add('POST', '/api/v2/users/me/gdpr-request', 'Nexus\Controllers\Api\UsersApiController@createGdprRequest');
+$router->add('GET', '/api/v2/users/me/sessions', 'Nexus\Controllers\Api\UsersApiController@sessions');
 $router->add('GET', '/api/v2/members/nearby', 'Nexus\Controllers\Api\UsersApiController@nearby');
 
 // ============================================
@@ -1102,9 +1104,15 @@ $router->add('POST', '/api/auth/reset-password', 'Nexus\Controllers\Api\Password
 $router->add('POST', '/api/auth/verify-email', 'Nexus\Controllers\Api\EmailVerificationApiController@verifyEmail');
 $router->add('POST', '/api/auth/resend-verification', 'Nexus\Controllers\Api\EmailVerificationApiController@resendVerification');
 
-// TOTP 2FA API
+// TOTP 2FA API (Legacy V1)
 $router->add('POST', '/api/totp/verify', 'Nexus\Controllers\Api\TotpApiController@verify');
 $router->add('GET', '/api/totp/status', 'Nexus\Controllers\Api\TotpApiController@status');
+
+// TOTP 2FA API (V2 - Bearer token compatible, used by React SPA)
+$router->add('GET', '/api/v2/auth/2fa/status', 'Nexus\Controllers\Api\TwoFactorApiController@status');
+$router->add('POST', '/api/v2/auth/2fa/setup', 'Nexus\Controllers\Api\TwoFactorApiController@setup');
+$router->add('POST', '/api/v2/auth/2fa/verify', 'Nexus\Controllers\Api\TwoFactorApiController@verify');
+$router->add('POST', '/api/v2/auth/2fa/disable', 'Nexus\Controllers\Api\TwoFactorApiController@disable');
 
 // Mobile App API (version checking, updates)
 $router->add('POST', '/api/app/check-version', 'Nexus\Controllers\Api\AppController@checkVersion');

--- a/react-frontend/src/pages/settings/SettingsPage.tsx
+++ b/react-frontend/src/pages/settings/SettingsPage.tsx
@@ -108,7 +108,12 @@ interface NotificationSettings {
   email_connections: boolean;
   email_transactions: boolean;
   email_reviews: boolean;
-  email_gamification: boolean;
+  email_gamification_digest: boolean;
+  email_gamification_milestones: boolean;
+  email_org_payments: boolean;
+  email_org_transfers: boolean;
+  email_org_membership: boolean;
+  email_org_admin: boolean;
   push_enabled: boolean;
 }
 
@@ -201,12 +206,23 @@ export function SettingsPage() {
     email_connections: true,
     email_transactions: true,
     email_reviews: true,
-    email_gamification: false,
+    email_gamification_digest: true,
+    email_gamification_milestones: true,
+    email_org_payments: true,
+    email_org_transfers: true,
+    email_org_membership: true,
+    email_org_admin: true,
     push_enabled: true,
   });
 
-  // Match digest frequency
+  // Match digest frequency & preferences
   const [matchDigestFrequency, setMatchDigestFrequency] = useState<string>('daily');
+  const [notifyHotMatches, setNotifyHotMatches] = useState(true);
+  const [notifyMutualMatches, setNotifyMutualMatches] = useState(true);
+
+  // Marketing consent
+  const [marketingConsent, setMarketingConsent] = useState(false);
+  const [marketingConsentLoading, setMarketingConsentLoading] = useState(false);
 
   // Privacy settings
   const [privacy, setPrivacy] = useState<PrivacySettings>({
@@ -270,20 +286,41 @@ export function SettingsPage() {
 
   const loadMatchPreferences = useCallback(async () => {
     try {
-      const response = await api.get<{ notification_frequency: string }>('/v2/users/me/match-preferences');
+      const response = await api.get<{ notification_frequency: string; notify_hot_matches: boolean; notify_mutual_matches: boolean }>('/v2/users/me/match-preferences');
       if (response.success && response.data) {
         setMatchDigestFrequency(response.data.notification_frequency || 'daily');
+        setNotifyHotMatches(response.data.notify_hot_matches ?? true);
+        setNotifyMutualMatches(response.data.notify_mutual_matches ?? true);
       }
     } catch (error) {
       logError('Failed to load match preferences', error);
     }
   }, []);
 
+  const loadMarketingConsent = useCallback(async () => {
+    try {
+      const response = await api.get<Array<{ consent_type_slug: string; given: boolean }>>('/v2/users/me/consent');
+      if (response.success && Array.isArray(response.data)) {
+        const marketing = response.data.find((c) => c.consent_type_slug === 'marketing_email');
+        if (marketing) {
+          setMarketingConsent(marketing.given);
+        }
+      }
+    } catch (error) {
+      logError('Failed to load marketing consent', error);
+    }
+  }, []);
+
   const loadPrivacySettings = useCallback(async () => {
     try {
-      const response = await api.get<{ privacy: PrivacySettings }>('/v2/users/me/preferences');
+      const response = await api.get<{ privacy: { privacy_profile: string; privacy_search: boolean; privacy_contact: boolean } }>('/v2/users/me/preferences');
       if (response.success && response.data?.privacy) {
-        setPrivacy((prev) => ({ ...prev, ...response.data!.privacy }));
+        const p = response.data.privacy;
+        setPrivacy({
+          profile_visibility: (p.privacy_profile as 'public' | 'members' | 'connections') || 'members',
+          search_indexing: p.privacy_search ?? true,
+          contact_permission: p.privacy_contact ?? true,
+        });
       }
     } catch (error) {
       logError('Failed to load privacy settings', error);
@@ -346,10 +383,11 @@ export function SettingsPage() {
     }
     loadNotificationSettings();
     loadMatchPreferences();
+    loadMarketingConsent();
     loadPrivacySettings();
     loadTwoFactorStatus();
     loadSessions();
-  }, [user, loadNotificationSettings, loadMatchPreferences, loadPrivacySettings, loadTwoFactorStatus, loadSessions]);
+  }, [user, loadNotificationSettings, loadMatchPreferences, loadMarketingConsent, loadPrivacySettings, loadTwoFactorStatus, loadSessions]);
 
   // Load insurance certificates when insurance is enabled
   const loadInsuranceCerts = useCallback(async () => {
@@ -420,6 +458,8 @@ export function SettingsPage() {
         api.put('/v2/users/me/notifications', notifications),
         api.put('/v2/users/me/match-preferences', {
           notification_frequency: matchDigestFrequency,
+          notify_hot_matches: notifyHotMatches,
+          notify_mutual_matches: notifyMutualMatches,
         }),
       ]);
       if (notifResponse.success && matchResponse.success) {
@@ -433,12 +473,19 @@ export function SettingsPage() {
     } finally {
       setIsSaving(false);
     }
-  }, [notifications, matchDigestFrequency, toast]);
+  }, [notifications, matchDigestFrequency, notifyHotMatches, notifyMutualMatches, toast]);
 
   const savePrivacy = useCallback(async () => {
     try {
       setIsSavingPrivacy(true);
-      const response = await api.put('/v2/users/me/preferences', { privacy });
+      // Map React field names to PHP field names
+      const response = await api.put('/v2/users/me/preferences', {
+        privacy: {
+          privacy_profile: privacy.profile_visibility,
+          privacy_search: privacy.search_indexing,
+          privacy_contact: privacy.contact_permission,
+        },
+      });
       if (response.success) {
         toast.success('Privacy settings saved');
       } else {
@@ -651,6 +698,31 @@ export function SettingsPage() {
       toast.error('Failed to disable 2FA', 'Password may be incorrect');
     } finally {
       setIsDisabling2FA(false);
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Marketing Consent Handler
+  // ─────────────────────────────────────────────────────────────────────────
+
+  async function handleMarketingConsentToggle(checked: boolean) {
+    try {
+      setMarketingConsentLoading(true);
+      const response = await api.put('/v2/users/me/consent', {
+        slug: 'marketing_email',
+        given: checked,
+      });
+      if (response.success) {
+        setMarketingConsent(checked);
+        toast.success(checked ? 'Subscribed to marketing emails' : 'Unsubscribed from marketing emails');
+      } else {
+        toast.error('Failed to update marketing consent');
+      }
+    } catch (error) {
+      logError('Failed to update marketing consent', error);
+      toast.error('Failed to update marketing consent');
+    } finally {
+      setMarketingConsentLoading(false);
     }
   }
 
@@ -1091,10 +1163,17 @@ export function SettingsPage() {
                   </h3>
 
                   <SettingToggle
+                    label="Gamification Digest"
+                    description="Periodic summary of your gamification activity and progress"
+                    checked={notifications.email_gamification_digest}
+                    onChange={(checked) => setNotifications((prev) => ({ ...prev, email_gamification_digest: checked }))}
+                  />
+
+                  <SettingToggle
                     label="Achievement Milestones"
                     description="Badge unlocks, level ups, and achievement notifications"
-                    checked={notifications.email_gamification}
-                    onChange={(checked) => setNotifications((prev) => ({ ...prev, email_gamification: checked }))}
+                    checked={notifications.email_gamification_milestones}
+                    onChange={(checked) => setNotifications((prev) => ({ ...prev, email_gamification_milestones: checked }))}
                   />
 
                   <SettingToggle
@@ -1104,6 +1183,44 @@ export function SettingsPage() {
                     onChange={(checked) => setNotifications((prev) => ({ ...prev, email_digest: checked }))}
                   />
                 </div>
+
+                {/* Organisation Notifications */}
+                {profileData.profile_type === 'organisation' && (
+                  <div className="pt-4 border-t border-theme-default space-y-4">
+                    <h3 className="text-sm font-medium text-theme-muted flex items-center gap-2">
+                      <Building2 className="w-4 h-4" aria-hidden="true" />
+                      Organisation Notifications
+                    </h3>
+
+                    <SettingToggle
+                      label="Payment Notifications"
+                      description="Notifications for organisation payment activity"
+                      checked={notifications.email_org_payments}
+                      onChange={(checked) => setNotifications((prev) => ({ ...prev, email_org_payments: checked }))}
+                    />
+
+                    <SettingToggle
+                      label="Transfer Notifications"
+                      description="Notifications for credit transfers"
+                      checked={notifications.email_org_transfers}
+                      onChange={(checked) => setNotifications((prev) => ({ ...prev, email_org_transfers: checked }))}
+                    />
+
+                    <SettingToggle
+                      label="Membership Updates"
+                      description="Member joins, leaves, and membership changes"
+                      checked={notifications.email_org_membership}
+                      onChange={(checked) => setNotifications((prev) => ({ ...prev, email_org_membership: checked }))}
+                    />
+
+                    <SettingToggle
+                      label="Admin Notifications"
+                      description="Administrative alerts and system notifications"
+                      checked={notifications.email_org_admin}
+                      onChange={(checked) => setNotifications((prev) => ({ ...prev, email_org_admin: checked }))}
+                    />
+                  </div>
+                )}
 
                 {/* Match Digest */}
                 <div className="pt-4 border-t border-theme-default space-y-4">
@@ -1137,6 +1254,20 @@ export function SettingsPage() {
                       </Select>
                     </div>
                   </div>
+
+                  <SettingToggle
+                    label="Hot Match Alerts"
+                    description="Get notified about high-compatibility matches"
+                    checked={notifyHotMatches}
+                    onChange={setNotifyHotMatches}
+                  />
+
+                  <SettingToggle
+                    label="Mutual Match Alerts"
+                    description="Get notified when someone you matched with also matches you"
+                    checked={notifyMutualMatches}
+                    onChange={setNotifyMutualMatches}
+                  />
                 </div>
 
                 {/* Push Notifications */}
@@ -1151,6 +1282,22 @@ export function SettingsPage() {
                     description="Receive real-time notifications on your device"
                     checked={notifications.push_enabled}
                     onChange={(checked) => setNotifications((prev) => ({ ...prev, push_enabled: checked }))}
+                  />
+                </div>
+
+                {/* Marketing & Communications */}
+                <div className="pt-4 border-t border-theme-default space-y-4">
+                  <h3 className="text-sm font-medium text-theme-muted flex items-center gap-2">
+                    <Mail className="w-4 h-4" aria-hidden="true" />
+                    Marketing & Communications
+                  </h3>
+
+                  <SettingToggle
+                    label="Marketing Emails"
+                    description="Receive newsletters, promotions, and community updates"
+                    checked={marketingConsent}
+                    onChange={handleMarketingConsentToggle}
+                    disabled={marketingConsentLoading}
                   />
                 </div>
 
@@ -2044,9 +2191,10 @@ interface SettingToggleProps {
   description: string;
   checked: boolean;
   onChange: (checked: boolean) => void;
+  disabled?: boolean;
 }
 
-function SettingToggle({ label, description, checked, onChange }: SettingToggleProps) {
+function SettingToggle({ label, description, checked, onChange, disabled }: SettingToggleProps) {
   return (
     <div className="flex items-center justify-between p-4 rounded-lg bg-theme-elevated">
       <div>
@@ -2057,6 +2205,7 @@ function SettingToggle({ label, description, checked, onChange }: SettingToggleP
         aria-label={label}
         isSelected={checked}
         onValueChange={onChange}
+        isDisabled={disabled}
         classNames={{
           wrapper: 'group-data-[selected=true]:bg-indigo-500',
         }}

--- a/react-frontend/src/pages/settings/SettingsPage.tsx
+++ b/react-frontend/src/pages/settings/SettingsPage.tsx
@@ -69,6 +69,9 @@ import {
   Info,
   FileCheck,
   Upload,
+  PenLine,
+  Ban,
+  Scale,
 } from 'lucide-react';
 import DOMPurify from 'dompurify';
 import { GlassCard } from '@/components/ui';
@@ -658,10 +661,20 @@ export function SettingsPage() {
   async function handleGdprRequest() {
     if (!gdprRequestType) return;
 
+    // Map UI types to GDPR API types
+    const typeMap: Record<string, string> = {
+      download: 'access',
+      portability: 'portability',
+      deletion: 'erasure',
+      rectification: 'rectification',
+      restriction: 'restriction',
+      objection: 'objection',
+    };
+
     try {
       setIsSubmittingGdpr(true);
       const response = await api.post('/v2/users/me/gdpr-request', {
-        type: gdprRequestType,
+        type: typeMap[gdprRequestType] || gdprRequestType,
       });
 
       if (response.success) {
@@ -1290,13 +1303,60 @@ export function SettingsPage() {
                     <p className="text-sm text-theme-subtle font-normal">Request permanent deletion of your data</p>
                   </div>
                 </Button>
+
+                <Button
+                  variant="flat"
+                  className="w-full justify-start bg-theme-elevated text-theme-primary h-auto py-3 px-4"
+                  startContent={
+                    <div className="p-2 rounded-lg bg-amber-500/20">
+                      <PenLine className="w-4 h-4 text-amber-600 dark:text-amber-400" aria-hidden="true" />
+                    </div>
+                  }
+                  onPress={() => openGdprModal('rectification')}
+                >
+                  <div className="text-left">
+                    <p className="font-medium">Data Rectification</p>
+                    <p className="text-sm text-theme-subtle font-normal">Request correction of inaccurate personal data</p>
+                  </div>
+                </Button>
+
+                <Button
+                  variant="flat"
+                  className="w-full justify-start bg-theme-elevated text-theme-primary h-auto py-3 px-4"
+                  startContent={
+                    <div className="p-2 rounded-lg bg-orange-500/20">
+                      <Ban className="w-4 h-4 text-orange-600 dark:text-orange-400" aria-hidden="true" />
+                    </div>
+                  }
+                  onPress={() => openGdprModal('restriction')}
+                >
+                  <div className="text-left">
+                    <p className="font-medium">Restriction of Processing</p>
+                    <p className="text-sm text-theme-subtle font-normal">Request restriction of your data processing</p>
+                  </div>
+                </Button>
+
+                <Button
+                  variant="flat"
+                  className="w-full justify-start bg-theme-elevated text-theme-primary h-auto py-3 px-4"
+                  startContent={
+                    <div className="p-2 rounded-lg bg-violet-500/20">
+                      <Scale className="w-4 h-4 text-violet-600 dark:text-violet-400" aria-hidden="true" />
+                    </div>
+                  }
+                  onPress={() => openGdprModal('objection')}
+                >
+                  <div className="text-left">
+                    <p className="font-medium">Right to Object</p>
+                    <p className="text-sm text-theme-subtle font-normal">Object to processing of your personal data</p>
+                  </div>
+                </Button>
               </div>
 
               <div className="mt-4 p-3 rounded-lg bg-blue-500/10 border border-blue-500/20">
                 <p className="text-sm text-theme-muted flex items-start gap-2">
                   <Info className="w-4 h-4 text-blue-500 flex-shrink-0 mt-0.5" aria-hidden="true" />
-                  Your rights include access to your data, rectification, erasure, restriction of processing,
-                  data portability, and the right to object. Contact our Data Protection Officer for any concerns.
+                  All six GDPR data subject rights are available above. Contact our Data Protection Officer for any additional concerns.
                 </p>
               </div>
             </GlassCard>
@@ -1893,6 +1953,9 @@ export function SettingsPage() {
             {gdprRequestType === 'download' && 'Download My Data'}
             {gdprRequestType === 'portability' && 'Data Portability Request'}
             {gdprRequestType === 'deletion' && 'Request Data Deletion'}
+            {gdprRequestType === 'rectification' && 'Data Rectification'}
+            {gdprRequestType === 'restriction' && 'Restriction of Processing'}
+            {gdprRequestType === 'objection' && 'Right to Object'}
           </ModalHeader>
           <ModalBody>
             <div className="space-y-4">
@@ -1918,6 +1981,27 @@ export function SettingsPage() {
                 <p className="text-theme-muted">
                   We will export your data in a structured, commonly used, and machine-readable format (JSON/CSV).
                   This allows you to transfer your data to another service. You will receive an email within 30 days.
+                </p>
+              )}
+
+              {gdprRequestType === 'rectification' && (
+                <p className="text-theme-muted">
+                  Request correction of any inaccurate or incomplete personal data we hold about you.
+                  We will review your request and update the records within 30 days.
+                </p>
+              )}
+
+              {gdprRequestType === 'restriction' && (
+                <p className="text-theme-muted">
+                  Request that we restrict the processing of your personal data. While restricted, we will
+                  store but not actively process your data. We will respond within 30 days.
+                </p>
+              )}
+
+              {gdprRequestType === 'objection' && (
+                <p className="text-theme-muted">
+                  Object to the processing of your personal data for specific purposes, such as
+                  direct marketing or profiling. We will review your objection within 30 days.
                 </p>
               )}
 

--- a/src/Controllers/Api/TwoFactorApiController.php
+++ b/src/Controllers/Api/TwoFactorApiController.php
@@ -1,0 +1,133 @@
+<?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
+declare(strict_types=1);
+
+namespace Nexus\Controllers\Api;
+
+use Nexus\Services\TotpService;
+
+/**
+ * V2 Two-Factor Authentication API Controller
+ *
+ * Bearer-token-compatible endpoints for managing 2FA from the React SPA.
+ *
+ * Endpoints:
+ * - GET  /api/v2/auth/2fa/status  - Check 2FA status
+ * - POST /api/v2/auth/2fa/setup   - Initialize 2FA setup (generate QR code)
+ * - POST /api/v2/auth/2fa/verify  - Verify code to complete setup
+ * - POST /api/v2/auth/2fa/disable - Disable 2FA (requires password)
+ */
+class TwoFactorApiController extends BaseApiController
+{
+    /**
+     * GET /api/v2/auth/2fa/status
+     * Get 2FA status for the authenticated user
+     */
+    public function status(): void
+    {
+        $userId = $this->getUserId();
+
+        $this->respondWithData([
+            'enabled' => TotpService::isEnabled($userId),
+            'setup_required' => TotpService::isSetupRequired($userId),
+            'backup_codes_remaining' => TotpService::getBackupCodeCount($userId),
+        ]);
+    }
+
+    /**
+     * POST /api/v2/auth/2fa/setup
+     * Initialize 2FA setup — generates secret + QR code
+     *
+     * Response: { qr_code_url: string (data URI), secret: string, backup_codes: [] }
+     */
+    public function setup(): void
+    {
+        $userId = $this->getUserId();
+        $this->verifyCsrf();
+        $this->rateLimit('2fa_setup', 5, 300);
+
+        if (TotpService::isEnabled($userId)) {
+            $this->respondWithError('ALREADY_ENABLED', '2FA is already enabled on your account', null, 409);
+        }
+
+        try {
+            $result = TotpService::initializeSetup($userId);
+
+            // Convert raw SVG to data URI for use in <img src="...">
+            $svgDataUri = 'data:image/svg+xml;base64,' . base64_encode($result['qr_code']);
+
+            $this->respondWithData([
+                'qr_code_url' => $svgDataUri,
+                'secret' => $result['secret'],
+                'backup_codes' => [],
+            ]);
+        } catch (\Exception $e) {
+            $this->respondWithError('SETUP_FAILED', 'Failed to initialize 2FA setup', null, 500);
+        }
+    }
+
+    /**
+     * POST /api/v2/auth/2fa/verify
+     * Verify TOTP code to complete 2FA setup
+     *
+     * Request Body: { "code": "123456" }
+     * Response: { backup_codes: string[] }
+     */
+    public function verify(): void
+    {
+        $userId = $this->getUserId();
+        $this->verifyCsrf();
+        $this->rateLimit('2fa_verify', 10, 300);
+
+        $data = $this->getAllInput();
+        $code = trim($data['code'] ?? '');
+
+        if (empty($code)) {
+            $this->respondWithError('VALIDATION_ERROR', 'Verification code is required', 'code', 400);
+        }
+
+        $result = TotpService::completeSetup($userId, $code);
+
+        if (!$result['success']) {
+            $this->respondWithError('VERIFICATION_FAILED', $result['error'] ?? 'Invalid verification code', 'code', 400);
+        }
+
+        $this->respondWithData([
+            'backup_codes' => $result['backup_codes'] ?? [],
+        ]);
+    }
+
+    /**
+     * POST /api/v2/auth/2fa/disable
+     * Disable 2FA (requires password verification)
+     *
+     * Request Body: { "password": "..." }
+     */
+    public function disable(): void
+    {
+        $userId = $this->getUserId();
+        $this->verifyCsrf();
+        $this->rateLimit('2fa_disable', 3, 3600);
+
+        $data = $this->getAllInput();
+        $password = $data['password'] ?? '';
+
+        if (empty($password)) {
+            $this->respondWithError('VALIDATION_ERROR', 'Password is required', 'password', 400);
+        }
+
+        $result = TotpService::disable($userId, $password);
+
+        if (!$result['success']) {
+            $this->respondWithError('DISABLE_FAILED', $result['error'] ?? 'Failed to disable 2FA', 'password', 403);
+        }
+
+        $this->respondWithData([
+            'message' => 'Two-factor authentication has been disabled',
+        ]);
+    }
+}

--- a/src/Controllers/Api/UsersApiController.php
+++ b/src/Controllers/Api/UsersApiController.php
@@ -7,6 +7,7 @@
 namespace Nexus\Controllers\Api;
 
 use Nexus\Services\UserService;
+use Nexus\Services\Enterprise\GdprService;
 use Nexus\Core\TenantContext;
 use Nexus\Core\ImageUploader;
 
@@ -342,6 +343,15 @@ class UsersApiController extends BaseApiController
             'email_messages' => (bool) ($prefs['email_messages'] ?? true),
             'email_listings' => (bool) ($prefs['email_listings'] ?? true),
             'email_digest' => (bool) ($prefs['email_digest'] ?? false),
+            'email_connections' => (bool) ($prefs['email_connections'] ?? true),
+            'email_transactions' => (bool) ($prefs['email_transactions'] ?? true),
+            'email_reviews' => (bool) ($prefs['email_reviews'] ?? true),
+            'email_gamification_digest' => (bool) ($prefs['email_gamification_digest'] ?? true),
+            'email_gamification_milestones' => (bool) ($prefs['email_gamification_milestones'] ?? true),
+            'email_org_payments' => (bool) ($prefs['email_org_payments'] ?? true),
+            'email_org_transfers' => (bool) ($prefs['email_org_transfers'] ?? true),
+            'email_org_membership' => (bool) ($prefs['email_org_membership'] ?? true),
+            'email_org_admin' => (bool) ($prefs['email_org_admin'] ?? true),
             'push_enabled' => (bool) ($prefs['push_enabled'] ?? true),
         ]);
     }
@@ -359,7 +369,13 @@ class UsersApiController extends BaseApiController
         $data = $this->getAllInput();
 
         $prefs = [];
-        $allowedKeys = ['email_messages', 'email_listings', 'email_digest', 'push_enabled'];
+        $allowedKeys = [
+            'email_messages', 'email_listings', 'email_digest',
+            'email_connections', 'email_transactions', 'email_reviews',
+            'email_gamification_digest', 'email_gamification_milestones',
+            'email_org_payments', 'email_org_transfers', 'email_org_membership', 'email_org_admin',
+            'push_enabled',
+        ];
 
         foreach ($allowedKeys as $key) {
             if (isset($data[$key])) {
@@ -378,6 +394,163 @@ class UsersApiController extends BaseApiController
         }
 
         $this->respondWithData(['message' => 'Notification preferences updated']);
+    }
+
+    /**
+     * GET /api/v2/users/me/consent
+     * Get the user's GDPR consent statuses
+     */
+    public function getConsent(): void
+    {
+        $userId = $this->getUserId();
+
+        $gdprService = new GdprService();
+        $consents = $gdprService->getUserConsents($userId);
+
+        $this->respondWithData($consents);
+    }
+
+    /**
+     * PUT /api/v2/users/me/consent
+     * Update a single consent preference
+     *
+     * Request Body (JSON):
+     * {
+     *   "slug": string (required) - consent type slug,
+     *   "given": bool (required)
+     * }
+     */
+    public function updateConsent(): void
+    {
+        $userId = $this->getUserId();
+        $this->verifyCsrf();
+        $this->rateLimit('update_consent', 10, 60);
+
+        $data = $this->getAllInput();
+        $slug = trim($data['slug'] ?? '');
+        $given = (bool) ($data['given'] ?? false);
+
+        if (empty($slug)) {
+            $this->respondWithError('VALIDATION_ERROR', 'Missing consent slug', 'slug', 400);
+        }
+
+        try {
+            $gdprService = new GdprService();
+            $result = $gdprService->updateUserConsent($userId, $slug, $given);
+
+            // Sync newsletter subscription when marketing_email consent changes
+            if ($slug === 'marketing_email') {
+                $this->syncNewsletterFromConsent($userId, $given);
+            }
+
+            $this->respondWithData($result);
+        } catch (\Exception $e) {
+            $this->respondWithError('CONSENT_UPDATE_FAILED', $e->getMessage(), null, 400);
+        }
+    }
+
+    /**
+     * POST /api/v2/users/me/gdpr-request
+     * Create a GDPR data request (access, erasure, portability, rectification, restriction, objection)
+     *
+     * Request Body (JSON):
+     * {
+     *   "type": string (required) - GDPR request type,
+     *   "notes": string (optional)
+     * }
+     */
+    public function createGdprRequest(): void
+    {
+        $userId = $this->getUserId();
+        $this->verifyCsrf();
+        $this->rateLimit('gdpr_request', 5, 3600);
+
+        $data = $this->getAllInput();
+        $type = trim($data['type'] ?? '');
+        $notes = $data['notes'] ?? null;
+
+        $validTypes = ['access', 'erasure', 'portability', 'rectification', 'restriction', 'objection'];
+
+        if (!in_array($type, $validTypes, true)) {
+            $this->respondWithError(
+                'VALIDATION_ERROR',
+                'Invalid request type. Valid types: ' . implode(', ', $validTypes),
+                'type',
+                400
+            );
+        }
+
+        try {
+            $gdprService = new GdprService();
+            $result = $gdprService->createRequest($userId, $type, [
+                'notes' => $notes,
+                'metadata' => [
+                    'source' => 'user_settings',
+                    'user_agent' => $_SERVER['HTTP_USER_AGENT'] ?? '',
+                    'requested_via' => $this->isStatelessRequest() ? 'api' : 'web',
+                ],
+            ]);
+
+            $this->respondWithData([
+                'request_id' => $result['id'],
+                'type' => $type,
+                'status' => 'pending',
+                'message' => 'Your request has been submitted and will be processed within 30 days.',
+            ], null, 201);
+        } catch (\RuntimeException $e) {
+            // Duplicate request
+            $this->respondWithError('DUPLICATE_REQUEST', $e->getMessage(), null, 409);
+        } catch (\Exception $e) {
+            $this->respondWithError('REQUEST_FAILED', $e->getMessage(), null, 500);
+        }
+    }
+
+    /**
+     * Sync newsletter subscription based on marketing_email consent
+     */
+    private function syncNewsletterFromConsent(int $userId, bool $subscribed): void
+    {
+        try {
+            $user = \Nexus\Models\User::findById($userId);
+            if (!$user) return;
+
+            $email = $user['email'];
+            $existing = \Nexus\Models\NewsletterSubscriber::findByEmail($email);
+
+            if ($subscribed) {
+                if (!$existing) {
+                    \Nexus\Models\NewsletterSubscriber::createConfirmed(
+                        $email,
+                        $user['first_name'],
+                        $user['last_name'],
+                        'gdpr_settings',
+                        $userId
+                    );
+                } elseif ($existing['status'] === 'unsubscribed') {
+                    \Nexus\Models\NewsletterSubscriber::update($existing['id'], ['status' => 'active']);
+                }
+
+                try {
+                    $mailchimp = new \Nexus\Services\MailchimpService();
+                    $mailchimp->subscribe($email, $user['first_name'], $user['last_name']);
+                } catch (\Throwable $e) {
+                    error_log("Mailchimp Subscribe Failed: " . $e->getMessage());
+                }
+            } else {
+                if ($existing && $existing['status'] === 'active') {
+                    \Nexus\Models\NewsletterSubscriber::update($existing['id'], ['status' => 'unsubscribed']);
+
+                    try {
+                        $mailchimp = new \Nexus\Services\MailchimpService();
+                        $mailchimp->unsubscribe($email);
+                    } catch (\Throwable $e) {
+                        error_log("Mailchimp Unsubscribe Failed: " . $e->getMessage());
+                    }
+                }
+            }
+        } catch (\Throwable $e) {
+            error_log("Newsletter Sync From Consent Failed: " . $e->getMessage());
+        }
     }
 
     /**

--- a/src/Controllers/Api/UsersApiController.php
+++ b/src/Controllers/Api/UsersApiController.php
@@ -205,6 +205,25 @@ class UsersApiController extends BaseApiController
      *
      * Response: 200 OK with updated preferences
      */
+    /**
+     * GET /api/v2/users/me/preferences
+     * Get the user's privacy and notification preferences
+     */
+    public function getPreferences(): void
+    {
+        $userId = $this->getUserId();
+
+        $profile = UserService::getOwnProfile($userId);
+        $this->respondWithData([
+            'privacy' => [
+                'privacy_profile' => $profile['privacy_profile'] ?? 'public',
+                'privacy_search' => (bool) ($profile['privacy_search'] ?? true),
+                'privacy_contact' => (bool) ($profile['privacy_contact'] ?? true),
+            ],
+            'notifications' => $profile['notification_preferences'] ?? [],
+        ]);
+    }
+
     public function updatePreferences(): void
     {
         $userId = $this->getUserId();
@@ -551,6 +570,78 @@ class UsersApiController extends BaseApiController
         } catch (\Throwable $e) {
             error_log("Newsletter Sync From Consent Failed: " . $e->getMessage());
         }
+    }
+
+    /**
+     * GET /api/v2/users/me/sessions
+     * List user's active sessions with device/browser info
+     */
+    public function sessions(): void
+    {
+        $userId = $this->getUserId();
+        $tenantId = TenantContext::getId();
+
+        $db = \Nexus\Core\Database::getInstance();
+        $stmt = $db->prepare(
+            "SELECT id, ip_address, user_agent, device_type, last_activity, created_at
+             FROM sessions
+             WHERE user_id = ? AND tenant_id = ?
+               AND (expires_at IS NULL OR expires_at > NOW())
+             ORDER BY last_activity DESC
+             LIMIT 20"
+        );
+        $stmt->execute([$userId, $tenantId]);
+        $rows = $stmt->fetchAll();
+
+        $currentSessionId = session_id() ?: '';
+
+        $sessions = array_map(function ($row) use ($currentSessionId) {
+            $ua = $row['user_agent'] ?? '';
+            return [
+                'id' => $row['id'],
+                'device' => $this->parseDevice($ua, $row['device_type'] ?? 'unknown'),
+                'browser' => $this->parseBrowser($ua),
+                'ip_address' => $row['ip_address'] ?? '',
+                'last_active' => $row['last_activity'] ?? $row['created_at'],
+                'is_current' => $row['id'] === $currentSessionId,
+            ];
+        }, $rows);
+
+        $this->respondWithData($sessions);
+    }
+
+    /**
+     * Parse browser name and version from user agent string
+     */
+    private function parseBrowser(string $ua): string
+    {
+        if (empty($ua)) return 'Unknown';
+
+        if (preg_match('/Edg[e\/]?([\d.]+)/i', $ua, $m)) return 'Edge ' . intval($m[1]);
+        if (preg_match('/OPR\/([\d.]+)/i', $ua, $m)) return 'Opera ' . intval($m[1]);
+        if (preg_match('/Chrome\/([\d.]+)/i', $ua, $m)) return 'Chrome ' . intval($m[1]);
+        if (preg_match('/Firefox\/([\d.]+)/i', $ua, $m)) return 'Firefox ' . intval($m[1]);
+        if (preg_match('/Safari\/([\d.]+)/i', $ua) && preg_match('/Version\/([\d.]+)/i', $ua, $m)) {
+            return 'Safari ' . intval($m[1]);
+        }
+        return 'Unknown';
+    }
+
+    /**
+     * Parse device/OS from user agent string
+     */
+    private function parseDevice(string $ua, string $deviceType): string
+    {
+        if (empty($ua)) return ucfirst($deviceType);
+
+        if (preg_match('/iPhone/i', $ua)) return 'iPhone';
+        if (preg_match('/iPad/i', $ua)) return 'iPad';
+        if (preg_match('/Android/i', $ua)) return 'Android';
+        if (preg_match('/Windows NT 10/i', $ua)) return 'Windows';
+        if (preg_match('/Macintosh/i', $ua)) return 'Mac';
+        if (preg_match('/Linux/i', $ua)) return 'Linux';
+
+        return ucfirst($deviceType);
     }
 
     /**


### PR DESCRIPTION
## Summary

Implements comprehensive V2 API endpoints to enable full settings parity between the legacy PHP settings UI and the new React SPA.

## Changes

### New API Endpoints

**Two-Factor Authentication (V2)**
- `GET /api/v2/auth/2fa/status` - Check 2FA status
- `POST /api/v2/auth/2fa/setup` - Initialize 2FA setup
- `POST /api/v2/auth/2fa/verify` - Verify TOTP code
- `POST /api/v2/auth/2fa/disable` - Disable 2FA

**User Preferences & Consent**
- `GET /api/v2/users/me/preferences` - Retrieve privacy preferences
- `GET /api/v2/users/me/consent` - Get GDPR consent statuses
- `PUT /api/v2/users/me/consent` - Update consent preferences
- `POST /api/v2/users/me/gdpr-request` - Create GDPR requests (access, erasure, portability, rectification, restriction, objection)
- `GET /api/v2/users/me/sessions` - List active user sessions with device/browser info

### Backend

- **New Controller**: `TwoFactorApiController.php` - Bearer-token-compatible 2FA management
- **Enhanced**: `UsersApiController.php` - Added comprehensive preference, consent, and session management
- Expanded notification settings to include organization-specific preferences and granular gamification options
- Implements GDPR compliance with all six data subject rights
- Newsletter subscription syncing with Mailchimp based on consent changes

### Frontend

- **Settings UI**: Full PHP-to-React parity achieved
- Added organization notification preferences (payments, transfers, membership, admin alerts)
- Enhanced match preferences (hot matches, mutual matches)
- Marketing consent toggle with real-time sync
- Complete GDPR request flow with explanatory modals for each request type
- Session management with device/browser detection
- Improved notification settings organization and labeling

### Routes

- Updated `routes.php` with all new V2 endpoints
- Maintained legacy V1 endpoints for backward compatibility
- Added CSRF and rate limiting protections to sensitive endpoints