### PR TITLE
fix(alerts): prevent balance alert emails from spamming all users

### DIFF
--- a/src/Services/BalanceAlertService.php
+++ b/src/Services/BalanceAlertService.php
@@ -27,23 +27,40 @@ class BalanceAlertService
     /**
      * Check all organization wallets for low balance and send alerts
      * Should be run via cron job
+     *
+     * Only alerts for wallets that have been previously funded (have transaction history).
+     * Wallets with balance 0 that were never funded are intentionally excluded.
      */
     public static function checkAllBalances()
     {
         $tenantId = TenantContext::getId();
 
-        // Get all active org wallets
+        // Get org wallets that have ACTUALLY been funded (have at least one credit transaction).
+        // This prevents alerting on wallets that were auto-created with 0 balance
+        // but never used, which would spam all org admins.
         $wallets = Database::query(
             "SELECT ow.*, vo.name as org_name
              FROM org_wallets ow
              JOIN vol_organizations vo ON ow.organization_id = vo.id AND ow.tenant_id = vo.tenant_id
-             WHERE ow.tenant_id = ? AND vo.status = 'approved'",
+             WHERE ow.tenant_id = ? AND vo.status = 'approved'
+             AND EXISTS (
+                 SELECT 1 FROM org_transactions ot
+                 WHERE ot.organization_id = ow.organization_id
+                 AND ot.tenant_id = ow.tenant_id
+                 AND ot.receiver_type = 'organization'
+                 AND ot.receiver_id = ow.organization_id
+             )",
             [$tenantId]
         )->fetchAll();
 
         $alertsSent = 0;
 
         foreach ($wallets as $wallet) {
+            // Skip if alerts are disabled for this org
+            if (!self::areAlertsEnabled($wallet['organization_id'])) {
+                continue;
+            }
+
             $result = self::checkBalance($wallet['organization_id'], $wallet['balance'], $wallet['org_name']);
             if ($result['alert_sent']) {
                 $alertsSent++;
@@ -137,6 +154,31 @@ class BalanceAlertService
             'low' => self::DEFAULT_LOW_BALANCE_THRESHOLD,
             'critical' => self::DEFAULT_CRITICAL_BALANCE_THRESHOLD,
         ];
+    }
+
+    /**
+     * Check if balance alerts are enabled for an organization.
+     * Returns true by default if no settings exist (opt-out model for funded wallets).
+     */
+    public static function areAlertsEnabled($organizationId)
+    {
+        $tenantId = TenantContext::getId();
+
+        try {
+            $settings = Database::query(
+                "SELECT alerts_enabled FROM org_alert_settings
+                 WHERE tenant_id = ? AND organization_id = ?",
+                [$tenantId, $organizationId]
+            )->fetch();
+
+            if ($settings) {
+                return (bool) $settings['alerts_enabled'];
+            }
+        } catch (\Exception $e) {
+            // Table may not exist — default to enabled
+        }
+
+        return true;
     }
 
     /**
@@ -236,11 +278,27 @@ class BalanceAlertService
     }
 
     /**
-     * Send balance alert to organization admins
+     * Send balance alert to organization owner (and admins for critical only).
+     *
+     * Financial alerts are sent to the org owner. For critical alerts,
+     * admins are also notified. Regular members never receive these.
      */
     private static function sendBalanceAlert($organizationId, $orgName, $balance, $severity)
     {
-        $admins = OrgMember::getAdminsAndOwners($organizationId);
+        if ($severity === 'critical') {
+            // Critical: notify owner + admins
+            $recipients = OrgMember::getAdminsAndOwners($organizationId);
+        } else {
+            // Low: notify owner only
+            $owner = OrgMember::getOwner($organizationId);
+            $recipients = $owner ? [$owner] : [];
+        }
+
+        if (empty($recipients)) {
+            error_log("BalanceAlertService: No recipients found for org $organizationId ($orgName)");
+            return;
+        }
+
         $basePath = TenantContext::getBasePath();
         $link = $basePath . "/organizations/{$organizationId}/wallet";
 
@@ -260,7 +318,7 @@ class BalanceAlertService
                     "Consider adding funds soon.";
         }
 
-        foreach ($admins as $admin) {
+        foreach ($recipients as $admin) {
             // Platform notification
             try {
                 Notification::create($admin['user_id'], $message, $link, 'balance_alert');

--- a/tests/Services/BalanceAlertCronTest.php
+++ b/tests/Services/BalanceAlertCronTest.php
@@ -47,6 +47,7 @@ class BalanceAlertCronTest extends TestCase
             'getThresholds',
             'setThresholds',
             'getBalanceStatus',
+            'areAlertsEnabled',
         ];
 
         $ref = new \ReflectionClass(BalanceAlertService::class);
@@ -422,5 +423,94 @@ class BalanceAlertCronTest extends TestCase
             -10 <= $critical,
             'Negative balance should be at or below critical threshold'
         );
+    }
+
+    // =========================================================================
+    // ALERTS ENABLED CHECK
+    // =========================================================================
+
+    /**
+     * Test areAlertsEnabled method exists and is public static
+     */
+    public function testAreAlertsEnabledMethodExists(): void
+    {
+        $ref = new \ReflectionClass(BalanceAlertService::class);
+        $this->assertTrue($ref->hasMethod('areAlertsEnabled'));
+
+        $method = $ref->getMethod('areAlertsEnabled');
+        $this->assertTrue($method->isPublic(), 'areAlertsEnabled should be public');
+        $this->assertTrue($method->isStatic(), 'areAlertsEnabled should be static');
+
+        $params = $method->getParameters();
+        $this->assertCount(1, $params, 'Should accept organizationId');
+        $this->assertEquals('organizationId', $params[0]->getName());
+    }
+
+    // =========================================================================
+    // FUNDED WALLET GUARD (prevents alerting on never-funded wallets)
+    // =========================================================================
+
+    /**
+     * Test that checkAllBalances uses transaction existence check
+     *
+     * The checkAllBalances method should only alert for wallets that have
+     * been previously funded (have at least one credit transaction).
+     * This prevents spamming org admins for wallets auto-created with 0 balance.
+     */
+    public function testCheckAllBalancesRequiresFundedWallets(): void
+    {
+        // Verify the method exists and takes no parameters
+        $ref = new \ReflectionMethod(BalanceAlertService::class, 'checkAllBalances');
+        $this->assertCount(0, $ref->getParameters());
+
+        // The implementation should use EXISTS subquery on org_transactions
+        // to filter to only funded wallets. This is a design requirement.
+        $sourceFile = file_get_contents((new \ReflectionClass(BalanceAlertService::class))->getFileName());
+        $this->assertStringContainsString(
+            'org_transactions',
+            $sourceFile,
+            'checkAllBalances should check org_transactions to verify wallet was funded'
+        );
+    }
+
+    /**
+     * Test that checkAllBalances checks areAlertsEnabled
+     */
+    public function testCheckAllBalancesRespectsAlertsEnabled(): void
+    {
+        $sourceFile = file_get_contents((new \ReflectionClass(BalanceAlertService::class))->getFileName());
+        $this->assertStringContainsString(
+            'areAlertsEnabled',
+            $sourceFile,
+            'checkAllBalances should check areAlertsEnabled before sending alerts'
+        );
+    }
+
+    // =========================================================================
+    // RECIPIENT SCOPING
+    // =========================================================================
+
+    /**
+     * Test that sendBalanceAlert scopes recipients by severity
+     *
+     * Low alerts: owner only
+     * Critical alerts: owner + admins
+     */
+    public function testSendBalanceAlertScopesRecipientsBySeverity(): void
+    {
+        $ref = new \ReflectionClass(BalanceAlertService::class);
+        $method = $ref->getMethod('sendBalanceAlert');
+
+        // Verify the method exists and accepts severity parameter
+        $params = $method->getParameters();
+        $this->assertGreaterThanOrEqual(4, count($params));
+
+        // The implementation should call getOwner for low alerts
+        // and getAdminsAndOwners for critical alerts
+        $sourceFile = file_get_contents($ref->getFileName());
+        $this->assertStringContainsString('getOwner', $sourceFile,
+            'sendBalanceAlert should use getOwner for low-severity alerts');
+        $this->assertStringContainsString('getAdminsAndOwners', $sourceFile,
+            'sendBalanceAlert should use getAdminsAndOwners for critical alerts');
     }
 }

--- a/tests/Services/BalanceAlertServiceTest.php
+++ b/tests/Services/BalanceAlertServiceTest.php
@@ -34,7 +34,7 @@ class BalanceAlertServiceTest extends TestCase
     {
         $methods = [
             'checkAllBalances', 'checkBalance', 'getThresholds',
-            'setThresholds', 'getBalanceStatus'
+            'setThresholds', 'getBalanceStatus', 'areAlertsEnabled'
         ];
 
         foreach ($methods as $method) {
@@ -49,10 +49,21 @@ class BalanceAlertServiceTest extends TestCase
     {
         $ref = new \ReflectionClass(BalanceAlertService::class);
 
-        $publicMethods = ['checkAllBalances', 'checkBalance', 'getThresholds', 'setThresholds', 'getBalanceStatus'];
+        $publicMethods = ['checkAllBalances', 'checkBalance', 'getThresholds', 'setThresholds', 'getBalanceStatus', 'areAlertsEnabled'];
         foreach ($publicMethods as $methodName) {
             $method = $ref->getMethod($methodName);
             $this->assertTrue($method->isStatic(), "Method {$methodName} should be static");
         }
+    }
+
+    public function testAreAlertsEnabledMethodSignature(): void
+    {
+        $ref = new \ReflectionMethod(BalanceAlertService::class, 'areAlertsEnabled');
+        $params = $ref->getParameters();
+
+        $this->assertCount(1, $params, 'areAlertsEnabled should accept organizationId');
+        $this->assertEquals('organizationId', $params[0]->getName());
+        $this->assertTrue($ref->isPublic(), 'areAlertsEnabled should be public');
+        $this->assertTrue($ref->isStatic(), 'areAlertsEnabled should be static');
     }
 }


### PR DESCRIPTION
## Summary
- **Only alert funded wallets**: Added `EXISTS` subquery on `org_transactions` so wallets auto-created with 0 balance (never received a deposit) are excluded from alerts
- **Respect `alerts_enabled` setting**: New `areAlertsEnabled()` method checks `org_alert_settings.alerts_enabled` before sending — orgs can now opt out
- **Scope recipients by severity**: Low alerts go to org owner only; critical alerts go to owner + admins (previously both went to all admins, which in a timebank cooperative = all users)

## Root cause
`checkAllBalances()` queried ALL `org_wallets` rows. Wallets start at balance 0 when auto-created via `getOrCreate()`. With default critical threshold of 10, every unfunded wallet (0 <= 10) triggered a "Critical Balance Alert" email to all org admins. In hOUR Timebank CLG where all members have admin roles, this meant every user got the email.

## Test plan
- [x] Verify `checkAllBalances` SQL includes `EXISTS` subquery filtering to funded wallets
- [x] Verify `areAlertsEnabled()` method reads `org_alert_settings.alerts_enabled`
- [x] Verify low alerts use `getOwner()`, critical alerts use `getAdminsAndOwners()`
- [ ] Deploy and confirm no spurious alert emails on next 8am cron run

🤖 Generated with [Claude Code](https://claude.com/claude-code)