### PR TITLE
fix(feed): resolve Load More returning duplicate items

### DIFF
--- a/src/Services/FeedService.php
+++ b/src/Services/FeedService.php
@@ -241,6 +241,21 @@ class FeedService
             return $cmp;
         });
 
+        // Apply cursor filtering AFTER merge+sort to handle cross-type pagination.
+        // Individual loaders only filter when cursor type matches their own type,
+        // so non-matching types return their first N items unfiltered — causing duplicates.
+        // Since the sort order is uniform (created_at DESC, id DESC) across all types,
+        // we filter uniformly: keep only items that sort AFTER the cursor position.
+        if ($cursorData) {
+            $cursorTs = $cursorData['created_at'];
+            $cursorId = (int)$cursorData['id'];
+            $items = array_values(array_filter($items, function ($item) use ($cursorTs, $cursorId) {
+                $cmp = strcmp($item['created_at'], $cursorTs);
+                if ($cmp !== 0) return $cmp < 0; // Keep only items older than cursor
+                return $item['id'] < $cursorId;   // Same timestamp: keep lower IDs
+            }));
+        }
+
         return array_slice($items, 0, $limit);
     }
 


### PR DESCRIPTION
## Summary
- **Bug:** "Load More" on the feed page (`/feed`) returned the same items repeatedly instead of loading the next page
- **Fix:** Added a post-merge cursor filter in `FeedService::loadAggregatedFeed()` that uniformly removes already-shown items across all content types, matching the sort order (`created_at DESC, id DESC`)

**Root Cause:** `FeedService::loadAggregatedFeed()` merges items from 6 content types (posts, listings, events, polls, goals, reviews). Each individual loader only applied cursor-based pagination when `$cursorData['type']` matched its own type — so when the cursor came from e.g. a `post`, the 5 other loaders completely ignored the cursor and returned their first N items on every subsequent page.

**Prevention:** The post-merge filter operates on the merged+sorted array uniformly, so it is inherently type-agnostic and cannot regress if new content types are added to the aggregated feed. A code comment explains the reasoning directly above the filter block.

## Test plan
- [ ] Navigate to `/feed` on `hour-timebank` tenant
- [ ] Scroll down and click "Load More" — verify new items appear (no duplicates)
- [ ] Click "Load More" multiple times — verify each page shows unique items
- [ ] Test with type filter (e.g., Posts only) — verify pagination still works
- [ ] Verify feed ends correctly when all items are loaded (`has_more` = false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)