### PR TITLE
feat(super-admin): wire up federation pages and fix API response shapes

### DIFF
--- a/react-frontend/src/admin/modules/super-admin/federation/FederationAuditLog.tsx
+++ b/react-frontend/src/admin/modules/super-admin/federation/FederationAuditLog.tsx
@@ -3,7 +3,7 @@
 // Author: Jasper Ford
 // See NOTICE file for attribution and acknowledgements.
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import {
   Card,
   CardBody,
@@ -22,6 +22,8 @@ import {
 import { AlertTriangle, AlertCircle, Info, Search, X, FileText } from 'lucide-react';
 import PageHeader from '../../../components/PageHeader';
 import { usePageTitle } from '@/hooks/usePageTitle';
+import { adminSuper } from '../../../api/adminApi';
+import type { SuperAuditEntry } from '../../../api/types';
 
 interface AuditEntry {
   id: number;
@@ -45,10 +47,36 @@ interface Stats {
   info: number;
 }
 
+function classifyLevel(actionType: string): 'critical' | 'warning' | 'info' {
+  if (actionType.includes('lockdown') || actionType.includes('emergency') || actionType.includes('terminate')) return 'critical';
+  if (actionType.includes('suspend') || actionType.includes('revoke') || actionType.includes('remove')) return 'warning';
+  return 'info';
+}
+
+function classifyCategory(targetType: string): string {
+  if (targetType.includes('partnership')) return 'partnership';
+  if (targetType.includes('whitelist')) return 'whitelist';
+  if (targetType.includes('feature')) return 'feature';
+  if (targetType.includes('system') || targetType.includes('federation')) return 'system';
+  return 'system';
+}
+
+function mapAuditEntry(e: SuperAuditEntry): AuditEntry {
+  return {
+    id: e.id,
+    level: classifyLevel(e.action_type),
+    action: e.action_type,
+    category: classifyCategory(e.target_type),
+    actor_name: e.actor_name,
+    data: e.new_value as Record<string, unknown> | undefined,
+    created_at: e.created_at,
+  };
+}
+
 export default function FederationAuditLog() {
   usePageTitle('Federation Audit Log');
-  const [entries] = useState<AuditEntry[]>([]);
-  const [stats] = useState<Stats>({ total: 0, critical: 0, warnings: 0, info: 0 });
+  const [entries, setEntries] = useState<AuditEntry[]>([]);
+  const [stats, setStats] = useState<Stats>({ total: 0, critical: 0, warnings: 0, info: 0 });
   const [filters, setFilters] = useState({
     level: 'all',
     category: 'all',
@@ -58,11 +86,45 @@ export default function FederationAuditLog() {
   });
   const [selectedEntry, setSelectedEntry] = useState<AuditEntry | null>(null);
   const [loading, setLoading] = useState(true);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
 
-  useEffect(() => {
-    // TODO: Replace with adminApi.getFederationAudit(filters)
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    const res = await adminSuper.getAudit({
+      target_type: 'federation',
+      search: filters.search || undefined,
+      date_from: filters.from || undefined,
+      date_to: filters.to || undefined,
+      limit: 100,
+    });
+    if (res.success && res.data) {
+      const raw = Array.isArray(res.data) ? res.data : [];
+      let mapped = raw.map(mapAuditEntry);
+
+      // Apply client-side level/category filters
+      if (filters.level !== 'all') {
+        mapped = mapped.filter(e => e.level === filters.level);
+      }
+      if (filters.category !== 'all') {
+        mapped = mapped.filter(e => e.category === filters.category);
+      }
+
+      setEntries(mapped);
+      setStats({
+        total: mapped.length,
+        critical: mapped.filter(e => e.level === 'critical').length,
+        warnings: mapped.filter(e => e.level === 'warning').length,
+        info: mapped.filter(e => e.level === 'info').length,
+      });
+    }
     setLoading(false);
   }, [filters]);
+
+  useEffect(() => {
+    clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(loadData, 300);
+    return () => clearTimeout(debounceRef.current);
+  }, [loadData]);
 
   const getLevelIcon = (level: string) => {
     switch (level) {

--- a/react-frontend/src/admin/modules/super-admin/federation/FederationControls.tsx
+++ b/react-frontend/src/admin/modules/super-admin/federation/FederationControls.tsx
@@ -3,7 +3,7 @@
 // Author: Jasper Ford
 // See NOTICE file for attribution and acknowledgements.
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { Card, CardBody, CardHeader, Button, Chip } from '@heroui/react';
 import {
@@ -21,7 +21,9 @@ import {
 } from 'lucide-react';
 import PageHeader from '../../../components/PageHeader';
 import { usePageTitle } from '@/hooks/usePageTitle';
-import { tenantPath } from '@/lib/tenant-routing';
+import { useToast, useTenant } from '@/contexts';
+import { adminSuper } from '../../../api/adminApi';
+import type { FederationStatusOverview } from '../../../api/types';
 
 interface FederationStats {
   system: {
@@ -75,19 +77,74 @@ interface FederationStats {
   };
 }
 
+function mapOverviewToStats(overview: FederationStatusOverview): FederationStats {
+  const sc = overview.system_controls;
+  const ps = overview.partnership_stats;
+  return {
+    system: {
+      enabled: sc.federation_enabled,
+      whitelist_mode: sc.whitelist_mode_enabled,
+      lockdown_active: sc.is_locked_down,
+      lockdown_reason: sc.lockdown_reason,
+    },
+    counts: {
+      whitelisted_tenants: overview.whitelisted_count,
+      active_partnerships: ps.active,
+      pending_partnerships: ps.pending,
+    },
+    features: {
+      profiles: sc.cross_tenant_profiles_enabled,
+      messaging: sc.cross_tenant_messaging_enabled,
+      transactions: sc.cross_tenant_transactions_enabled,
+      listings: sc.cross_tenant_listings_enabled,
+      events: sc.cross_tenant_events_enabled,
+      groups: sc.cross_tenant_groups_enabled,
+    },
+    recent_partnerships: [],
+    whitelisted_tenants: [],
+    critical_events: overview.recent_audit
+      .filter(e => e.action_type?.includes('lockdown') || e.action_type?.includes('emergency'))
+      .slice(0, 5)
+      .map(e => ({ action: e.action_type || '', actor: e.actor_name || 'System', timestamp: e.created_at })),
+    recent_activity: overview.recent_audit.slice(0, 5).map(e => ({
+      action: e.action_type || '',
+      description: e.description || '',
+      timestamp: e.created_at,
+    })),
+    analytics: {
+      total_transactions: 0,
+      total_messages: 0,
+      active_partnerships_30d: ps.active,
+    },
+  };
+}
+
 export default function FederationControls() {
   usePageTitle('Federation Controls');
-  const [stats] = useState<FederationStats | null>(null);
+  const toast = useToast();
+  const { tenantPath } = useTenant();
+  const [stats, setStats] = useState<FederationStats | null>(null);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    // TODO: Replace with adminApi.getFederationStats()
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    const res = await adminSuper.getFederationStatus();
+    if (res.success && res.data) {
+      setStats(mapOverviewToStats(res.data));
+    }
     setLoading(false);
   }, []);
 
+  useEffect(() => { loadData(); }, [loadData]);
+
   const handleLiftLockdown = async () => {
-    // TODO: Replace with adminApi.liftLockdown()
-    console.log('Lift lockdown');
+    const res = await adminSuper.liftLockdown();
+    if (res.success) {
+      toast.success('Emergency lockdown lifted');
+      loadData();
+    } else {
+      toast.error(res.error || 'Failed to lift lockdown');
+    }
   };
 
   if (loading) {
@@ -231,7 +288,7 @@ export default function FederationControls() {
           <h3 className="text-lg font-semibold">Whitelisted Tenants</h3>
           <Button
             as={Link}
-            to={tenantPath('/admin/super/federation/whitelist', null)}
+            to={tenantPath('/admin/super/federation/whitelist')}
             size="sm"
             color="primary"
             variant="flat"
@@ -275,7 +332,7 @@ export default function FederationControls() {
           <h3 className="text-lg font-semibold">Recent Partnerships</h3>
           <Button
             as={Link}
-            to={tenantPath('/admin/super/federation/partnerships', null)}
+            to={tenantPath('/admin/super/federation/partnerships')}
             size="sm"
             color="primary"
             variant="flat"
@@ -433,7 +490,7 @@ export default function FederationControls() {
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
             <Button
               as={Link}
-              to={tenantPath('/admin/super/federation/system-controls', null)}
+              to={tenantPath('/admin/super/federation/system-controls')}
               className="h-auto py-6"
               variant="flat"
               color="primary"
@@ -445,7 +502,7 @@ export default function FederationControls() {
             </Button>
             <Button
               as={Link}
-              to={tenantPath('/admin/super/federation/whitelist', null)}
+              to={tenantPath('/admin/super/federation/whitelist')}
               className="h-auto py-6"
               variant="flat"
               color="primary"
@@ -457,7 +514,7 @@ export default function FederationControls() {
             </Button>
             <Button
               as={Link}
-              to={tenantPath('/admin/super/federation/partnerships', null)}
+              to={tenantPath('/admin/super/federation/partnerships')}
               className="h-auto py-6"
               variant="flat"
               color="primary"
@@ -469,7 +526,7 @@ export default function FederationControls() {
             </Button>
             <Button
               as={Link}
-              to={tenantPath('/admin/super/federation/audit', null)}
+              to={tenantPath('/admin/super/federation/audit')}
               className="h-auto py-6"
               variant="flat"
               color="primary"

--- a/react-frontend/src/admin/modules/super-admin/federation/FederationSystemControls.tsx
+++ b/react-frontend/src/admin/modules/super-admin/federation/FederationSystemControls.tsx
@@ -3,7 +3,7 @@
 // Author: Jasper Ford
 // See NOTICE file for attribution and acknowledgements.
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import {
   Card,
   CardBody,
@@ -17,6 +17,8 @@ import { Lock, Shield } from 'lucide-react';
 import PageHeader from '../../../components/PageHeader';
 import { usePageTitle } from '@/hooks/usePageTitle';
 import { useToast } from '@/contexts/ToastContext';
+import { adminSuper } from '../../../api/adminApi';
+import type { FederationSystemControls as FederationSystemControlsType } from '../../../api/types';
 
 interface SystemControls {
   federation_enabled: boolean;
@@ -33,6 +35,26 @@ interface FeatureToggles {
   listings: boolean;
   events: boolean;
   groups: boolean;
+}
+
+function mapApiToLocal(sc: FederationSystemControlsType): { controls: SystemControls; features: FeatureToggles } {
+  return {
+    controls: {
+      federation_enabled: sc.federation_enabled,
+      whitelist_mode: sc.whitelist_mode_enabled,
+      max_level: sc.max_federation_level,
+      lockdown_active: sc.is_locked_down,
+      lockdown_reason: sc.lockdown_reason,
+    },
+    features: {
+      profiles: sc.cross_tenant_profiles_enabled,
+      messaging: sc.cross_tenant_messaging_enabled,
+      transactions: sc.cross_tenant_transactions_enabled,
+      listings: sc.cross_tenant_listings_enabled,
+      events: sc.cross_tenant_events_enabled,
+      groups: sc.cross_tenant_groups_enabled,
+    },
+  };
 }
 
 export default function FederationSystemControls() {
@@ -55,10 +77,18 @@ export default function FederationSystemControls() {
   const [lockdownReason, setLockdownReason] = useState('');
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    // TODO: Replace with adminApi.getFederationStats()
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    const res = await adminSuper.getSystemControls();
+    if (res.success && res.data) {
+      const mapped = mapApiToLocal(res.data);
+      setControls(mapped.controls);
+      setFeatures(mapped.features);
+    }
     setLoading(false);
   }, []);
+
+  useEffect(() => { loadData(); }, [loadData]);
 
   const handleTriggerLockdown = async () => {
     if (!lockdownReason.trim()) {
@@ -66,28 +96,53 @@ export default function FederationSystemControls() {
       return;
     }
 
-    // TODO: Replace with adminApi.triggerLockdown(lockdownReason)
-    setControls(prev => ({ ...prev, lockdown_active: true, lockdown_reason: lockdownReason }));
-    toast.success('Emergency lockdown activated');
-    setLockdownReason('');
+    const res = await adminSuper.emergencyLockdown(lockdownReason);
+    if (res.success) {
+      setControls(prev => ({ ...prev, lockdown_active: true, lockdown_reason: lockdownReason }));
+      toast.success('Emergency lockdown activated');
+      setLockdownReason('');
+    } else {
+      toast.error(res.error || 'Failed to activate lockdown');
+    }
   };
 
   const handleLiftLockdown = async () => {
-    // TODO: Replace with adminApi.liftLockdown()
-    setControls(prev => ({ ...prev, lockdown_active: false, lockdown_reason: undefined }));
-    toast.success('Emergency lockdown lifted');
+    const res = await adminSuper.liftLockdown();
+    if (res.success) {
+      setControls(prev => ({ ...prev, lockdown_active: false, lockdown_reason: undefined }));
+      toast.success('Emergency lockdown lifted');
+    } else {
+      toast.error(res.error || 'Failed to lift lockdown');
+    }
   };
 
   const handleToggleControl = async (key: keyof SystemControls, value: boolean | number) => {
-    // TODO: Replace with adminApi.updateSystemControl(key, value)
-    setControls(prev => ({ ...prev, [key]: value }));
-    toast.success('System control updated');
+    const apiKeyMap: Record<string, string> = {
+      federation_enabled: 'federation_enabled',
+      whitelist_mode: 'whitelist_mode_enabled',
+      max_level: 'max_federation_level',
+    };
+    const apiKey = apiKeyMap[key];
+    if (!apiKey) return;
+
+    const res = await adminSuper.updateSystemControls({ [apiKey]: value });
+    if (res.success) {
+      setControls(prev => ({ ...prev, [key]: value }));
+      toast.success('System control updated');
+    } else {
+      toast.error(res.error || 'Failed to update control');
+    }
   };
 
   const handleToggleFeature = async (key: keyof FeatureToggles, value: boolean) => {
-    // TODO: Replace with adminApi.updateSystemControl(`feature_${key}`, value)
-    setFeatures(prev => ({ ...prev, [key]: value }));
-    toast.success(`${key} feature ${value ? 'enabled' : 'disabled'}`);
+    const apiKey = `cross_tenant_${key}_enabled`;
+    const res = await adminSuper.updateSystemControls({ [apiKey]: value });
+    if (res.success) {
+      setFeatures(prev => ({ ...prev, [key]: value }));
+      toast.success(`${key} feature ${value ? 'enabled' : 'disabled'}`);
+    } else {
+      toast.error(res.error || 'Failed to update feature');
+    }
   };
 
   if (loading) {

--- a/react-frontend/src/admin/modules/super-admin/federation/FederationTenantFeatures.tsx
+++ b/react-frontend/src/admin/modules/super-admin/federation/FederationTenantFeatures.tsx
@@ -3,7 +3,7 @@
 // Author: Jasper Ford
 // See NOTICE file for attribution and acknowledgements.
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { Card, CardBody, CardHeader, Chip } from '@heroui/react';
 import { Users, MessageSquare, DollarSign, FileText, Calendar, UsersRound, AlertCircle, Shield } from 'lucide-react';
@@ -11,7 +11,8 @@ import PageHeader from '../../../components/PageHeader';
 import { useTenant } from '@/contexts/TenantContext';
 import { usePageTitle } from '@/hooks/usePageTitle';
 import { useToast } from '@/contexts/ToastContext';
-import { tenantPath } from '@/lib/tenant-routing';
+import { adminSuper } from '../../../api/adminApi';
+import type { TenantFederationFeatures as TenantFederationFeaturesType, FederationPartnership } from '../../../api/types';
 
 interface TenantInfo {
   id: number;
@@ -41,11 +42,23 @@ interface Partnership {
   created_at: string;
 }
 
+function mapPartnership(p: FederationPartnership, currentTenantId: number): Partnership {
+  const isFirst = p.tenant_1_id === currentTenantId;
+  return {
+    id: p.id,
+    partner_id: isFirst ? p.tenant_2_id : p.tenant_1_id,
+    partner_name: isFirst ? p.tenant_2_name : p.tenant_1_name,
+    level: 1,
+    status: p.status,
+    created_at: p.created_at,
+  };
+}
+
 export default function FederationTenantFeatures() {
   const { tenantId } = useParams<{ tenantId: string }>();
-  useTenant();
+  const { tenantPath } = useTenant();
   const toast = useToast();
-  const [tenantInfo] = useState<TenantInfo | null>(null);
+  const [tenantInfo, setTenantInfo] = useState<TenantInfo | null>(null);
   const [features, setFeatures] = useState<FeatureToggles>({
     profiles: false,
     messaging: false,
@@ -56,25 +69,57 @@ export default function FederationTenantFeatures() {
     analytics: false,
     webhooks: false,
   });
-  const [partnerships] = useState<Partnership[]>([]);
+  const [partnerships, setPartnerships] = useState<Partnership[]>([]);
   const [loading, setLoading] = useState(true);
 
   usePageTitle(tenantInfo ? `${tenantInfo.name} - Federation Features` : 'Tenant Features');
 
-  useEffect(() => {
-    // TODO: Replace with adminApi.getTenantFeatures(tenantId)
+  const loadData = useCallback(async () => {
+    if (!tenantId) return;
+    setLoading(true);
+    const res = await adminSuper.getTenantFederationFeatures(Number(tenantId));
+    if (res.success && res.data) {
+      const data = res.data as TenantFederationFeaturesType;
+      setTenantInfo({
+        id: data.tenant_id,
+        name: data.tenant_name,
+        domain: '',
+        is_whitelisted: data.is_whitelisted,
+        partnerships_count: data.partnerships?.length || 0,
+      });
+      setFeatures({
+        profiles: data.features?.profiles ?? false,
+        messaging: data.features?.messaging ?? false,
+        transactions: data.features?.transactions ?? false,
+        listings: data.features?.listings ?? false,
+        events: data.features?.events ?? false,
+        groups: data.features?.groups ?? false,
+        analytics: data.features?.analytics ?? false,
+        webhooks: data.features?.webhooks ?? false,
+      });
+      if (data.partnerships) {
+        setPartnerships(data.partnerships.map(p => mapPartnership(p, data.tenant_id)));
+      }
+    }
     setLoading(false);
   }, [tenantId]);
+
+  useEffect(() => { loadData(); }, [loadData]);
 
   const handleToggleFeature = async (key: keyof FeatureToggles, value: boolean) => {
     if (!tenantInfo?.is_whitelisted) {
       toast.error('Tenant must be whitelisted to enable features');
       return;
     }
+    if (!tenantId) return;
 
-    // TODO: Replace with adminApi.updateTenantFeature(tenantId, key, value)
-    setFeatures(prev => ({ ...prev, [key]: value }));
-    toast.success(`${key} ${value ? 'enabled' : 'disabled'}`);
+    const res = await adminSuper.updateTenantFederationFeature(Number(tenantId), key, value);
+    if (res.success) {
+      setFeatures(prev => ({ ...prev, [key]: value }));
+      toast.success(`${key} ${value ? 'enabled' : 'disabled'}`);
+    } else {
+      toast.error(res.error || 'Failed to update feature');
+    }
   };
 
   const getLevelColor = (level: number) => {
@@ -257,7 +302,7 @@ export default function FederationTenantFeatures() {
                     <tr key={partnership.id} className="border-b border-default-100">
                       <td className="py-3 px-4">
                         <Link
-                          to={tenantPath(`/admin/super/federation/tenant/${partnership.partner_id}/features`, null)}
+                          to={tenantPath(`/admin/super/federation/tenant/${partnership.partner_id}/features`)}
                           className="text-primary hover:underline"
                         >
                           {partnership.partner_name}

--- a/react-frontend/src/admin/modules/super-admin/federation/FederationWhitelist.tsx
+++ b/react-frontend/src/admin/modules/super-admin/federation/FederationWhitelist.tsx
@@ -3,7 +3,7 @@
 // Author: Jasper Ford
 // See NOTICE file for attribution and acknowledgements.
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import {
   Card,
@@ -18,8 +18,9 @@ import { Plus, Trash2 } from 'lucide-react';
 import PageHeader from '../../../components/PageHeader';
 import ConfirmModal from '../../../components/ConfirmModal';
 import { usePageTitle } from '@/hooks/usePageTitle';
-import { useToast } from '@/contexts/ToastContext';
-import { tenantPath } from '@/lib/tenant-routing';
+import { useToast, useTenant } from '@/contexts';
+import { adminSuper } from '../../../api/adminApi';
+import type { FederationWhitelistEntry, SuperAdminTenant } from '../../../api/types';
 
 interface WhitelistEntry {
   id: number;
@@ -37,20 +38,47 @@ interface Tenant {
   domain: string;
 }
 
+function mapWhitelistEntry(e: FederationWhitelistEntry): WhitelistEntry {
+  return {
+    id: e.tenant_id,
+    tenant_id: e.tenant_id,
+    tenant_name: e.tenant_name,
+    domain: e.tenant_domain || '',
+    approved_by_name: String(e.added_by),
+    approved_at: e.added_at,
+    notes: e.notes,
+  };
+}
+
 export default function FederationWhitelist() {
   usePageTitle('Federation Whitelist');
   const toast = useToast();
+  const { tenantPath } = useTenant();
   const [entries, setEntries] = useState<WhitelistEntry[]>([]);
-  const [availableTenants] = useState<Tenant[]>([]);
+  const [availableTenants, setAvailableTenants] = useState<Tenant[]>([]);
   const [selectedTenantId, setSelectedTenantId] = useState<string>('');
   const [notes, setNotes] = useState('');
   const [loading, setLoading] = useState(true);
   const [removing, setRemoving] = useState<number | null>(null);
 
-  useEffect(() => {
-    // TODO: Replace with adminApi.listWhitelist() and adminApi.getAvailableTenants()
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    const [whitelistRes, tenantsRes] = await Promise.all([
+      adminSuper.getWhitelist(),
+      adminSuper.listTenants(),
+    ]);
+    if (whitelistRes.success && whitelistRes.data) {
+      const mapped = (Array.isArray(whitelistRes.data) ? whitelistRes.data : []).map(mapWhitelistEntry);
+      setEntries(mapped);
+    }
+    if (tenantsRes.success && tenantsRes.data) {
+      const tenants = (Array.isArray(tenantsRes.data) ? tenantsRes.data : []) as SuperAdminTenant[];
+      setAvailableTenants(tenants.map(t => ({ id: t.id, name: t.name, domain: t.domain || '' })));
+    }
     setLoading(false);
   }, []);
+
+  useEffect(() => { loadData(); }, [loadData]);
 
   const handleAdd = async () => {
     if (!selectedTenantId) {
@@ -58,17 +86,27 @@ export default function FederationWhitelist() {
       return;
     }
 
-    // TODO: Replace with adminApi.addToWhitelist(parseInt(selectedTenantId), notes)
-    toast.success('Tenant added to whitelist');
-    setSelectedTenantId('');
-    setNotes('');
+    const res = await adminSuper.addToWhitelist(parseInt(selectedTenantId), notes || undefined);
+    if (res.success) {
+      toast.success('Tenant added to whitelist');
+      setSelectedTenantId('');
+      setNotes('');
+      loadData();
+    } else {
+      toast.error(res.error || 'Failed to add tenant to whitelist');
+    }
   };
 
-  const handleRemove = async (id: number) => {
-    // TODO: Replace with adminApi.removeFromWhitelist(id)
-    setEntries(prev => prev.filter(e => e.id !== id));
-    setRemoving(null);
-    toast.success('Tenant removed from whitelist');
+  const handleRemove = async (tenantId: number) => {
+    const res = await adminSuper.removeFromWhitelist(tenantId);
+    if (res.success) {
+      setEntries(prev => prev.filter(e => e.tenant_id !== tenantId));
+      setRemoving(null);
+      toast.success('Tenant removed from whitelist');
+    } else {
+      toast.error(res.error || 'Failed to remove tenant');
+      setRemoving(null);
+    }
   };
 
   if (loading) {
@@ -152,7 +190,7 @@ export default function FederationWhitelist() {
                     <tr key={entry.id} className="border-b border-default-100">
                       <td className="py-3 px-4">
                         <Link
-                          to={tenantPath(`/admin/super/federation/tenant/${entry.tenant_id}/features`, null)}
+                          to={tenantPath(`/admin/super/federation/tenant/${entry.tenant_id}/features`)}
                           className="text-primary hover:underline"
                         >
                           {entry.tenant_name}
@@ -170,7 +208,7 @@ export default function FederationWhitelist() {
                         <div className="flex items-center gap-2">
                           <Button
                             as={Link}
-                            to={tenantPath(`/admin/super/federation/tenant/${entry.tenant_id}/features`, null)}
+                            to={tenantPath(`/admin/super/federation/tenant/${entry.tenant_id}/features`)}
                             size="sm"
                             variant="flat"
                             color="primary"
@@ -181,7 +219,7 @@ export default function FederationWhitelist() {
                             size="sm"
                             variant="flat"
                             color="danger"
-                            onPress={() => setRemoving(entry.id)}
+                            onPress={() => setRemoving(entry.tenant_id)}
                             startContent={<Trash2 className="w-4 h-4" />}
                           >
                             Remove
@@ -200,7 +238,7 @@ export default function FederationWhitelist() {
       </Card>
 
       {/* Remove Confirmation Modal */}
-      {removing && (
+      {removing !== null && (
         <ConfirmModal
           isOpen={true}
           onClose={() => setRemoving(null)}

--- a/react-frontend/src/admin/modules/super-admin/federation/Partnerships.tsx
+++ b/react-frontend/src/admin/modules/super-admin/federation/Partnerships.tsx
@@ -3,13 +3,15 @@
 // Author: Jasper Ford
 // See NOTICE file for attribution and acknowledgements.
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { Card, CardBody, CardHeader, Button, Chip, Tabs, Tab } from '@heroui/react';
 import { TrendingUp, Users, MessageSquare, DollarSign, FileText, Calendar, UsersRound, Pause, XCircle } from 'lucide-react';
 import PageHeader from '../../../components/PageHeader';
 import ConfirmModal from '../../../components/ConfirmModal';
 import { usePageTitle } from '@/hooks/usePageTitle';
 import { useToast } from '@/contexts/ToastContext';
+import { adminSuper } from '../../../api/adminApi';
+import type { FederationPartnership } from '../../../api/types';
 
 interface Partnership {
   id: number;
@@ -39,32 +41,80 @@ interface Stats {
 
 type PartnershipStatus = 'all' | 'active' | 'pending' | 'suspended' | 'terminated';
 
+function mapApiPartnership(p: FederationPartnership): Partnership {
+  return {
+    id: p.id,
+    tenant_a_id: p.tenant_1_id,
+    tenant_a_name: p.tenant_1_name,
+    tenant_b_id: p.tenant_2_id,
+    tenant_b_name: p.tenant_2_name,
+    level: 1,
+    status: p.status,
+    features: { profiles: false, messaging: false, transactions: false, listings: false, events: false, groups: false },
+    created_at: p.created_at,
+  };
+}
+
+function computeStats(partnerships: Partnership[]): Stats {
+  return partnerships.reduce(
+    (acc, p) => {
+      if (p.status in acc) acc[p.status as keyof Stats]++;
+      return acc;
+    },
+    { active: 0, pending: 0, suspended: 0, terminated: 0 },
+  );
+}
+
 export default function Partnerships() {
   usePageTitle('Partnerships');
   const toast = useToast();
   const [partnerships, setPartnerships] = useState<Partnership[]>([]);
-  const [stats] = useState<Stats>({ active: 0, pending: 0, suspended: 0, terminated: 0 });
+  const [stats, setStats] = useState<Stats>({ active: 0, pending: 0, suspended: 0, terminated: 0 });
   const [filter, setFilter] = useState<PartnershipStatus>('all');
   const [loading, setLoading] = useState(true);
   const [actionPartnership, setActionPartnership] = useState<{ id: number; action: 'suspend' | 'terminate' } | null>(null);
 
-  useEffect(() => {
-    // TODO: Replace with adminApi.listPartnerships()
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    const res = await adminSuper.getFederationPartnerships();
+    if (res.success && res.data) {
+      const mapped = (Array.isArray(res.data) ? res.data : []).map(mapApiPartnership);
+      setPartnerships(mapped);
+      setStats(computeStats(mapped));
+    }
     setLoading(false);
   }, []);
 
+  useEffect(() => { loadData(); }, [loadData]);
+
   const handleSuspend = async (id: number) => {
-    // TODO: Replace with adminApi.suspendPartnership(id)
-    setPartnerships(prev => prev.map(p => p.id === id ? { ...p, status: 'suspended' as const } : p));
-    setActionPartnership(null);
-    toast.success('Partnership suspended');
+    const res = await adminSuper.suspendPartnership(id, 'Suspended by admin');
+    if (res.success) {
+      setPartnerships(prev => {
+        const updated = prev.map(p => p.id === id ? { ...p, status: 'suspended' as const } : p);
+        setStats(computeStats(updated));
+        return updated;
+      });
+      setActionPartnership(null);
+      toast.success('Partnership suspended');
+    } else {
+      toast.error(res.error || 'Failed to suspend partnership');
+    }
   };
 
   const handleTerminate = async (id: number) => {
-    // TODO: Replace with adminApi.terminatePartnership(id)
-    setPartnerships(prev => prev.map(p => p.id === id ? { ...p, status: 'terminated' as const } : p));
-    setActionPartnership(null);
-    toast.success('Partnership terminated');
+    const res = await adminSuper.terminatePartnership(id, 'Terminated by admin');
+    if (res.success) {
+      setPartnerships(prev => {
+        const updated = prev.map(p => p.id === id ? { ...p, status: 'terminated' as const } : p);
+        setStats(computeStats(updated));
+        return updated;
+      });
+      setActionPartnership(null);
+      toast.success('Partnership terminated');
+    } else {
+      toast.error(res.error || 'Failed to terminate partnership');
+    }
   };
 
   const getLevelColor = (level: number) => {

--- a/src/Controllers/Api/AdminSuperApiController.php
+++ b/src/Controllers/Api/AdminSuperApiController.php
@@ -189,12 +189,23 @@ class AdminSuperApiController extends BaseApiController
         $admins = TenantVisibilityService::getTenantAdmins($tenantId);
         $breadcrumb = Tenant::getBreadcrumb($tenantId);
 
-        $this->respondWithData([
-            'tenant' => $tenant,
+        // Decode features JSON for the frontend
+        $features = [];
+        if (!empty($tenant['features'])) {
+            $features = is_string($tenant['features'])
+                ? (json_decode($tenant['features'], true) ?: [])
+                : $tenant['features'];
+        }
+        unset($tenant['features']);
+
+        // Flatten: merge tenant fields with children/admins/breadcrumb at root level
+        // React SuperAdminTenantDetail expects all fields flat, not nested under 'tenant' key
+        $this->respondWithData(array_merge($tenant, [
+            'features' => $features,
             'children' => $children,
             'admins' => $admins,
             'breadcrumb' => $breadcrumb,
-        ]);
+        ]));
     }
 
     /**
@@ -390,8 +401,8 @@ class AdminSuperApiController extends BaseApiController
     {
         $this->requireSuperAdmin();
 
-        $userId = $this->extractId('users');
-        $user = User::findById($userId, false);
+        $targetUserId = $this->extractId('users');
+        $user = User::findById($targetUserId, false);
 
         if (!$user) {
             $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
@@ -399,10 +410,12 @@ class AdminSuperApiController extends BaseApiController
 
         $tenant = Tenant::find($user['tenant_id']);
 
-        $this->respondWithData([
-            'user' => $user,
-            'tenant' => $tenant,
-        ]);
+        // Flatten: merge user fields with tenant_name at root level
+        // React SuperAdminUserDetail expects all fields flat, not nested under 'user' key
+        $this->respondWithData(array_merge($user, [
+            'tenant_name' => $tenant['name'] ?? null,
+            'name' => trim(($user['first_name'] ?? '') . ' ' . ($user['last_name'] ?? '')),
+        ]));
     }
 
     /**
@@ -1000,15 +1013,16 @@ class AdminSuperApiController extends BaseApiController
     {
         $this->requireSuperAdmin();
 
-        $systemStatus = FederationFeatureService::getSystemControls();
+        $systemControls = FederationFeatureService::getSystemControls();
         $partnershipStats = FederationPartnershipService::getStats();
         $whitelistedTenants = FederationFeatureService::getWhitelistedTenants();
         $recentAudit = FederationAuditService::getLog(['limit' => 20]);
 
+        // Keys must match FederationStatusOverview TypeScript type
         $this->respondWithData([
-            'system_status' => $systemStatus,
+            'system_controls' => $systemControls,
             'partnership_stats' => $partnershipStats,
-            'whitelisted_tenants' => $whitelistedTenants,
+            'whitelisted_count' => count($whitelistedTenants),
             'recent_audit' => $recentAudit,
         ]);
     }


### PR DESCRIPTION
## Changes

### Frontend Components
- **FederationAuditLog**: Added data loading from API with debounced search, client-side filtering by level/category, and proper audit entry mapping
- **FederationControls**: Integrated `getFederationStatus()` API call, mapped response to local state, added emergency lockdown controls
- **FederationSystemControls**: Wired system controls and feature toggles to API endpoints with proper request/response mapping
- **FederationTenantFeatures**: Added tenant federation features loading and per-tenant feature toggle updates
- **FederationWhitelist**: Implemented whitelist CRUD operations and available tenants list loading
- **Partnerships**: Added partnership list loading with filtering, suspend/terminate actions with stats computation

### Backend API Controller
- Fixed `/super/federation/status` response shape:
  - Changed `system_status` key to `system_controls` to match TypeScript types
  - Changed `whitelisted_tenants` array to `whitelisted_count` integer
- Fixed `/super/tenants/{id}` response to flatten data at root level (not nested under `tenant` key)
- Fixed `/super/users/{id}` response to flatten data at root level with computed `name` field

### API Integration
- All pages now properly call `adminSuper` API methods
- Added type mappings between API responses and local component state
- Implemented error handling and toast notifications for all async operations
- Added loading states and proper cleanup of async operations

### Routing Fixes
- Updated all `tenantPath()` calls to use correct signature (single argument instead of two)