### PR TITLE
fix(admin): enable super admin cross-tenant access for all moderation features

### DIFF
--- a/react-frontend/src/admin/api/adminApi.ts
+++ b/react-frontend/src/admin/api/adminApi.ts
@@ -1292,7 +1292,7 @@ export const adminCron = {
 
 export const adminModeration = {
   // Feed Posts
-  getFeedPosts: (params?: { type?: string; status?: string; user_id?: number; page?: number; limit?: number }) =>
+  getFeedPosts: (params?: { type?: string; status?: string; user_id?: number; tenant_id?: number; page?: number; limit?: number }) =>
     api.get<PaginatedResponse<AdminFeedPost>>(`/v2/admin/feed/posts${buildQuery(params || {})}`),
 
   getFeedPost: (id: number) =>
@@ -1308,7 +1308,7 @@ export const adminModeration = {
     api.get<ModerationStats>('/v2/admin/feed/stats'),
 
   // Comments
-  getComments: (params?: { content_type?: string; is_flagged?: boolean; page?: number; limit?: number }) =>
+  getComments: (params?: { content_type?: string; is_flagged?: boolean; tenant_id?: number; page?: number; limit?: number }) =>
     api.get<PaginatedResponse<AdminComment>>(`/v2/admin/comments${buildQuery(params || {})}`),
 
   getComment: (id: number) =>
@@ -1321,7 +1321,7 @@ export const adminModeration = {
     api.delete<{ success: boolean }>(`/v2/admin/comments/${id}`),
 
   // Reviews
-  getReviews: (params?: { rating?: number; is_flagged?: boolean; page?: number; limit?: number }) =>
+  getReviews: (params?: { rating?: number; is_flagged?: boolean; tenant_id?: number; page?: number; limit?: number }) =>
     api.get<PaginatedResponse<AdminReview>>(`/v2/admin/reviews${buildQuery(params || {})}`),
 
   getReview: (id: number) =>
@@ -1337,7 +1337,7 @@ export const adminModeration = {
     api.delete<{ success: boolean }>(`/v2/admin/reviews/${id}`),
 
   // Reports
-  getReports: (params?: { type?: string; status?: string; page?: number; limit?: number }) =>
+  getReports: (params?: { type?: string; status?: string; tenant_id?: number; page?: number; limit?: number }) =>
     api.get<PaginatedResponse<AdminReport>>(`/v2/admin/reports${buildQuery(params || {})}`),
 
   getReport: (id: number) =>

--- a/react-frontend/src/admin/api/types.ts
+++ b/react-frontend/src/admin/api/types.ts
@@ -1483,6 +1483,8 @@ export interface MatchStats {
 export interface AdminFeedPost {
   id: number;
   user_id: number;
+  tenant_id: number;
+  tenant_name: string;
   user_name: string;
   user_avatar?: string | null;
   content: string;
@@ -1499,6 +1501,8 @@ export interface AdminFeedPost {
 export interface AdminComment {
   id: number;
   user_id: number;
+  tenant_id: number;
+  tenant_name: string;
   user_name: string;
   user_avatar?: string | null;
   content_type: 'listing' | 'event' | 'post' | 'blog';
@@ -1514,6 +1518,8 @@ export interface AdminComment {
 export interface AdminReview {
   id: number;
   reviewer_id: number;
+  tenant_id: number;
+  tenant_name: string;
   reviewer_name: string;
   reviewer_avatar?: string | null;
   reviewee_id: number;
@@ -1530,6 +1536,8 @@ export interface AdminReview {
 export interface AdminReport {
   id: number;
   reporter_id: number;
+  tenant_id: number;
+  tenant_name: string;
   reporter_name: string;
   reporter_avatar?: string | null;
   content_type: 'listing' | 'event' | 'post' | 'comment' | 'review' | 'user';

--- a/react-frontend/src/admin/modules/moderation/CommentsModeration.tsx
+++ b/react-frontend/src/admin/modules/moderation/CommentsModeration.tsx
@@ -3,7 +3,7 @@
 // Author: Jasper Ford
 // See NOTICE file for attribution and acknowledgements.
 
-import { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Button,
   Input,
@@ -23,10 +23,12 @@ import {
 import { Search, RefreshCw, EyeOff, Trash2 } from 'lucide-react';
 import { usePageTitle } from '@/hooks/usePageTitle';
 import { useApi } from '@/hooks/useApi';
+import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/contexts/ToastContext';
 import PageHeader from '@/admin/components/PageHeader';
 import ConfirmModal from '@/admin/components/ConfirmModal';
 import { adminModeration } from '@/admin/api/adminApi';
+import { adminSuper } from '@/admin/api/adminApi';
 import type { AdminComment } from '@/admin/api/types';
 
 const CONTENT_TYPES = [
@@ -41,16 +43,41 @@ export default function CommentsModeration() {
   usePageTitle('Comments Moderation');
 
   const toast = useToast();
+  const { user } = useAuth();
+  const userRecord = user as Record<string, unknown> | null;
+  const isSuperAdmin =
+    (user?.role as string) === 'super_admin' ||
+    userRecord?.is_super_admin === true ||
+    userRecord?.is_tenant_super_admin === true;
+
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState('');
   const [contentTypeFilter, setContentTypeFilter] = useState('');
+  const [tenantFilter, setTenantFilter] = useState('');
   const [activeSearch, setActiveSearch] = useState('');
   const [activeContentType, setActiveContentType] = useState('');
+  const [activeTenant, setActiveTenant] = useState('');
   const [actionLoading, setActionLoading] = useState(false);
   const [confirmAction, setConfirmAction] = useState<{
     type: 'hide' | 'delete';
     comment: AdminComment;
   } | null>(null);
+  const [tenants, setTenants] = useState<Array<{ id: number; name: string }>>([]);
+
+  // Load tenants list for super admin filter
+  useEffect(() => {
+    if (!isSuperAdmin) return;
+    adminSuper.listTenants().then((res) => {
+      if (res.success && Array.isArray(res.data)) {
+        setTenants(res.data.map((t) => ({
+          id: Number(t.id),
+          name: String(t.name || 'Unknown'),
+        })));
+      }
+    }).catch(() => {
+      // Tenant list is optional; silently fail
+    });
+  }, [isSuperAdmin]);
 
   // Build query params for the endpoint
   const buildQueryString = () => {
@@ -59,25 +86,29 @@ export default function CommentsModeration() {
     params.append('limit', '20');
     if (activeSearch) params.append('search', activeSearch);
     if (activeContentType) params.append('content_type', activeContentType);
+    if (isSuperAdmin && activeTenant) params.append('tenant_id', activeTenant);
     return params.toString();
   };
 
   const { data, isLoading, error, execute, meta } = useApi<AdminComment[]>(
     `/v2/admin/comments?${buildQueryString()}`,
-    { immediate: true, deps: [page, activeSearch, activeContentType] }
+    { immediate: true, deps: [page, activeSearch, activeContentType, activeTenant] }
   );
 
   const handleSearch = () => {
     setActiveSearch(search);
     setActiveContentType(contentTypeFilter);
+    setActiveTenant(tenantFilter);
     setPage(1);
   };
 
   const handleClear = () => {
     setSearch('');
     setContentTypeFilter('');
+    setTenantFilter('');
     setActiveSearch('');
     setActiveContentType('');
+    setActiveTenant('');
     setPage(1);
   };
 
@@ -111,11 +142,93 @@ export default function CommentsModeration() {
   const comments = data || [];
   const totalPages = meta?.total_pages || 1;
 
+  // Build cell content for a comment row
+  const renderCells = (comment: AdminComment): React.ReactElement[] => {
+    const cells: React.ReactElement[] = [
+      <TableCell key="user">
+        <div className="flex items-center gap-3">
+          <Avatar
+            src={comment.user_avatar || undefined}
+            name={comment.user_name}
+            size="sm"
+            className="flex-shrink-0"
+          />
+          <div className="flex flex-col">
+            <span className="text-sm font-medium">{comment.user_name}</span>
+            <span className="text-xs text-default-400">ID: {comment.user_id}</span>
+          </div>
+        </div>
+      </TableCell>,
+    ];
+
+    if (isSuperAdmin) {
+      cells.push(
+        <TableCell key="tenant">
+          <Chip size="sm" variant="flat" color="secondary">
+            {comment.tenant_name}
+          </Chip>
+        </TableCell>
+      );
+    }
+
+    cells.push(
+      <TableCell key="comment">
+        <div className="max-w-md">
+          <p className="text-sm line-clamp-2">{comment.content}</p>
+          {comment.is_flagged && (
+            <Chip size="sm" color="warning" variant="flat" className="mt-1">
+              Flagged
+            </Chip>
+          )}
+        </div>
+      </TableCell>,
+      <TableCell key="contentType">
+        <Chip size="sm" variant="flat">
+          {comment.content_type}
+        </Chip>
+      </TableCell>,
+      <TableCell key="created">
+        <span className="text-sm text-default-500">
+          {new Date(comment.created_at).toLocaleDateString()}
+        </span>
+      </TableCell>,
+      <TableCell key="actions">
+        <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            variant="flat"
+            color="warning"
+            startContent={<EyeOff className="w-4 h-4" />}
+            onPress={() => setConfirmAction({ type: 'hide', comment })}
+          >
+            Hide
+          </Button>
+          <Button
+            size="sm"
+            variant="flat"
+            color="danger"
+            startContent={<Trash2 className="w-4 h-4" />}
+            onPress={() => setConfirmAction({ type: 'delete', comment })}
+          >
+            Delete
+          </Button>
+        </div>
+      </TableCell>
+    );
+
+    return cells;
+  };
+
+  // Determine columns based on super admin status
+  const columns = isSuperAdmin
+    ? ['USER', 'TENANT', 'COMMENT', 'CONTENT TYPE', 'CREATED', 'ACTIONS']
+    : ['USER', 'COMMENT', 'CONTENT TYPE', 'CREATED', 'ACTIONS'];
+
   return (
     <div className="space-y-6">
       <PageHeader
         title="Comments Moderation"
-        description="Moderate comments across all content types"
+        description={isSuperAdmin ? 'Moderate comments across all tenants' : 'Moderate comments across all content types'}
         actions={
           <Button
             color="primary"
@@ -151,6 +264,23 @@ export default function CommentsModeration() {
             </SelectItem>
           ))}
         </Select>
+        {isSuperAdmin && (
+          <Select
+            label="Tenant"
+            selectedKeys={tenantFilter ? [tenantFilter] : []}
+            onChange={(e) => setTenantFilter(e.target.value)}
+            className="w-full sm:w-56"
+          >
+            {[
+              <SelectItem key="">All Tenants</SelectItem>,
+              ...tenants.map((t) => (
+                <SelectItem key={t.id.toString()}>
+                  {t.name}
+                </SelectItem>
+              )),
+            ]}
+          </Select>
+        )}
         <div className="flex gap-2">
           <Button color="primary" onPress={handleSearch}>
             Apply
@@ -165,6 +295,7 @@ export default function CommentsModeration() {
       {meta && (
         <div className="text-sm text-default-500">
           Showing {comments.length} of {meta.total ?? comments.length} comments
+          {isSuperAdmin && !activeTenant && ' (all tenants)'}
         </div>
       )}
 
@@ -178,11 +309,9 @@ export default function CommentsModeration() {
       {/* Table */}
       <Table aria-label="Comments table">
         <TableHeader>
-          <TableColumn>USER</TableColumn>
-          <TableColumn>COMMENT</TableColumn>
-          <TableColumn>CONTENT TYPE</TableColumn>
-          <TableColumn>CREATED</TableColumn>
-          <TableColumn>ACTIONS</TableColumn>
+          {columns.map((col) => (
+            <TableColumn key={col}>{col}</TableColumn>
+          ))}
         </TableHeader>
         <TableBody
           items={comments}
@@ -198,62 +327,7 @@ export default function CommentsModeration() {
         >
           {(comment) => (
             <TableRow key={comment.id}>
-              <TableCell>
-                <div className="flex items-center gap-3">
-                  <Avatar
-                    src={comment.user_avatar || undefined}
-                    name={comment.user_name}
-                    size="sm"
-                    className="flex-shrink-0"
-                  />
-                  <div className="flex flex-col">
-                    <span className="text-sm font-medium">{comment.user_name}</span>
-                    <span className="text-xs text-default-400">ID: {comment.user_id}</span>
-                  </div>
-                </div>
-              </TableCell>
-              <TableCell>
-                <div className="max-w-md">
-                  <p className="text-sm line-clamp-2">{comment.content}</p>
-                  {comment.is_flagged && (
-                    <Chip size="sm" color="warning" variant="flat" className="mt-1">
-                      Flagged
-                    </Chip>
-                  )}
-                </div>
-              </TableCell>
-              <TableCell>
-                <Chip size="sm" variant="flat">
-                  {comment.content_type}
-                </Chip>
-              </TableCell>
-              <TableCell>
-                <span className="text-sm text-default-500">
-                  {new Date(comment.created_at).toLocaleDateString()}
-                </span>
-              </TableCell>
-              <TableCell>
-                <div className="flex items-center gap-2">
-                  <Button
-                    size="sm"
-                    variant="flat"
-                    color="warning"
-                    startContent={<EyeOff className="w-4 h-4" />}
-                    onPress={() => setConfirmAction({ type: 'hide', comment })}
-                  >
-                    Hide
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="flat"
-                    color="danger"
-                    startContent={<Trash2 className="w-4 h-4" />}
-                    onPress={() => setConfirmAction({ type: 'delete', comment })}
-                  >
-                    Delete
-                  </Button>
-                </div>
-              </TableCell>
+              {renderCells(comment)}
             </TableRow>
           )}
         </TableBody>
@@ -280,8 +354,8 @@ export default function CommentsModeration() {
         title={confirmAction?.type === 'hide' ? 'Hide Comment' : 'Delete Comment'}
         message={
           confirmAction?.type === 'hide'
-            ? 'Are you sure you want to hide this comment? It will no longer be visible to members.'
-            : 'Are you sure you want to permanently delete this comment? This action cannot be undone.'
+            ? `Are you sure you want to hide this comment${isSuperAdmin && confirmAction?.comment ? ` from ${confirmAction.comment.tenant_name}` : ''}? It will no longer be visible to members.`
+            : `Are you sure you want to permanently delete this comment${isSuperAdmin && confirmAction?.comment ? ` from ${confirmAction.comment.tenant_name}` : ''}? This action cannot be undone.`
         }
         confirmLabel={confirmAction?.type === 'hide' ? 'Hide Comment' : 'Delete Comment'}
         confirmColor={confirmAction?.type === 'hide' ? 'warning' : 'danger'}

--- a/react-frontend/src/admin/modules/moderation/FeedModeration.tsx
+++ b/react-frontend/src/admin/modules/moderation/FeedModeration.tsx
@@ -3,7 +3,7 @@
 // Author: Jasper Ford
 // See NOTICE file for attribution and acknowledgements.
 
-import { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Button,
   Input,
@@ -23,10 +23,12 @@ import {
 import { Search, RefreshCw, EyeOff, Trash2 } from 'lucide-react';
 import { usePageTitle } from '@/hooks/usePageTitle';
 import { useApi } from '@/hooks/useApi';
+import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/contexts/ToastContext';
 import PageHeader from '@/admin/components/PageHeader';
 import ConfirmModal from '@/admin/components/ConfirmModal';
 import { adminModeration } from '@/admin/api/adminApi';
+import { adminSuper } from '@/admin/api/adminApi';
 import type { AdminFeedPost } from '@/admin/api/types';
 
 const POST_TYPES = [
@@ -41,16 +43,41 @@ export default function FeedModeration() {
   usePageTitle('Feed Moderation');
 
   const toast = useToast();
+  const { user } = useAuth();
+  const userRecord = user as Record<string, unknown> | null;
+  const isSuperAdmin =
+    (user?.role as string) === 'super_admin' ||
+    userRecord?.is_super_admin === true ||
+    userRecord?.is_tenant_super_admin === true;
+
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState('');
   const [typeFilter, setTypeFilter] = useState('');
+  const [tenantFilter, setTenantFilter] = useState('');
   const [activeSearch, setActiveSearch] = useState('');
   const [activeType, setActiveType] = useState('');
+  const [activeTenant, setActiveTenant] = useState('');
   const [actionLoading, setActionLoading] = useState(false);
   const [confirmAction, setConfirmAction] = useState<{
     type: 'hide' | 'delete';
     post: AdminFeedPost;
   } | null>(null);
+  const [tenants, setTenants] = useState<Array<{ id: number; name: string }>>([]);
+
+  // Load tenants list for super admin filter
+  useEffect(() => {
+    if (!isSuperAdmin) return;
+    adminSuper.listTenants().then((res) => {
+      if (res.success && Array.isArray(res.data)) {
+        setTenants(res.data.map((t) => ({
+          id: Number(t.id),
+          name: String(t.name || 'Unknown'),
+        })));
+      }
+    }).catch(() => {
+      // Tenant list is optional; silently fail
+    });
+  }, [isSuperAdmin]);
 
   // Build query params for the endpoint
   const buildQueryString = () => {
@@ -59,25 +86,29 @@ export default function FeedModeration() {
     params.append('limit', '20');
     if (activeSearch) params.append('search', activeSearch);
     if (activeType) params.append('type', activeType);
+    if (isSuperAdmin && activeTenant) params.append('tenant_id', activeTenant);
     return params.toString();
   };
 
   const { data, isLoading, error, execute, meta } = useApi<AdminFeedPost[]>(
     `/v2/admin/feed/posts?${buildQueryString()}`,
-    { immediate: true, deps: [page, activeSearch, activeType] }
+    { immediate: true, deps: [page, activeSearch, activeType, activeTenant] }
   );
 
   const handleSearch = () => {
     setActiveSearch(search);
     setActiveType(typeFilter);
+    setActiveTenant(tenantFilter);
     setPage(1);
   };
 
   const handleClear = () => {
     setSearch('');
     setTypeFilter('');
+    setTenantFilter('');
     setActiveSearch('');
     setActiveType('');
+    setActiveTenant('');
     setPage(1);
   };
 
@@ -111,11 +142,102 @@ export default function FeedModeration() {
   const posts = data || [];
   const totalPages = meta?.total_pages || 1;
 
+  // Build cell content for a post row
+  const renderCells = (post: AdminFeedPost): React.ReactElement[] => {
+    const cells: React.ReactElement[] = [
+      <TableCell key="user">
+        <div className="flex items-center gap-3">
+          <Avatar
+            src={post.user_avatar || undefined}
+            name={post.user_name}
+            size="sm"
+            className="flex-shrink-0"
+          />
+          <div className="flex flex-col">
+            <span className="text-sm font-medium">{post.user_name}</span>
+            <span className="text-xs text-default-400">ID: {post.user_id}</span>
+          </div>
+        </div>
+      </TableCell>,
+    ];
+
+    if (isSuperAdmin) {
+      cells.push(
+        <TableCell key="tenant">
+          <Chip size="sm" variant="flat" color="secondary">
+            {post.tenant_name}
+          </Chip>
+        </TableCell>
+      );
+    }
+
+    cells.push(
+      <TableCell key="content">
+        <div className="max-w-md">
+          <p className="text-sm line-clamp-2">{post.content}</p>
+          {post.is_flagged && (
+            <Chip size="sm" color="warning" variant="flat" className="mt-1">
+              Flagged
+            </Chip>
+          )}
+        </div>
+      </TableCell>,
+      <TableCell key="type">
+        <Chip size="sm" variant="flat">
+          {post.type}
+        </Chip>
+      </TableCell>,
+      <TableCell key="status">
+        {post.is_hidden ? (
+          <Chip size="sm" color="warning" variant="flat">Hidden</Chip>
+        ) : (
+          <Chip size="sm" color="success" variant="flat">Visible</Chip>
+        )}
+      </TableCell>,
+      <TableCell key="created">
+        <span className="text-sm text-default-500">
+          {new Date(post.created_at).toLocaleDateString()}
+        </span>
+      </TableCell>,
+      <TableCell key="actions">
+        <div className="flex items-center gap-2">
+          {!post.is_hidden && (
+            <Button
+              size="sm"
+              variant="flat"
+              color="warning"
+              startContent={<EyeOff className="w-4 h-4" />}
+              onPress={() => setConfirmAction({ type: 'hide', post })}
+            >
+              Hide
+            </Button>
+          )}
+          <Button
+            size="sm"
+            variant="flat"
+            color="danger"
+            startContent={<Trash2 className="w-4 h-4" />}
+            onPress={() => setConfirmAction({ type: 'delete', post })}
+          >
+            Delete
+          </Button>
+        </div>
+      </TableCell>
+    );
+
+    return cells;
+  };
+
+  // Determine columns based on super admin status
+  const columns = isSuperAdmin
+    ? ['USER', 'TENANT', 'CONTENT', 'TYPE', 'STATUS', 'CREATED', 'ACTIONS']
+    : ['USER', 'CONTENT', 'TYPE', 'STATUS', 'CREATED', 'ACTIONS'];
+
   return (
     <div className="space-y-6">
       <PageHeader
         title="Feed Moderation"
-        description="Moderate feed posts across your community"
+        description={isSuperAdmin ? 'Moderate feed posts across all tenants' : 'Moderate feed posts across your community'}
         actions={
           <Button
             color="primary"
@@ -151,6 +273,23 @@ export default function FeedModeration() {
             </SelectItem>
           ))}
         </Select>
+        {isSuperAdmin && (
+          <Select
+            label="Tenant"
+            selectedKeys={tenantFilter ? [tenantFilter] : []}
+            onChange={(e) => setTenantFilter(e.target.value)}
+            className="w-full sm:w-56"
+          >
+            {[
+              <SelectItem key="">All Tenants</SelectItem>,
+              ...tenants.map((t) => (
+                <SelectItem key={t.id.toString()}>
+                  {t.name}
+                </SelectItem>
+              )),
+            ]}
+          </Select>
+        )}
         <div className="flex gap-2">
           <Button color="primary" onPress={handleSearch}>
             Apply
@@ -165,6 +304,7 @@ export default function FeedModeration() {
       {meta && (
         <div className="text-sm text-default-500">
           Showing {posts.length} of {meta.total ?? posts.length} posts
+          {isSuperAdmin && !activeTenant && ' (all tenants)'}
         </div>
       )}
 
@@ -178,12 +318,9 @@ export default function FeedModeration() {
       {/* Table */}
       <Table aria-label="Feed posts table">
         <TableHeader>
-          <TableColumn>USER</TableColumn>
-          <TableColumn>CONTENT</TableColumn>
-          <TableColumn>TYPE</TableColumn>
-          <TableColumn>STATUS</TableColumn>
-          <TableColumn>CREATED</TableColumn>
-          <TableColumn>ACTIONS</TableColumn>
+          {columns.map((col) => (
+            <TableColumn key={col}>{col}</TableColumn>
+          ))}
         </TableHeader>
         <TableBody
           items={posts}
@@ -197,71 +334,7 @@ export default function FeedModeration() {
         >
           {(post) => (
             <TableRow key={post.id}>
-              <TableCell>
-                <div className="flex items-center gap-3">
-                  <Avatar
-                    src={post.user_avatar || undefined}
-                    name={post.user_name}
-                    size="sm"
-                    className="flex-shrink-0"
-                  />
-                  <div className="flex flex-col">
-                    <span className="text-sm font-medium">{post.user_name}</span>
-                    <span className="text-xs text-default-400">ID: {post.user_id}</span>
-                  </div>
-                </div>
-              </TableCell>
-              <TableCell>
-                <div className="max-w-md">
-                  <p className="text-sm line-clamp-2">{post.content}</p>
-                  {post.is_flagged && (
-                    <Chip size="sm" color="warning" variant="flat" className="mt-1">
-                      Flagged
-                    </Chip>
-                  )}
-                </div>
-              </TableCell>
-              <TableCell>
-                <Chip size="sm" variant="flat">
-                  {post.type}
-                </Chip>
-              </TableCell>
-              <TableCell>
-                {post.is_hidden ? (
-                  <Chip size="sm" color="warning" variant="flat">Hidden</Chip>
-                ) : (
-                  <Chip size="sm" color="success" variant="flat">Visible</Chip>
-                )}
-              </TableCell>
-              <TableCell>
-                <span className="text-sm text-default-500">
-                  {new Date(post.created_at).toLocaleDateString()}
-                </span>
-              </TableCell>
-              <TableCell>
-                <div className="flex items-center gap-2">
-                  {!post.is_hidden && (
-                    <Button
-                      size="sm"
-                      variant="flat"
-                      color="warning"
-                      startContent={<EyeOff className="w-4 h-4" />}
-                      onPress={() => setConfirmAction({ type: 'hide', post })}
-                    >
-                      Hide
-                    </Button>
-                  )}
-                  <Button
-                    size="sm"
-                    variant="flat"
-                    color="danger"
-                    startContent={<Trash2 className="w-4 h-4" />}
-                    onPress={() => setConfirmAction({ type: 'delete', post })}
-                  >
-                    Delete
-                  </Button>
-                </div>
-              </TableCell>
+              {renderCells(post)}
             </TableRow>
           )}
         </TableBody>
@@ -288,8 +361,8 @@ export default function FeedModeration() {
         title={confirmAction?.type === 'hide' ? 'Hide Post' : 'Delete Post'}
         message={
           confirmAction?.type === 'hide'
-            ? 'Are you sure you want to hide this post? It will no longer be visible to members.'
-            : 'Are you sure you want to permanently delete this post? This action cannot be undone.'
+            ? `Are you sure you want to hide this post${isSuperAdmin && confirmAction?.post ? ` from ${confirmAction.post.tenant_name}` : ''}? It will no longer be visible to members.`
+            : `Are you sure you want to permanently delete this post${isSuperAdmin && confirmAction?.post ? ` from ${confirmAction.post.tenant_name}` : ''}? This action cannot be undone.`
         }
         confirmLabel={confirmAction?.type === 'hide' ? 'Hide Post' : 'Delete Post'}
         confirmColor={confirmAction?.type === 'hide' ? 'warning' : 'danger'}

--- a/react-frontend/src/admin/modules/moderation/ReportsManagement.tsx
+++ b/react-frontend/src/admin/modules/moderation/ReportsManagement.tsx
@@ -3,7 +3,7 @@
 // Author: Jasper Ford
 // See NOTICE file for attribution and acknowledgements.
 
-import { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Button,
   Input,
@@ -25,10 +25,12 @@ import {
 import { Search, RefreshCw, CheckCircle2, XCircle, AlertCircle, Flag } from 'lucide-react';
 import { usePageTitle } from '@/hooks/usePageTitle';
 import { useApi } from '@/hooks/useApi';
+import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/contexts/ToastContext';
 import PageHeader from '@/admin/components/PageHeader';
 import ConfirmModal from '@/admin/components/ConfirmModal';
 import { adminModeration } from '@/admin/api/adminApi';
+import { adminSuper } from '@/admin/api/adminApi';
 import type { AdminReport, ModerationStats } from '@/admin/api/types';
 
 const CONTENT_TYPES = [
@@ -51,18 +53,43 @@ export default function ReportsManagement() {
   usePageTitle('Reports Management');
 
   const toast = useToast();
+  const { user } = useAuth();
+  const userRecord = user as Record<string, unknown> | null;
+  const isSuperAdmin =
+    (user?.role as string) === 'super_admin' ||
+    userRecord?.is_super_admin === true ||
+    userRecord?.is_tenant_super_admin === true;
+
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState('');
   const [typeFilter, setTypeFilter] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
+  const [tenantFilter, setTenantFilter] = useState('');
   const [activeSearch, setActiveSearch] = useState('');
   const [activeType, setActiveType] = useState('');
   const [activeStatus, setActiveStatus] = useState('');
+  const [activeTenant, setActiveTenant] = useState('');
   const [actionLoading, setActionLoading] = useState(false);
   const [confirmAction, setConfirmAction] = useState<{
     type: 'resolve' | 'dismiss';
     report: AdminReport;
   } | null>(null);
+  const [tenants, setTenants] = useState<Array<{ id: number; name: string }>>([]);
+
+  // Load tenants list for super admin filter
+  useEffect(() => {
+    if (!isSuperAdmin) return;
+    adminSuper.listTenants().then((res) => {
+      if (res.success && Array.isArray(res.data)) {
+        setTenants(res.data.map((t) => ({
+          id: Number(t.id),
+          name: String(t.name || 'Unknown'),
+        })));
+      }
+    }).catch(() => {
+      // Tenant list is optional; silently fail
+    });
+  }, [isSuperAdmin]);
 
   const { data: stats, execute: refetchStats } = useApi<ModerationStats>(
     '/v2/admin/reports/stats',
@@ -77,18 +104,20 @@ export default function ReportsManagement() {
     if (activeSearch) params.append('search', activeSearch);
     if (activeType) params.append('type', activeType);
     if (activeStatus) params.append('status', activeStatus);
+    if (isSuperAdmin && activeTenant) params.append('tenant_id', activeTenant);
     return params.toString();
   };
 
   const { data, isLoading, error, execute, meta } = useApi<AdminReport[]>(
     `/v2/admin/reports?${buildQueryString()}`,
-    { immediate: true, deps: [page, activeSearch, activeType, activeStatus] }
+    { immediate: true, deps: [page, activeSearch, activeType, activeStatus, activeTenant] }
   );
 
   const handleSearch = () => {
     setActiveSearch(search);
     setActiveType(typeFilter);
     setActiveStatus(statusFilter);
+    setActiveTenant(tenantFilter);
     setPage(1);
   };
 
@@ -96,9 +125,11 @@ export default function ReportsManagement() {
     setSearch('');
     setTypeFilter('');
     setStatusFilter('');
+    setTenantFilter('');
     setActiveSearch('');
     setActiveType('');
     setActiveStatus('');
+    setActiveTenant('');
     setPage(1);
   };
 
@@ -133,11 +164,107 @@ export default function ReportsManagement() {
   const reports = data || [];
   const totalPages = meta?.total_pages || 1;
 
+  // Build cell content for a report row
+  const renderCells = (report: AdminReport): React.ReactElement[] => {
+    const cells: React.ReactElement[] = [
+      <TableCell key="reporter">
+        <div className="flex items-center gap-3">
+          <Avatar
+            src={report.reporter_avatar || undefined}
+            name={report.reporter_name}
+            size="sm"
+            className="flex-shrink-0"
+          />
+          <div className="flex flex-col">
+            <span className="text-sm font-medium">{report.reporter_name}</span>
+            <span className="text-xs text-default-400">ID: {report.reporter_id}</span>
+          </div>
+        </div>
+      </TableCell>,
+    ];
+
+    if (isSuperAdmin) {
+      cells.push(
+        <TableCell key="tenant">
+          <Chip size="sm" variant="flat" color="secondary">
+            {report.tenant_name}
+          </Chip>
+        </TableCell>
+      );
+    }
+
+    cells.push(
+      <TableCell key="contentType">
+        <Chip size="sm" variant="flat">
+          {report.content_type}
+        </Chip>
+      </TableCell>,
+      <TableCell key="reason">
+        <span className="text-sm">{report.reason}</span>
+      </TableCell>,
+      <TableCell key="description">
+        <p className="text-sm line-clamp-2 max-w-md">{report.description}</p>
+      </TableCell>,
+      <TableCell key="status">
+        {report.status === 'pending' && (
+          <Chip size="sm" color="warning" variant="flat">Pending</Chip>
+        )}
+        {report.status === 'resolved' && (
+          <Chip size="sm" color="success" variant="flat">Resolved</Chip>
+        )}
+        {report.status === 'dismissed' && (
+          <Chip size="sm" color="default" variant="flat">Dismissed</Chip>
+        )}
+      </TableCell>,
+      <TableCell key="created">
+        <span className="text-sm text-default-500">
+          {new Date(report.created_at).toLocaleDateString()}
+        </span>
+      </TableCell>,
+      <TableCell key="actions">
+        {report.status === 'pending' && (
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              variant="flat"
+              color="success"
+              startContent={<CheckCircle2 className="w-4 h-4" />}
+              onPress={() => setConfirmAction({ type: 'resolve', report })}
+            >
+              Resolve
+            </Button>
+            <Button
+              size="sm"
+              variant="flat"
+              color="default"
+              startContent={<XCircle className="w-4 h-4" />}
+              onPress={() => setConfirmAction({ type: 'dismiss', report })}
+            >
+              Dismiss
+            </Button>
+          </div>
+        )}
+        {report.status !== 'pending' && (
+          <div className="text-sm text-default-400">
+            {report.resolved_by && `By ${report.resolved_by}`}
+          </div>
+        )}
+      </TableCell>
+    );
+
+    return cells;
+  };
+
+  // Determine columns based on super admin status
+  const columns = isSuperAdmin
+    ? ['REPORTER', 'TENANT', 'CONTENT TYPE', 'REASON', 'DESCRIPTION', 'STATUS', 'CREATED', 'ACTIONS']
+    : ['REPORTER', 'CONTENT TYPE', 'REASON', 'DESCRIPTION', 'STATUS', 'CREATED', 'ACTIONS'];
+
   return (
     <div className="space-y-6">
       <PageHeader
         title="Reports Management"
-        description="Manage user-submitted reports and flagged content"
+        description={isSuperAdmin ? 'Manage reports across all tenants' : 'Manage user-submitted reports and flagged content'}
         actions={
           <Button
             color="primary"
@@ -238,6 +365,23 @@ export default function ReportsManagement() {
             </SelectItem>
           ))}
         </Select>
+        {isSuperAdmin && (
+          <Select
+            label="Tenant"
+            selectedKeys={tenantFilter ? [tenantFilter] : []}
+            onChange={(e) => setTenantFilter(e.target.value)}
+            className="w-full sm:w-56"
+          >
+            {[
+              <SelectItem key="">All Tenants</SelectItem>,
+              ...tenants.map((t) => (
+                <SelectItem key={t.id.toString()}>
+                  {t.name}
+                </SelectItem>
+              )),
+            ]}
+          </Select>
+        )}
         <div className="flex gap-2">
           <Button color="primary" onPress={handleSearch}>
             Apply
@@ -252,6 +396,7 @@ export default function ReportsManagement() {
       {meta && (
         <div className="text-sm text-default-500">
           Showing {reports.length} of {meta.total ?? reports.length} reports
+          {isSuperAdmin && !activeTenant && ' (all tenants)'}
         </div>
       )}
 
@@ -265,13 +410,9 @@ export default function ReportsManagement() {
       {/* Table */}
       <Table aria-label="Reports table">
         <TableHeader>
-          <TableColumn>REPORTER</TableColumn>
-          <TableColumn>CONTENT TYPE</TableColumn>
-          <TableColumn>REASON</TableColumn>
-          <TableColumn>DESCRIPTION</TableColumn>
-          <TableColumn>STATUS</TableColumn>
-          <TableColumn>CREATED</TableColumn>
-          <TableColumn>ACTIONS</TableColumn>
+          {columns.map((col) => (
+            <TableColumn key={col}>{col}</TableColumn>
+          ))}
         </TableHeader>
         <TableBody
           items={reports}
@@ -287,76 +428,7 @@ export default function ReportsManagement() {
         >
           {(report) => (
             <TableRow key={report.id}>
-              <TableCell>
-                <div className="flex items-center gap-3">
-                  <Avatar
-                    src={report.reporter_avatar || undefined}
-                    name={report.reporter_name}
-                    size="sm"
-                    className="flex-shrink-0"
-                  />
-                  <div className="flex flex-col">
-                    <span className="text-sm font-medium">{report.reporter_name}</span>
-                    <span className="text-xs text-default-400">ID: {report.reporter_id}</span>
-                  </div>
-                </div>
-              </TableCell>
-              <TableCell>
-                <Chip size="sm" variant="flat">
-                  {report.content_type}
-                </Chip>
-              </TableCell>
-              <TableCell>
-                <span className="text-sm">{report.reason}</span>
-              </TableCell>
-              <TableCell>
-                <p className="text-sm line-clamp-2 max-w-md">{report.description}</p>
-              </TableCell>
-              <TableCell>
-                {report.status === 'pending' && (
-                  <Chip size="sm" color="warning" variant="flat">Pending</Chip>
-                )}
-                {report.status === 'resolved' && (
-                  <Chip size="sm" color="success" variant="flat">Resolved</Chip>
-                )}
-                {report.status === 'dismissed' && (
-                  <Chip size="sm" color="default" variant="flat">Dismissed</Chip>
-                )}
-              </TableCell>
-              <TableCell>
-                <span className="text-sm text-default-500">
-                  {new Date(report.created_at).toLocaleDateString()}
-                </span>
-              </TableCell>
-              <TableCell>
-                {report.status === 'pending' && (
-                  <div className="flex items-center gap-2">
-                    <Button
-                      size="sm"
-                      variant="flat"
-                      color="success"
-                      startContent={<CheckCircle2 className="w-4 h-4" />}
-                      onPress={() => setConfirmAction({ type: 'resolve', report })}
-                    >
-                      Resolve
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="flat"
-                      color="default"
-                      startContent={<XCircle className="w-4 h-4" />}
-                      onPress={() => setConfirmAction({ type: 'dismiss', report })}
-                    >
-                      Dismiss
-                    </Button>
-                  </div>
-                )}
-                {report.status !== 'pending' && (
-                  <div className="text-sm text-default-400">
-                    {report.resolved_by && `By ${report.resolved_by}`}
-                  </div>
-                )}
-              </TableCell>
+              {renderCells(report)}
             </TableRow>
           )}
         </TableBody>
@@ -383,8 +455,8 @@ export default function ReportsManagement() {
         title={confirmAction?.type === 'resolve' ? 'Resolve Report' : 'Dismiss Report'}
         message={
           confirmAction?.type === 'resolve'
-            ? 'Are you sure you want to mark this report as resolved? This indicates you have taken appropriate action.'
-            : 'Are you sure you want to dismiss this report? This indicates no action is needed.'
+            ? `Are you sure you want to mark this report${isSuperAdmin && confirmAction?.report ? ` from ${confirmAction.report.tenant_name}` : ''} as resolved? This indicates you have taken appropriate action.`
+            : `Are you sure you want to dismiss this report${isSuperAdmin && confirmAction?.report ? ` from ${confirmAction.report.tenant_name}` : ''}? This indicates no action is needed.`
         }
         confirmLabel={confirmAction?.type === 'resolve' ? 'Resolve Report' : 'Dismiss Report'}
         confirmColor={confirmAction?.type === 'resolve' ? 'primary' : 'warning'}

--- a/react-frontend/src/admin/modules/moderation/ReviewsModeration.tsx
+++ b/react-frontend/src/admin/modules/moderation/ReviewsModeration.tsx
@@ -3,7 +3,7 @@
 // Author: Jasper Ford
 // See NOTICE file for attribution and acknowledgements.
 
-import { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Button,
   Input,
@@ -23,10 +23,12 @@ import {
 import { Search, RefreshCw, Flag, EyeOff, Trash2, Star } from 'lucide-react';
 import { usePageTitle } from '@/hooks/usePageTitle';
 import { useApi } from '@/hooks/useApi';
+import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/contexts/ToastContext';
 import PageHeader from '@/admin/components/PageHeader';
 import ConfirmModal from '@/admin/components/ConfirmModal';
 import { adminModeration } from '@/admin/api/adminApi';
+import { adminSuper } from '@/admin/api/adminApi';
 import type { AdminReview } from '@/admin/api/types';
 
 const RATING_FILTERS = [
@@ -42,16 +44,41 @@ export default function ReviewsModeration() {
   usePageTitle('Reviews Moderation');
 
   const toast = useToast();
+  const { user } = useAuth();
+  const userRecord = user as Record<string, unknown> | null;
+  const isSuperAdmin =
+    (user?.role as string) === 'super_admin' ||
+    userRecord?.is_super_admin === true ||
+    userRecord?.is_tenant_super_admin === true;
+
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState('');
   const [ratingFilter, setRatingFilter] = useState('');
+  const [tenantFilter, setTenantFilter] = useState('');
   const [activeSearch, setActiveSearch] = useState('');
   const [activeRating, setActiveRating] = useState('');
+  const [activeTenant, setActiveTenant] = useState('');
   const [actionLoading, setActionLoading] = useState(false);
   const [confirmAction, setConfirmAction] = useState<{
     type: 'flag' | 'hide' | 'delete';
     review: AdminReview;
   } | null>(null);
+  const [tenants, setTenants] = useState<Array<{ id: number; name: string }>>([]);
+
+  // Load tenants list for super admin filter
+  useEffect(() => {
+    if (!isSuperAdmin) return;
+    adminSuper.listTenants().then((res) => {
+      if (res.success && Array.isArray(res.data)) {
+        setTenants(res.data.map((t) => ({
+          id: Number(t.id),
+          name: String(t.name || 'Unknown'),
+        })));
+      }
+    }).catch(() => {
+      // Tenant list is optional; silently fail
+    });
+  }, [isSuperAdmin]);
 
   // Build query params for the endpoint
   const buildQueryString = () => {
@@ -60,25 +87,29 @@ export default function ReviewsModeration() {
     params.append('limit', '20');
     if (activeSearch) params.append('search', activeSearch);
     if (activeRating) params.append('rating', activeRating);
+    if (isSuperAdmin && activeTenant) params.append('tenant_id', activeTenant);
     return params.toString();
   };
 
   const { data, isLoading, error, execute, meta } = useApi<AdminReview[]>(
     `/v2/admin/reviews?${buildQueryString()}`,
-    { immediate: true, deps: [page, activeSearch, activeRating] }
+    { immediate: true, deps: [page, activeSearch, activeRating, activeTenant] }
   );
 
   const handleSearch = () => {
     setActiveSearch(search);
     setActiveRating(ratingFilter);
+    setActiveTenant(tenantFilter);
     setPage(1);
   };
 
   const handleClear = () => {
     setSearch('');
     setRatingFilter('');
+    setTenantFilter('');
     setActiveSearch('');
     setActiveRating('');
+    setActiveTenant('');
     setPage(1);
   };
 
@@ -136,11 +167,117 @@ export default function ReviewsModeration() {
     );
   };
 
+  // Build cell content for a review row
+  const renderCells = (review: AdminReview): React.ReactElement[] => {
+    const cells: React.ReactElement[] = [
+      <TableCell key="reviewer">
+        <div className="flex items-center gap-3">
+          <Avatar
+            src={review.reviewer_avatar || undefined}
+            name={review.reviewer_name}
+            size="sm"
+            className="flex-shrink-0"
+          />
+          <span className="text-sm font-medium">{review.reviewer_name}</span>
+        </div>
+      </TableCell>,
+      <TableCell key="reviewee">
+        <div className="flex items-center gap-3">
+          <Avatar
+            src={review.reviewee_avatar || undefined}
+            name={review.reviewee_name}
+            size="sm"
+            className="flex-shrink-0"
+          />
+          <span className="text-sm font-medium">{review.reviewee_name}</span>
+        </div>
+      </TableCell>,
+    ];
+
+    if (isSuperAdmin) {
+      cells.push(
+        <TableCell key="tenant">
+          <Chip size="sm" variant="flat" color="secondary">
+            {review.tenant_name}
+          </Chip>
+        </TableCell>
+      );
+    }
+
+    cells.push(
+      <TableCell key="rating">{renderStars(review.rating)}</TableCell>,
+      <TableCell key="comment">
+        <div className="max-w-md">
+          <p className="text-sm line-clamp-2">{review.content}</p>
+          {review.is_flagged && (
+            <Chip size="sm" color="warning" variant="flat" className="mt-1">
+              Flagged
+            </Chip>
+          )}
+        </div>
+      </TableCell>,
+      <TableCell key="status">
+        {review.is_hidden ? (
+          <Chip size="sm" color="warning" variant="flat">Hidden</Chip>
+        ) : (
+          <Chip size="sm" color="success" variant="flat">Visible</Chip>
+        )}
+      </TableCell>,
+      <TableCell key="created">
+        <span className="text-sm text-default-500">
+          {new Date(review.created_at).toLocaleDateString()}
+        </span>
+      </TableCell>,
+      <TableCell key="actions">
+        <div className="flex items-center gap-2">
+          {!review.is_flagged && (
+            <Button
+              size="sm"
+              variant="flat"
+              color="warning"
+              startContent={<Flag className="w-4 h-4" />}
+              onPress={() => setConfirmAction({ type: 'flag', review })}
+            >
+              Flag
+            </Button>
+          )}
+          {!review.is_hidden && (
+            <Button
+              size="sm"
+              variant="flat"
+              color="warning"
+              startContent={<EyeOff className="w-4 h-4" />}
+              onPress={() => setConfirmAction({ type: 'hide', review })}
+            >
+              Hide
+            </Button>
+          )}
+          <Button
+            size="sm"
+            variant="flat"
+            color="danger"
+            startContent={<Trash2 className="w-4 h-4" />}
+            onPress={() => setConfirmAction({ type: 'delete', review })}
+          >
+            Delete
+          </Button>
+        </div>
+      </TableCell>
+    );
+
+    return cells;
+  };
+
+  // Determine columns based on super admin status
+  const columns = isSuperAdmin
+    ? ['REVIEWER', 'REVIEWEE', 'TENANT', 'RATING', 'COMMENT', 'STATUS', 'CREATED', 'ACTIONS']
+    : ['REVIEWER', 'REVIEWEE', 'RATING', 'COMMENT', 'STATUS', 'CREATED', 'ACTIONS'];
+
   return (
     <div className="space-y-6">
       <PageHeader
         title="Reviews Moderation"
-        description="Moderate member reviews and ratings"
+        description={isSuperAdmin ? 'Moderate member reviews across all tenants' : 'Moderate member reviews and ratings'}
         actions={
           <Button
             color="primary"
@@ -176,6 +313,23 @@ export default function ReviewsModeration() {
             </SelectItem>
           ))}
         </Select>
+        {isSuperAdmin && (
+          <Select
+            label="Tenant"
+            selectedKeys={tenantFilter ? [tenantFilter] : []}
+            onChange={(e) => setTenantFilter(e.target.value)}
+            className="w-full sm:w-56"
+          >
+            {[
+              <SelectItem key="">All Tenants</SelectItem>,
+              ...tenants.map((t) => (
+                <SelectItem key={t.id.toString()}>
+                  {t.name}
+                </SelectItem>
+              )),
+            ]}
+          </Select>
+        )}
         <div className="flex gap-2">
           <Button color="primary" onPress={handleSearch}>
             Apply
@@ -190,6 +344,7 @@ export default function ReviewsModeration() {
       {meta && (
         <div className="text-sm text-default-500">
           Showing {reviews.length} of {meta.total ?? reviews.length} reviews
+          {isSuperAdmin && !activeTenant && ' (all tenants)'}
         </div>
       )}
 
@@ -203,13 +358,9 @@ export default function ReviewsModeration() {
       {/* Table */}
       <Table aria-label="Reviews table">
         <TableHeader>
-          <TableColumn>REVIEWER</TableColumn>
-          <TableColumn>REVIEWEE</TableColumn>
-          <TableColumn>RATING</TableColumn>
-          <TableColumn>COMMENT</TableColumn>
-          <TableColumn>STATUS</TableColumn>
-          <TableColumn>CREATED</TableColumn>
-          <TableColumn>ACTIONS</TableColumn>
+          {columns.map((col) => (
+            <TableColumn key={col}>{col}</TableColumn>
+          ))}
         </TableHeader>
         <TableBody
           items={reviews}
@@ -225,86 +376,7 @@ export default function ReviewsModeration() {
         >
           {(review) => (
             <TableRow key={review.id}>
-              <TableCell>
-                <div className="flex items-center gap-3">
-                  <Avatar
-                    src={review.reviewer_avatar || undefined}
-                    name={review.reviewer_name}
-                    size="sm"
-                    className="flex-shrink-0"
-                  />
-                  <span className="text-sm font-medium">{review.reviewer_name}</span>
-                </div>
-              </TableCell>
-              <TableCell>
-                <div className="flex items-center gap-3">
-                  <Avatar
-                    src={review.reviewee_avatar || undefined}
-                    name={review.reviewee_name}
-                    size="sm"
-                    className="flex-shrink-0"
-                  />
-                  <span className="text-sm font-medium">{review.reviewee_name}</span>
-                </div>
-              </TableCell>
-              <TableCell>{renderStars(review.rating)}</TableCell>
-              <TableCell>
-                <div className="max-w-md">
-                  <p className="text-sm line-clamp-2">{review.content}</p>
-                  {review.is_flagged && (
-                    <Chip size="sm" color="warning" variant="flat" className="mt-1">
-                      Flagged
-                    </Chip>
-                  )}
-                </div>
-              </TableCell>
-              <TableCell>
-                {review.is_hidden ? (
-                  <Chip size="sm" color="warning" variant="flat">Hidden</Chip>
-                ) : (
-                  <Chip size="sm" color="success" variant="flat">Visible</Chip>
-                )}
-              </TableCell>
-              <TableCell>
-                <span className="text-sm text-default-500">
-                  {new Date(review.created_at).toLocaleDateString()}
-                </span>
-              </TableCell>
-              <TableCell>
-                <div className="flex items-center gap-2">
-                  {!review.is_flagged && (
-                    <Button
-                      size="sm"
-                      variant="flat"
-                      color="warning"
-                      startContent={<Flag className="w-4 h-4" />}
-                      onPress={() => setConfirmAction({ type: 'flag', review })}
-                    >
-                      Flag
-                    </Button>
-                  )}
-                  {!review.is_hidden && (
-                    <Button
-                      size="sm"
-                      variant="flat"
-                      color="warning"
-                      startContent={<EyeOff className="w-4 h-4" />}
-                      onPress={() => setConfirmAction({ type: 'hide', review })}
-                    >
-                      Hide
-                    </Button>
-                  )}
-                  <Button
-                    size="sm"
-                    variant="flat"
-                    color="danger"
-                    startContent={<Trash2 className="w-4 h-4" />}
-                    onPress={() => setConfirmAction({ type: 'delete', review })}
-                  >
-                    Delete
-                  </Button>
-                </div>
-              </TableCell>
+              {renderCells(review)}
             </TableRow>
           )}
         </TableBody>
@@ -337,10 +409,10 @@ export default function ReviewsModeration() {
         }
         message={
           confirmAction?.type === 'flag'
-            ? 'Are you sure you want to flag this review for admin attention?'
+            ? `Are you sure you want to flag this review${isSuperAdmin && confirmAction?.review ? ` from ${confirmAction.review.tenant_name}` : ''} for admin attention?`
             : confirmAction?.type === 'hide'
-            ? 'Are you sure you want to hide this review? It will no longer be visible to members.'
-            : 'Are you sure you want to permanently delete this review? This action cannot be undone.'
+            ? `Are you sure you want to hide this review${isSuperAdmin && confirmAction?.review ? ` from ${confirmAction.review.tenant_name}` : ''}? It will no longer be visible to members.`
+            : `Are you sure you want to permanently delete this review${isSuperAdmin && confirmAction?.review ? ` from ${confirmAction.review.tenant_name}` : ''}? This action cannot be undone.`
         }
         confirmLabel={
           confirmAction?.type === 'flag'

--- a/src/Controllers/Api/AdminBrokerApiController.php
+++ b/src/Controllers/Api/AdminBrokerApiController.php
@@ -53,14 +53,30 @@ class AdminBrokerApiController extends BaseApiController
     public function dashboard(): void
     {
         $this->requireBrokerAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
+
+        // Determine tenant scoping
+        if ($isSuperAdmin) {
+            if ($filterTenantId) {
+                $tenantWhere = 'tenant_id = ?';
+                $tenantParams = [$filterTenantId];
+            } else {
+                $tenantWhere = '1=1';
+                $tenantParams = [];
+            }
+        } else {
+            $tenantWhere = 'tenant_id = ?';
+            $tenantParams = [$tenantId];
+        }
 
         // Pending exchanges
         $pendingExchanges = 0;
         try {
             $row = Database::query(
-                "SELECT COUNT(*) as cnt FROM exchange_requests WHERE tenant_id = ? AND status IN ('pending_broker', 'disputed')",
-                [$tenantId]
+                "SELECT COUNT(*) as cnt FROM exchange_requests WHERE {$tenantWhere} AND status IN ('pending_broker', 'disputed')",
+                $tenantParams
             )->fetch();
             $pendingExchanges = (int) ($row['cnt'] ?? 0);
         } catch (\Exception $e) {
@@ -71,8 +87,8 @@ class AdminBrokerApiController extends BaseApiController
         $unreviewedMessages = 0;
         try {
             $row = Database::query(
-                "SELECT COUNT(*) as cnt FROM broker_message_copies WHERE tenant_id = ? AND reviewed_by IS NULL",
-                [$tenantId]
+                "SELECT COUNT(*) as cnt FROM broker_message_copies WHERE {$tenantWhere} AND reviewed_by IS NULL",
+                $tenantParams
             )->fetch();
             $unreviewedMessages = (int) ($row['cnt'] ?? 0);
         } catch (\Exception $e) {
@@ -83,8 +99,8 @@ class AdminBrokerApiController extends BaseApiController
         $highRiskListings = 0;
         try {
             $row = Database::query(
-                "SELECT COUNT(*) as cnt FROM listing_risk_tags WHERE tenant_id = ? AND risk_level = 'high'",
-                [$tenantId]
+                "SELECT COUNT(*) as cnt FROM listing_risk_tags WHERE {$tenantWhere} AND risk_level = 'high'",
+                $tenantParams
             )->fetch();
             $highRiskListings = (int) ($row['cnt'] ?? 0);
         } catch (\Exception $e) {
@@ -95,8 +111,8 @@ class AdminBrokerApiController extends BaseApiController
         $monitoredUsers = 0;
         try {
             $row = Database::query(
-                "SELECT COUNT(*) as cnt FROM user_messaging_restrictions WHERE tenant_id = ? AND under_monitoring = 1",
-                [$tenantId]
+                "SELECT COUNT(*) as cnt FROM user_messaging_restrictions WHERE {$tenantWhere} AND under_monitoring = 1",
+                $tenantParams
             )->fetch();
             $monitoredUsers = (int) ($row['cnt'] ?? 0);
         } catch (\Exception $e) {
@@ -111,8 +127,8 @@ class AdminBrokerApiController extends BaseApiController
                 "SELECT
                     SUM(CASE WHEN status IN ('pending', 'submitted') THEN 1 ELSE 0 END) as pending,
                     SUM(CASE WHEN status = 'verified' AND expiry_date BETWEEN CURDATE() AND DATE_ADD(CURDATE(), INTERVAL 30 DAY) THEN 1 ELSE 0 END) as expiring
-                 FROM vetting_records WHERE tenant_id = ?",
-                [$tenantId]
+                 FROM vetting_records WHERE {$tenantWhere}",
+                $tenantParams
             )->fetch();
             $vettingPending = (int) ($row['pending'] ?? 0);
             $vettingExpiring = (int) ($row['expiring'] ?? 0);
@@ -124,8 +140,8 @@ class AdminBrokerApiController extends BaseApiController
         $safeguardingAlerts = 0;
         try {
             $row = Database::query(
-                "SELECT COUNT(*) as cnt FROM abuse_alerts WHERE tenant_id = ? AND status = 'open'",
-                [$tenantId]
+                "SELECT COUNT(*) as cnt FROM abuse_alerts WHERE {$tenantWhere} AND status = 'open'",
+                $tenantParams
             )->fetch();
             $safeguardingAlerts = (int) ($row['cnt'] ?? 0);
         } catch (\Exception $e) {
@@ -135,18 +151,21 @@ class AdminBrokerApiController extends BaseApiController
         // Recent broker activity (last 20 actions)
         $recentActivity = [];
         try {
+            $actWhere = $isSuperAdmin && !$filterTenantId ? '1=1' : 'al.tenant_id = ?';
+            $actParams = $isSuperAdmin && !$filterTenantId ? [] : ($filterTenantId ? [$filterTenantId] : [$tenantId]);
             $recentActivity = Database::query(
-                "SELECT al.*, u.first_name, u.last_name
+                "SELECT al.*, u.first_name, u.last_name, t.name as tenant_name
                  FROM activity_logs al
                  LEFT JOIN users u ON u.id = al.user_id
-                 WHERE al.tenant_id = ? AND al.action_type IN (
+                 LEFT JOIN tenants t ON al.tenant_id = t.id
+                 WHERE {$actWhere} AND al.action_type IN (
                      'exchange_approved', 'exchange_rejected', 'message_reviewed',
                      'risk_tag_added', 'user_monitored', 'vetting_verified', 'vetting_rejected',
                      'user_banned', 'user_unbanned', 'balance_adjusted'
                  )
                  ORDER BY al.created_at DESC
                  LIMIT 20",
-                [$tenantId]
+                $actParams
             )->fetchAll();
         } catch (\Exception $e) {
             // Table may not exist
@@ -173,21 +192,36 @@ class AdminBrokerApiController extends BaseApiController
     public function exchanges(): void
     {
         $this->requireBrokerAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $page = $this->queryInt('page', 1, 1);
         $perPage = $this->queryInt('per_page', 20, 1, 100);
         $status = $this->query('status');
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
         $offset = ($page - 1) * $perPage;
 
         try {
-            // Build WHERE clause
-            $where = "er.tenant_id = ?";
-            $params = [$tenantId];
+            // Build WHERE clause with tenant scoping
+            $conditions = [];
+            $params = [];
+
+            if ($isSuperAdmin) {
+                if ($filterTenantId) {
+                    $conditions[] = 'er.tenant_id = ?';
+                    $params[] = $filterTenantId;
+                }
+                // No tenant filter = all tenants for super admin
+            } else {
+                $conditions[] = 'er.tenant_id = ?';
+                $params[] = $tenantId;
+            }
 
             if ($status && $status !== 'all') {
-                $where .= " AND er.status = ?";
+                $conditions[] = 'er.status = ?';
                 $params[] = $status;
             }
+
+            $where = !empty($conditions) ? implode(' AND ', $conditions) : '1=1';
 
             // Get total count
             $countRow = Database::query(
@@ -196,22 +230,30 @@ class AdminBrokerApiController extends BaseApiController
             )->fetch();
             $total = (int) ($countRow['cnt'] ?? 0);
 
-            // Get paginated data
+            // Get paginated data — join tenants table for cross-tenant name display
             $queryParams = array_merge($params, [$perPage, $offset]);
             $items = Database::query(
                 "SELECT er.*,
                     CONCAT(req.first_name, ' ', req.last_name) as requester_name,
                     CONCAT(prov.first_name, ' ', prov.last_name) as provider_name,
-                    l.title as listing_title
+                    l.title as listing_title,
+                    t.name as tenant_name
                 FROM exchange_requests er
                 JOIN users req ON er.requester_id = req.id
                 JOIN users prov ON er.provider_id = prov.id
                 LEFT JOIN listings l ON er.listing_id = l.id
+                LEFT JOIN tenants t ON er.tenant_id = t.id
                 WHERE {$where}
                 ORDER BY er.created_at DESC
                 LIMIT ? OFFSET ?",
                 $queryParams
             )->fetchAll();
+
+            // Add tenant info to each item
+            foreach ($items as &$item) {
+                $item['tenant_name'] = $item['tenant_name'] ?? 'Unknown';
+            }
+            unset($item);
 
             $this->respondWithPaginatedCollection($items, $total, $page, $perPage);
         } catch (\Exception $e) {
@@ -227,15 +269,23 @@ class AdminBrokerApiController extends BaseApiController
     public function approveExchange(int $id): void
     {
         $adminId = $this->requireBrokerAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $notes = $this->input('notes', '');
 
         try {
-            // Verify the exchange belongs to this tenant and is pending broker approval
-            $exchange = Database::query(
-                "SELECT id, status FROM exchange_requests WHERE id = ? AND tenant_id = ?",
-                [$id, $tenantId]
-            )->fetch();
+            // Super admins can approve exchanges from any tenant
+            if ($isSuperAdmin) {
+                $exchange = Database::query(
+                    "SELECT id, status, tenant_id FROM exchange_requests WHERE id = ?",
+                    [$id]
+                )->fetch();
+            } else {
+                $exchange = Database::query(
+                    "SELECT id, status, tenant_id FROM exchange_requests WHERE id = ? AND tenant_id = ?",
+                    [$id, $tenantId]
+                )->fetch();
+            }
 
             if (!$exchange) {
                 $this->respondWithError('NOT_FOUND', 'Exchange request not found', null, 404);
@@ -270,6 +320,7 @@ class AdminBrokerApiController extends BaseApiController
     public function rejectExchange(int $id): void
     {
         $adminId = $this->requireBrokerAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $reason = $this->input('reason', '');
 
@@ -279,11 +330,18 @@ class AdminBrokerApiController extends BaseApiController
         }
 
         try {
-            // Verify the exchange belongs to this tenant and is pending broker approval
-            $exchange = Database::query(
-                "SELECT id, status FROM exchange_requests WHERE id = ? AND tenant_id = ?",
-                [$id, $tenantId]
-            )->fetch();
+            // Super admins can reject exchanges from any tenant
+            if ($isSuperAdmin) {
+                $exchange = Database::query(
+                    "SELECT id, status, tenant_id FROM exchange_requests WHERE id = ?",
+                    [$id]
+                )->fetch();
+            } else {
+                $exchange = Database::query(
+                    "SELECT id, status, tenant_id FROM exchange_requests WHERE id = ? AND tenant_id = ?",
+                    [$id, $tenantId]
+                )->fetch();
+            }
 
             if (!$exchange) {
                 $this->respondWithError('NOT_FOUND', 'Exchange request not found', null, 404);
@@ -319,29 +377,52 @@ class AdminBrokerApiController extends BaseApiController
     public function riskTags(): void
     {
         $this->requireBrokerAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $riskLevel = $this->query('risk_level');
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
         try {
-            $where = "rt.tenant_id = ?";
-            $params = [$tenantId];
+            $conditions = [];
+            $params = [];
+
+            // Tenant scoping
+            if ($isSuperAdmin) {
+                if ($filterTenantId) {
+                    $conditions[] = 'rt.tenant_id = ?';
+                    $params[] = $filterTenantId;
+                }
+                // No filter = all tenants for super admin
+            } else {
+                $conditions[] = 'rt.tenant_id = ?';
+                $params[] = $tenantId;
+            }
 
             if ($riskLevel && $riskLevel !== 'all') {
-                $where .= " AND rt.risk_level = ?";
+                $conditions[] = 'rt.risk_level = ?';
                 $params[] = $riskLevel;
             }
+
+            $where = !empty($conditions) ? implode(' AND ', $conditions) : '1=1';
 
             $items = Database::query(
                 "SELECT rt.*,
                     l.title as listing_title,
-                    CONCAT(u.first_name, ' ', u.last_name) as owner_name
+                    CONCAT(u.first_name, ' ', u.last_name) as owner_name,
+                    t.name as tenant_name
                 FROM listing_risk_tags rt
                 LEFT JOIN listings l ON rt.listing_id = l.id
                 LEFT JOIN users u ON l.user_id = u.id
+                LEFT JOIN tenants t ON rt.tenant_id = t.id
                 WHERE {$where}
                 ORDER BY FIELD(rt.risk_level, 'critical', 'high', 'medium', 'low'), rt.created_at DESC",
                 $params
             )->fetchAll();
+
+            foreach ($items as &$item) {
+                $item['tenant_name'] = $item['tenant_name'] ?? 'Unknown';
+            }
+            unset($item);
 
             $this->respondWithData($items);
         } catch (\Exception $e) {
@@ -358,23 +439,39 @@ class AdminBrokerApiController extends BaseApiController
     public function messages(): void
     {
         $this->requireBrokerAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $page = $this->queryInt('page', 1, 1);
         $perPage = $this->queryInt('per_page', 20, 1, 100);
         $filter = $this->query('filter', 'all');
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
         $offset = ($page - 1) * $perPage;
 
         try {
-            $where = "bmc.tenant_id = ?";
-            $params = [$tenantId];
+            $conditions = [];
+            $params = [];
+
+            // Tenant scoping
+            if ($isSuperAdmin) {
+                if ($filterTenantId) {
+                    $conditions[] = 'bmc.tenant_id = ?';
+                    $params[] = $filterTenantId;
+                }
+                // No filter = all tenants for super admin
+            } else {
+                $conditions[] = 'bmc.tenant_id = ?';
+                $params[] = $tenantId;
+            }
 
             if ($filter === 'unreviewed') {
-                $where .= " AND bmc.reviewed_by IS NULL";
+                $conditions[] = 'bmc.reviewed_by IS NULL';
             } elseif ($filter === 'flagged') {
-                $where .= " AND bmc.flagged = 1";
+                $conditions[] = 'bmc.flagged = 1';
             } elseif ($filter === 'reviewed') {
-                $where .= " AND bmc.reviewed_by IS NOT NULL";
+                $conditions[] = 'bmc.reviewed_by IS NOT NULL';
             }
+
+            $where = !empty($conditions) ? implode(' AND ', $conditions) : '1=1';
 
             // Count
             $countRow = Database::query(
@@ -383,27 +480,31 @@ class AdminBrokerApiController extends BaseApiController
             )->fetch();
             $total = (int) ($countRow['cnt'] ?? 0);
 
-            // Paginated data
+            // Paginated data — join tenants table for cross-tenant name display
             $queryParams = array_merge($params, [$perPage, $offset]);
             $items = Database::query(
                 "SELECT bmc.*,
                     CONCAT(s.first_name, ' ', s.last_name) as sender_name,
                     CONCAT(r.first_name, ' ', r.last_name) as receiver_name,
-                    l.title as listing_title
+                    l.title as listing_title,
+                    t.name as tenant_name
                 FROM broker_message_copies bmc
                 LEFT JOIN users s ON bmc.sender_id = s.id
                 LEFT JOIN users r ON bmc.receiver_id = r.id
                 LEFT JOIN listings l ON bmc.related_listing_id = l.id
+                LEFT JOIN tenants t ON bmc.tenant_id = t.id
                 WHERE {$where}
                 ORDER BY bmc.created_at DESC
                 LIMIT ? OFFSET ?",
                 $queryParams
             )->fetchAll();
 
-            // Normalize boolean fields
+            // Normalize boolean fields and add tenant info
             foreach ($items as &$item) {
                 $item['flagged'] = (bool) ($item['flagged'] ?? false);
+                $item['tenant_name'] = $item['tenant_name'] ?? 'Unknown';
             }
+            unset($item);
 
             $this->respondWithPaginatedCollection($items, $total, $page, $perPage);
         } catch (\Exception $e) {
@@ -419,23 +520,33 @@ class AdminBrokerApiController extends BaseApiController
     public function reviewMessage(int $id): void
     {
         $adminId = $this->requireBrokerAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         try {
-            // Verify the message belongs to this tenant
-            $message = Database::query(
-                "SELECT id FROM broker_message_copies WHERE id = ? AND tenant_id = ?",
-                [$id, $tenantId]
-            )->fetch();
+            // Super admins can review messages from any tenant
+            if ($isSuperAdmin) {
+                $message = Database::query(
+                    "SELECT id, tenant_id FROM broker_message_copies WHERE id = ?",
+                    [$id]
+                )->fetch();
+            } else {
+                $message = Database::query(
+                    "SELECT id, tenant_id FROM broker_message_copies WHERE id = ? AND tenant_id = ?",
+                    [$id, $tenantId]
+                )->fetch();
+            }
 
             if (!$message) {
                 $this->respondWithError('NOT_FOUND', 'Message not found', null, 404);
                 return;
             }
 
+            // Use the record's own tenant_id for the update
+            $recordTenantId = (int) $message['tenant_id'];
             Database::query(
                 "UPDATE broker_message_copies SET reviewed_by = ?, reviewed_at = NOW() WHERE id = ? AND tenant_id = ?",
-                [$adminId, $id, $tenantId]
+                [$adminId, $id, $recordTenantId]
             );
 
             $this->respondWithData(['id' => $id, 'reviewed' => true]);
@@ -452,23 +563,46 @@ class AdminBrokerApiController extends BaseApiController
     public function monitoring(): void
     {
         $this->requireBrokerAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
         try {
+            $conditions = ['umr.under_monitoring = 1'];
+            $params = [];
+
+            // Tenant scoping
+            if ($isSuperAdmin) {
+                if ($filterTenantId) {
+                    $conditions[] = 'umr.tenant_id = ?';
+                    $params[] = $filterTenantId;
+                }
+                // No filter = all tenants for super admin
+            } else {
+                $conditions[] = 'umr.tenant_id = ?';
+                $params[] = $tenantId;
+            }
+
+            $where = implode(' AND ', $conditions);
+
             $items = Database::query(
                 "SELECT umr.*,
-                    CONCAT(u.first_name, ' ', u.last_name) as user_name
+                    CONCAT(u.first_name, ' ', u.last_name) as user_name,
+                    t.name as tenant_name
                 FROM user_messaging_restrictions umr
                 LEFT JOIN users u ON umr.user_id = u.id
-                WHERE umr.tenant_id = ? AND umr.under_monitoring = 1
+                LEFT JOIN tenants t ON umr.tenant_id = t.id
+                WHERE {$where}
                 ORDER BY umr.monitoring_started_at DESC",
-                [$tenantId]
+                $params
             )->fetchAll();
 
-            // Normalize boolean fields
+            // Normalize boolean fields and add tenant info
             foreach ($items as &$item) {
                 $item['under_monitoring'] = (bool) ($item['under_monitoring'] ?? false);
+                $item['tenant_name'] = $item['tenant_name'] ?? 'Unknown';
             }
+            unset($item);
 
             $this->respondWithData($items);
         } catch (\Exception $e) {
@@ -485,6 +619,7 @@ class AdminBrokerApiController extends BaseApiController
     public function flagMessage(int $id): void
     {
         $adminId = $this->requireBrokerAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $reason = trim($this->input('reason', ''));
         $severity = $this->input('severity', 'concern');
@@ -500,19 +635,29 @@ class AdminBrokerApiController extends BaseApiController
         }
 
         try {
-            $message = Database::query(
-                "SELECT id FROM broker_message_copies WHERE id = ? AND tenant_id = ?",
-                [$id, $tenantId]
-            )->fetch();
+            // Super admins can flag messages from any tenant
+            if ($isSuperAdmin) {
+                $message = Database::query(
+                    "SELECT id, tenant_id FROM broker_message_copies WHERE id = ?",
+                    [$id]
+                )->fetch();
+            } else {
+                $message = Database::query(
+                    "SELECT id, tenant_id FROM broker_message_copies WHERE id = ? AND tenant_id = ?",
+                    [$id, $tenantId]
+                )->fetch();
+            }
 
             if (!$message) {
                 $this->respondWithError('NOT_FOUND', 'Message not found', null, 404);
                 return;
             }
 
+            // Use the record's own tenant_id for the update
+            $recordTenantId = (int) $message['tenant_id'];
             Database::query(
                 "UPDATE broker_message_copies SET flagged = 1, flag_reason = ?, flag_severity = ?, reviewed_by = ?, reviewed_at = NOW() WHERE id = ? AND tenant_id = ?",
-                [$reason, $severity, $adminId, $id, $tenantId]
+                [$reason, $severity, $adminId, $id, $recordTenantId]
             );
 
             $this->respondWithData(['id' => $id, 'flagged' => true, 'flag_reason' => $reason, 'flag_severity' => $severity]);
@@ -530,22 +675,42 @@ class AdminBrokerApiController extends BaseApiController
     public function showMessage(int $id): void
     {
         $this->requireBrokerAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         try {
-            // Load the broker copy with sender/receiver names and listing title
-            $copy = Database::query(
-                "SELECT bmc.*,
-                    CONCAT(s.first_name, ' ', s.last_name) as sender_name,
-                    CONCAT(r.first_name, ' ', r.last_name) as receiver_name,
-                    l.title as listing_title
-                FROM broker_message_copies bmc
-                LEFT JOIN users s ON bmc.sender_id = s.id
-                LEFT JOIN users r ON bmc.receiver_id = r.id
-                LEFT JOIN listings l ON bmc.related_listing_id = l.id
-                WHERE bmc.id = ? AND bmc.tenant_id = ?",
-                [$id, $tenantId]
-            )->fetch();
+            // Super admins can view messages from any tenant
+            if ($isSuperAdmin) {
+                $copy = Database::query(
+                    "SELECT bmc.*,
+                        CONCAT(s.first_name, ' ', s.last_name) as sender_name,
+                        CONCAT(r.first_name, ' ', r.last_name) as receiver_name,
+                        l.title as listing_title,
+                        t.name as tenant_name
+                    FROM broker_message_copies bmc
+                    LEFT JOIN users s ON bmc.sender_id = s.id
+                    LEFT JOIN users r ON bmc.receiver_id = r.id
+                    LEFT JOIN listings l ON bmc.related_listing_id = l.id
+                    LEFT JOIN tenants t ON bmc.tenant_id = t.id
+                    WHERE bmc.id = ?",
+                    [$id]
+                )->fetch();
+            } else {
+                $copy = Database::query(
+                    "SELECT bmc.*,
+                        CONCAT(s.first_name, ' ', s.last_name) as sender_name,
+                        CONCAT(r.first_name, ' ', r.last_name) as receiver_name,
+                        l.title as listing_title,
+                        t.name as tenant_name
+                    FROM broker_message_copies bmc
+                    LEFT JOIN users s ON bmc.sender_id = s.id
+                    LEFT JOIN users r ON bmc.receiver_id = r.id
+                    LEFT JOIN listings l ON bmc.related_listing_id = l.id
+                    LEFT JOIN tenants t ON bmc.tenant_id = t.id
+                    WHERE bmc.id = ? AND bmc.tenant_id = ?",
+                    [$id, $tenantId]
+                )->fetch();
+            }
 
             if (!$copy) {
                 $this->respondWithError('NOT_FOUND', 'Broker message copy not found', null, 404);
@@ -553,8 +718,10 @@ class AdminBrokerApiController extends BaseApiController
             }
 
             $copy['flagged'] = (bool) ($copy['flagged'] ?? false);
+            $copy['tenant_name'] = $copy['tenant_name'] ?? 'Unknown';
+            $copyTenantId = (int) $copy['tenant_id'];
 
-            // Load full conversation thread between sender and receiver
+            // Load full conversation thread between sender and receiver — use the copy's own tenant_id
             $thread = Database::query(
                 "SELECT m.id, m.sender_id, m.receiver_id, m.body, m.created_at, m.is_deleted,
                     CONCAT(u.first_name, ' ', u.last_name) as sender_name
@@ -564,7 +731,7 @@ class AdminBrokerApiController extends BaseApiController
                   AND ((m.sender_id = ? AND m.receiver_id = ?) OR (m.sender_id = ? AND m.receiver_id = ?))
                 ORDER BY m.created_at ASC
                 LIMIT 200",
-                [$tenantId, $copy['sender_id'], $copy['receiver_id'], $copy['receiver_id'], $copy['sender_id']]
+                [$copyTenantId, $copy['sender_id'], $copy['receiver_id'], $copy['receiver_id'], $copy['sender_id']]
             )->fetchAll();
 
             // Redact deleted messages
@@ -575,14 +742,14 @@ class AdminBrokerApiController extends BaseApiController
             }
             unset($msg);
 
-            // If copy has an archive, load it
+            // If copy has an archive, load it — use the copy's own tenant_id
             $archive = null;
             if (!empty($copy['archive_id'])) {
                 $archive = Database::query(
                     "SELECT id, decision, decision_notes, decided_by_name, decided_at, flag_reason, flag_severity
                     FROM broker_review_archives
                     WHERE id = ? AND tenant_id = ?",
-                    [$copy['archive_id'], $tenantId]
+                    [$copy['archive_id'], $copyTenantId]
                 )->fetch() ?: null;
             }
 
@@ -606,28 +773,47 @@ class AdminBrokerApiController extends BaseApiController
     public function approveMessage(int $id): void
     {
         $adminId = $this->requireBrokerAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $notes = trim($this->input('notes', ''));
 
         try {
-            // Load the broker copy with sender/receiver names and listing title
-            $copy = Database::query(
-                "SELECT bmc.*,
-                    CONCAT(s.first_name, ' ', s.last_name) as sender_name,
-                    CONCAT(r.first_name, ' ', r.last_name) as receiver_name,
-                    l.title as listing_title
-                FROM broker_message_copies bmc
-                LEFT JOIN users s ON bmc.sender_id = s.id
-                LEFT JOIN users r ON bmc.receiver_id = r.id
-                LEFT JOIN listings l ON bmc.related_listing_id = l.id
-                WHERE bmc.id = ? AND bmc.tenant_id = ?",
-                [$id, $tenantId]
-            )->fetch();
+            // Super admins can approve messages from any tenant
+            if ($isSuperAdmin) {
+                $copy = Database::query(
+                    "SELECT bmc.*,
+                        CONCAT(s.first_name, ' ', s.last_name) as sender_name,
+                        CONCAT(r.first_name, ' ', r.last_name) as receiver_name,
+                        l.title as listing_title
+                    FROM broker_message_copies bmc
+                    LEFT JOIN users s ON bmc.sender_id = s.id
+                    LEFT JOIN users r ON bmc.receiver_id = r.id
+                    LEFT JOIN listings l ON bmc.related_listing_id = l.id
+                    WHERE bmc.id = ?",
+                    [$id]
+                )->fetch();
+            } else {
+                $copy = Database::query(
+                    "SELECT bmc.*,
+                        CONCAT(s.first_name, ' ', s.last_name) as sender_name,
+                        CONCAT(r.first_name, ' ', r.last_name) as receiver_name,
+                        l.title as listing_title
+                    FROM broker_message_copies bmc
+                    LEFT JOIN users s ON bmc.sender_id = s.id
+                    LEFT JOIN users r ON bmc.receiver_id = r.id
+                    LEFT JOIN listings l ON bmc.related_listing_id = l.id
+                    WHERE bmc.id = ? AND bmc.tenant_id = ?",
+                    [$id, $tenantId]
+                )->fetch();
+            }
 
             if (!$copy) {
                 $this->respondWithError('NOT_FOUND', 'Broker message copy not found', null, 404);
                 return;
             }
+
+            // Use the record's own tenant_id for all writes
+            $copyTenantId = (int) $copy['tenant_id'];
 
             // Prevent double-archiving
             if (!empty($copy['archive_id'])) {
@@ -642,7 +828,7 @@ class AdminBrokerApiController extends BaseApiController
             )->fetch();
             $adminName = $adminRow['name'] ?? 'Unknown';
 
-            // Snapshot the full conversation between sender and receiver
+            // Snapshot the full conversation between sender and receiver — use the copy's own tenant_id
             $conversationRows = Database::query(
                 "SELECT m.id, m.sender_id, m.body, m.created_at, m.is_deleted,
                     CONCAT(u.first_name, ' ', u.last_name) as sender_name
@@ -652,7 +838,7 @@ class AdminBrokerApiController extends BaseApiController
                   AND ((m.sender_id = ? AND m.receiver_id = ?) OR (m.sender_id = ? AND m.receiver_id = ?))
                 ORDER BY m.created_at ASC
                 LIMIT 500",
-                [$tenantId, $copy['sender_id'], $copy['receiver_id'], $copy['receiver_id'], $copy['sender_id']]
+                [$copyTenantId, $copy['sender_id'], $copy['receiver_id'], $copy['receiver_id'], $copy['sender_id']]
             )->fetchAll();
 
             // Redact deleted messages in snapshot
@@ -669,7 +855,7 @@ class AdminBrokerApiController extends BaseApiController
             // Determine decision based on flag status
             $decision = !empty($copy['flagged']) ? 'flagged' : 'approved';
 
-            // INSERT the immutable archive record
+            // INSERT the immutable archive record — use the copy's own tenant_id
             Database::query(
                 "INSERT INTO broker_review_archives
                     (tenant_id, broker_copy_id, sender_id, sender_name, receiver_id, receiver_name,
@@ -678,7 +864,7 @@ class AdminBrokerApiController extends BaseApiController
                      decided_at, flag_reason, flag_severity, created_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), ?, ?, NOW())",
                 [
-                    $tenantId,
+                    $copyTenantId,
                     $id,
                     $copy['sender_id'],
                     $copy['sender_name'] ?? '',
@@ -701,7 +887,7 @@ class AdminBrokerApiController extends BaseApiController
 
             $archiveId = Database::lastInsertId();
 
-            // Update the broker copy: link to archive, set reviewed if not already
+            // Update the broker copy: link to archive, set reviewed if not already — use the copy's own tenant_id
             Database::query(
                 "UPDATE broker_message_copies
                  SET archived_at = NOW(),
@@ -709,7 +895,7 @@ class AdminBrokerApiController extends BaseApiController
                      reviewed_by = COALESCE(reviewed_by, ?),
                      reviewed_at = COALESCE(reviewed_at, NOW())
                  WHERE id = ? AND tenant_id = ?",
-                [$archiveId, $adminId, $id, $tenantId]
+                [$archiveId, $adminId, $id, $copyTenantId]
             );
 
             $this->respondWithData([
@@ -732,6 +918,7 @@ class AdminBrokerApiController extends BaseApiController
     public function archives(): void
     {
         $this->requireBrokerAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $page = $this->queryInt('page', 1, 1);
@@ -740,52 +927,74 @@ class AdminBrokerApiController extends BaseApiController
         $search = $this->query('search');
         $from = $this->query('from');
         $to = $this->query('to');
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
         $offset = ($page - 1) * $perPage;
 
         try {
-            $where = "tenant_id = ?";
-            $params = [$tenantId];
+            $conditions = [];
+            $params = [];
+
+            // Tenant scoping
+            if ($isSuperAdmin) {
+                if ($filterTenantId) {
+                    $conditions[] = 'bra.tenant_id = ?';
+                    $params[] = $filterTenantId;
+                }
+                // No filter = all tenants for super admin
+            } else {
+                $conditions[] = 'bra.tenant_id = ?';
+                $params[] = $tenantId;
+            }
 
             if ($decision && $decision !== 'all') {
-                $where .= " AND decision = ?";
+                $conditions[] = 'bra.decision = ?';
                 $params[] = $decision;
             }
 
             if ($search) {
-                $where .= " AND (sender_name LIKE ? OR receiver_name LIKE ?)";
+                $conditions[] = '(bra.sender_name LIKE ? OR bra.receiver_name LIKE ?)';
                 $params[] = "%{$search}%";
                 $params[] = "%{$search}%";
             }
 
             if ($from) {
-                $where .= " AND decided_at >= ?";
+                $conditions[] = 'bra.decided_at >= ?';
                 $params[] = $from;
             }
 
             if ($to) {
-                $where .= " AND decided_at <= ?";
+                $conditions[] = 'bra.decided_at <= ?';
                 $params[] = $to . ' 23:59:59';
             }
 
+            $where = !empty($conditions) ? implode(' AND ', $conditions) : '1=1';
+
             // Count total
             $countRow = Database::query(
-                "SELECT COUNT(*) as cnt FROM broker_review_archives WHERE {$where}",
+                "SELECT COUNT(*) as cnt FROM broker_review_archives bra WHERE {$where}",
                 $params
             )->fetch();
             $total = (int) ($countRow['cnt'] ?? 0);
 
-            // Paginated data (exclude large conversation_snapshot from list view)
+            // Paginated data (exclude large conversation_snapshot from list view) — join tenants for name
             $queryParams = array_merge($params, [$perPage, $offset]);
             $items = Database::query(
-                "SELECT id, tenant_id, broker_copy_id, sender_id, sender_name, receiver_id, receiver_name,
-                    related_listing_id, listing_title, copy_reason, decision, decision_notes,
-                    decided_by, decided_by_name, decided_at, flag_reason, flag_severity, created_at
-                FROM broker_review_archives
+                "SELECT bra.id, bra.tenant_id, bra.broker_copy_id, bra.sender_id, bra.sender_name, bra.receiver_id, bra.receiver_name,
+                    bra.related_listing_id, bra.listing_title, bra.copy_reason, bra.decision, bra.decision_notes,
+                    bra.decided_by, bra.decided_by_name, bra.decided_at, bra.flag_reason, bra.flag_severity, bra.created_at,
+                    t.name as tenant_name
+                FROM broker_review_archives bra
+                LEFT JOIN tenants t ON bra.tenant_id = t.id
                 WHERE {$where}
-                ORDER BY decided_at DESC
+                ORDER BY bra.decided_at DESC
                 LIMIT ? OFFSET ?",
                 $queryParams
             )->fetchAll();
+
+            foreach ($items as &$item) {
+                $item['tenant_name'] = $item['tenant_name'] ?? 'Unknown';
+            }
+            unset($item);
 
             $this->respondWithPaginatedCollection($items, $total, $page, $perPage);
         } catch (\Exception $e) {
@@ -802,18 +1011,35 @@ class AdminBrokerApiController extends BaseApiController
     public function showArchive(int $id): void
     {
         $this->requireBrokerAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         try {
-            $archive = Database::query(
-                "SELECT * FROM broker_review_archives WHERE id = ? AND tenant_id = ?",
-                [$id, $tenantId]
-            )->fetch();
+            // Super admins can view archives from any tenant
+            if ($isSuperAdmin) {
+                $archive = Database::query(
+                    "SELECT bra.*, t.name as tenant_name
+                     FROM broker_review_archives bra
+                     LEFT JOIN tenants t ON bra.tenant_id = t.id
+                     WHERE bra.id = ?",
+                    [$id]
+                )->fetch();
+            } else {
+                $archive = Database::query(
+                    "SELECT bra.*, t.name as tenant_name
+                     FROM broker_review_archives bra
+                     LEFT JOIN tenants t ON bra.tenant_id = t.id
+                     WHERE bra.id = ? AND bra.tenant_id = ?",
+                    [$id, $tenantId]
+                )->fetch();
+            }
 
             if (!$archive) {
                 $this->respondWithError('NOT_FOUND', 'Archive not found', null, 404);
                 return;
             }
+
+            $archive['tenant_name'] = $archive['tenant_name'] ?? 'Unknown';
 
             // Decode the conversation snapshot from JSON
             if (!empty($archive['conversation_snapshot'])) {
@@ -838,27 +1064,38 @@ class AdminBrokerApiController extends BaseApiController
     public function setMonitoring(int $userId): void
     {
         $adminId = $this->requireBrokerAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $underMonitoring = (bool) $this->input('under_monitoring', true);
         $reason = trim($this->input('reason', ''));
         $messagingDisabled = (bool) $this->input('messaging_disabled', false);
 
         try {
-            // Verify user belongs to this tenant
-            $user = Database::query(
-                "SELECT id FROM users WHERE id = ? AND tenant_id = ?",
-                [$userId, $tenantId]
-            )->fetch();
+            // Super admins can manage monitoring for users from any tenant
+            if ($isSuperAdmin) {
+                $user = Database::query(
+                    "SELECT id, tenant_id FROM users WHERE id = ?",
+                    [$userId]
+                )->fetch();
+            } else {
+                $user = Database::query(
+                    "SELECT id, tenant_id FROM users WHERE id = ? AND tenant_id = ?",
+                    [$userId, $tenantId]
+                )->fetch();
+            }
 
             if (!$user) {
                 $this->respondWithError('NOT_FOUND', 'User not found', null, 404);
                 return;
             }
 
+            // Use the user's own tenant_id for all writes
+            $userTenantId = (int) $user['tenant_id'];
+
             // Check if record already exists
             $existing = Database::query(
                 "SELECT id FROM user_messaging_restrictions WHERE user_id = ? AND tenant_id = ?",
-                [$userId, $tenantId]
+                [$userId, $userTenantId]
             )->fetch();
 
             if ($underMonitoring) {
@@ -870,12 +1107,12 @@ class AdminBrokerApiController extends BaseApiController
                 if ($existing) {
                     Database::query(
                         "UPDATE user_messaging_restrictions SET under_monitoring = 1, monitoring_reason = ?, messaging_disabled = ?, monitoring_started_at = NOW(), restricted_by = ? WHERE user_id = ? AND tenant_id = ?",
-                        [$reason, $messagingDisabled ? 1 : 0, $adminId, $userId, $tenantId]
+                        [$reason, $messagingDisabled ? 1 : 0, $adminId, $userId, $userTenantId]
                     );
                 } else {
                     Database::query(
                         "INSERT INTO user_messaging_restrictions (user_id, tenant_id, under_monitoring, monitoring_reason, messaging_disabled, monitoring_started_at, restricted_by) VALUES (?, ?, 1, ?, ?, NOW(), ?)",
-                        [$userId, $tenantId, $reason, $messagingDisabled ? 1 : 0, $adminId]
+                        [$userId, $userTenantId, $reason, $messagingDisabled ? 1 : 0, $adminId]
                     );
                 }
                 $this->respondWithData(['user_id' => $userId, 'under_monitoring' => true]);
@@ -883,7 +1120,7 @@ class AdminBrokerApiController extends BaseApiController
                 if ($existing) {
                     Database::query(
                         "UPDATE user_messaging_restrictions SET under_monitoring = 0, monitoring_reason = NULL, monitoring_started_at = NULL WHERE user_id = ? AND tenant_id = ?",
-                        [$userId, $tenantId]
+                        [$userId, $userTenantId]
                     );
                 }
                 $this->respondWithData(['user_id' => $userId, 'under_monitoring' => false]);
@@ -902,6 +1139,7 @@ class AdminBrokerApiController extends BaseApiController
     public function saveRiskTag(int $listingId): void
     {
         $adminId = $this->requireBrokerAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $riskLevel = $this->input('risk_level', 'low');
@@ -924,33 +1162,43 @@ class AdminBrokerApiController extends BaseApiController
         }
 
         try {
-            // Verify listing belongs to this tenant
-            $listing = Database::query(
-                "SELECT id FROM listings WHERE id = ? AND tenant_id = ?",
-                [$listingId, $tenantId]
-            )->fetch();
+            // Super admins can tag listings from any tenant
+            if ($isSuperAdmin) {
+                $listing = Database::query(
+                    "SELECT id, tenant_id FROM listings WHERE id = ?",
+                    [$listingId]
+                )->fetch();
+            } else {
+                $listing = Database::query(
+                    "SELECT id, tenant_id FROM listings WHERE id = ? AND tenant_id = ?",
+                    [$listingId, $tenantId]
+                )->fetch();
+            }
 
             if (!$listing) {
                 $this->respondWithError('NOT_FOUND', 'Listing not found', null, 404);
                 return;
             }
 
+            // Use the listing's own tenant_id for all writes
+            $listingTenantId = (int) $listing['tenant_id'];
+
             // Upsert
             $existing = Database::query(
                 "SELECT id FROM listing_risk_tags WHERE listing_id = ? AND tenant_id = ?",
-                [$listingId, $tenantId]
+                [$listingId, $listingTenantId]
             )->fetch();
 
             if ($existing) {
                 Database::query(
                     "UPDATE listing_risk_tags SET risk_level = ?, risk_category = ?, risk_notes = ?, member_visible_notes = ?, requires_approval = ?, insurance_required = ?, dbs_required = ?, tagged_by = ?, updated_at = NOW() WHERE listing_id = ? AND tenant_id = ?",
-                    [$riskLevel, $riskCategory, $riskNotes, $memberVisibleNotes, $requiresApproval ? 1 : 0, $insuranceRequired ? 1 : 0, $dbsRequired ? 1 : 0, $adminId, $listingId, $tenantId]
+                    [$riskLevel, $riskCategory, $riskNotes, $memberVisibleNotes, $requiresApproval ? 1 : 0, $insuranceRequired ? 1 : 0, $dbsRequired ? 1 : 0, $adminId, $listingId, $listingTenantId]
                 );
                 $tagId = $existing['id'];
             } else {
                 Database::query(
                     "INSERT INTO listing_risk_tags (listing_id, tenant_id, risk_level, risk_category, risk_notes, member_visible_notes, requires_approval, insurance_required, dbs_required, tagged_by, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())",
-                    [$listingId, $tenantId, $riskLevel, $riskCategory, $riskNotes, $memberVisibleNotes, $requiresApproval ? 1 : 0, $insuranceRequired ? 1 : 0, $dbsRequired ? 1 : 0, $adminId]
+                    [$listingId, $listingTenantId, $riskLevel, $riskCategory, $riskNotes, $memberVisibleNotes, $requiresApproval ? 1 : 0, $insuranceRequired ? 1 : 0, $dbsRequired ? 1 : 0, $adminId]
                 );
                 $tagId = Database::lastInsertId();
             }
@@ -969,22 +1217,33 @@ class AdminBrokerApiController extends BaseApiController
     public function removeRiskTag(int $listingId): void
     {
         $this->requireBrokerAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         try {
-            $existing = Database::query(
-                "SELECT id FROM listing_risk_tags WHERE listing_id = ? AND tenant_id = ?",
-                [$listingId, $tenantId]
-            )->fetch();
+            // Super admins can remove risk tags from any tenant
+            if ($isSuperAdmin) {
+                $existing = Database::query(
+                    "SELECT id, tenant_id FROM listing_risk_tags WHERE listing_id = ?",
+                    [$listingId]
+                )->fetch();
+            } else {
+                $existing = Database::query(
+                    "SELECT id, tenant_id FROM listing_risk_tags WHERE listing_id = ? AND tenant_id = ?",
+                    [$listingId, $tenantId]
+                )->fetch();
+            }
 
             if (!$existing) {
                 $this->respondWithError('NOT_FOUND', 'Risk tag not found', null, 404);
                 return;
             }
 
+            // Use the record's own tenant_id for the delete
+            $recordTenantId = (int) $existing['tenant_id'];
             Database::query(
                 "DELETE FROM listing_risk_tags WHERE listing_id = ? AND tenant_id = ?",
-                [$listingId, $tenantId]
+                [$listingId, $recordTenantId]
             );
 
             $this->respondWithData(['listing_id' => $listingId, 'removed' => true]);
@@ -1002,7 +1261,9 @@ class AdminBrokerApiController extends BaseApiController
     public function getConfiguration(): void
     {
         $this->requireBrokerAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
         $defaults = [
             // Messaging
@@ -1044,10 +1305,41 @@ class AdminBrokerApiController extends BaseApiController
             'insurance_expiry_warning_days' => 30,
         ];
 
+        // Determine which tenant's config to load
+        if ($isSuperAdmin && $filterTenantId) {
+            $scopeTenantId = $filterTenantId;
+        } else {
+            $scopeTenantId = $tenantId;
+        }
+
         try {
+            // Super admin with no tenant filter: show all tenant configs
+            if ($isSuperAdmin && !$filterTenantId) {
+                $rows = Database::query(
+                    "SELECT ts.tenant_id, ts.setting_value, t.name as tenant_name
+                     FROM tenant_settings ts
+                     LEFT JOIN tenants t ON ts.tenant_id = t.id
+                     WHERE ts.setting_key = 'broker_config'
+                     ORDER BY t.name ASC"
+                )->fetchAll();
+
+                $allConfigs = [];
+                foreach ($rows as $r) {
+                    $saved = json_decode($r['setting_value'], true) ?? [];
+                    $allConfigs[] = [
+                        'tenant_id' => (int) $r['tenant_id'],
+                        'tenant_name' => $r['tenant_name'] ?? 'Unknown',
+                        'config' => array_merge($defaults, $saved),
+                    ];
+                }
+
+                $this->respondWithData($allConfigs);
+                return;
+            }
+
             $row = Database::query(
                 "SELECT setting_value FROM tenant_settings WHERE tenant_id = ? AND setting_key = 'broker_config'",
-                [$tenantId]
+                [$scopeTenantId]
             )->fetch();
 
             $config = $defaults;
@@ -1071,9 +1363,16 @@ class AdminBrokerApiController extends BaseApiController
     public function saveConfiguration(): void
     {
         $this->requireBrokerAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $body = $this->getJsonInput();
+
+        // Super admin can specify which tenant to configure
+        $targetTenantId = $tenantId;
+        if ($isSuperAdmin && !empty($body['tenant_id'])) {
+            $targetTenantId = (int) $body['tenant_id'];
+        }
 
         // Whitelist allowed keys
         $allowedKeys = [
@@ -1102,19 +1401,19 @@ class AdminBrokerApiController extends BaseApiController
         try {
             $existing = Database::query(
                 "SELECT id FROM tenant_settings WHERE tenant_id = ? AND setting_key = 'broker_config'",
-                [$tenantId]
+                [$targetTenantId]
             )->fetch();
 
             $json = json_encode($config);
             if ($existing) {
                 Database::query(
                     "UPDATE tenant_settings SET setting_value = ?, updated_at = NOW() WHERE tenant_id = ? AND setting_key = 'broker_config'",
-                    [$json, $tenantId]
+                    [$json, $targetTenantId]
                 );
             } else {
                 Database::query(
                     "INSERT INTO tenant_settings (tenant_id, setting_key, setting_value, created_at, updated_at) VALUES (?, 'broker_config', ?, NOW(), NOW())",
-                    [$tenantId, $json]
+                    [$targetTenantId, $json]
                 );
             }
 
@@ -1132,32 +1431,62 @@ class AdminBrokerApiController extends BaseApiController
     public function showExchange(int $id): void
     {
         $this->requireBrokerAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         try {
-            $exchange = Database::query(
-                "SELECT er.*,
-                    CONCAT(req.first_name, ' ', req.last_name) as requester_name,
-                    req.email as requester_email,
-                    req.avatar as requester_avatar,
-                    CONCAT(prov.first_name, ' ', prov.last_name) as provider_name,
-                    prov.email as provider_email,
-                    prov.avatar as provider_avatar,
-                    l.title as listing_title,
-                    l.listing_type,
-                    l.hours_offered
-                FROM exchange_requests er
-                JOIN users req ON er.requester_id = req.id
-                JOIN users prov ON er.provider_id = prov.id
-                LEFT JOIN listings l ON er.listing_id = l.id
-                WHERE er.id = ? AND er.tenant_id = ?",
-                [$id, $tenantId]
-            )->fetch();
+            // Super admins can view exchanges from any tenant
+            if ($isSuperAdmin) {
+                $exchange = Database::query(
+                    "SELECT er.*,
+                        CONCAT(req.first_name, ' ', req.last_name) as requester_name,
+                        req.email as requester_email,
+                        req.avatar as requester_avatar,
+                        CONCAT(prov.first_name, ' ', prov.last_name) as provider_name,
+                        prov.email as provider_email,
+                        prov.avatar as provider_avatar,
+                        l.title as listing_title,
+                        l.listing_type,
+                        l.hours_offered,
+                        t.name as tenant_name
+                    FROM exchange_requests er
+                    JOIN users req ON er.requester_id = req.id
+                    JOIN users prov ON er.provider_id = prov.id
+                    LEFT JOIN listings l ON er.listing_id = l.id
+                    LEFT JOIN tenants t ON er.tenant_id = t.id
+                    WHERE er.id = ?",
+                    [$id]
+                )->fetch();
+            } else {
+                $exchange = Database::query(
+                    "SELECT er.*,
+                        CONCAT(req.first_name, ' ', req.last_name) as requester_name,
+                        req.email as requester_email,
+                        req.avatar as requester_avatar,
+                        CONCAT(prov.first_name, ' ', prov.last_name) as provider_name,
+                        prov.email as provider_email,
+                        prov.avatar as provider_avatar,
+                        l.title as listing_title,
+                        l.listing_type,
+                        l.hours_offered,
+                        t.name as tenant_name
+                    FROM exchange_requests er
+                    JOIN users req ON er.requester_id = req.id
+                    JOIN users prov ON er.provider_id = prov.id
+                    LEFT JOIN listings l ON er.listing_id = l.id
+                    LEFT JOIN tenants t ON er.tenant_id = t.id
+                    WHERE er.id = ? AND er.tenant_id = ?",
+                    [$id, $tenantId]
+                )->fetch();
+            }
 
             if (!$exchange) {
                 $this->respondWithError('NOT_FOUND', 'Exchange request not found', null, 404);
                 return;
             }
+
+            $exchange['tenant_name'] = $exchange['tenant_name'] ?? 'Unknown';
+            $exchangeTenantId = (int) $exchange['tenant_id'];
 
             // Fetch history/timeline
             $history = [];
@@ -1175,13 +1504,13 @@ class AdminBrokerApiController extends BaseApiController
                 // exchange_history table may not exist
             }
 
-            // Risk tag for the listing
+            // Risk tag for the listing — use the exchange's own tenant_id
             $riskTag = null;
             if (!empty($exchange['listing_id'])) {
                 try {
                     $riskTag = Database::query(
                         "SELECT * FROM listing_risk_tags WHERE listing_id = ? AND tenant_id = ?",
-                        [$exchange['listing_id'], $tenantId]
+                        [$exchange['listing_id'], $exchangeTenantId]
                     )->fetch() ?: null;
                 } catch (\Exception $e) {}
             }

--- a/src/Controllers/Api/AdminCommentsApiController.php
+++ b/src/Controllers/Api/AdminCommentsApiController.php
@@ -15,6 +15,7 @@ use Nexus\Models\ActivityLog;
  *
  * Moderate comments across all content types.
  * All endpoints require admin authentication.
+ * Super admins can operate across all tenants.
  *
  * Schema notes:
  * - Uses target_type/target_id (NOT content_type/content_id)
@@ -34,11 +35,12 @@ class AdminCommentsApiController extends BaseApiController
     /**
      * GET /api/v2/admin/comments
      *
-     * Query params: page, limit, target_type, search
+     * Query params: page, limit, target_type, search, tenant_id (super admin only)
      */
     public function index(): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $page = max(1, (int) ($_GET['page'] ?? 1));
@@ -46,9 +48,22 @@ class AdminCommentsApiController extends BaseApiController
         $offset = ($page - 1) * $limit;
         $targetType = $_GET['target_type'] ?? null;
         $search = $_GET['search'] ?? null;
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
-        $conditions = ['c.tenant_id = ?'];
-        $params = [$tenantId];
+        $conditions = [];
+        $params = [];
+
+        // Tenant scoping: super admins can see all tenants or filter by one
+        if ($isSuperAdmin) {
+            if ($filterTenantId) {
+                $conditions[] = 'c.tenant_id = ?';
+                $params[] = $filterTenantId;
+            }
+            // No tenant filter = all tenants for super admin
+        } else {
+            $conditions[] = 'c.tenant_id = ?';
+            $params[] = $tenantId;
+        }
 
         // Target type filter
         if ($targetType) {
@@ -64,7 +79,7 @@ class AdminCommentsApiController extends BaseApiController
             $params[] = $searchPattern;
         }
 
-        $where = implode(' AND ', $conditions);
+        $where = !empty($conditions) ? implode(' AND ', $conditions) : '1=1';
 
         // Get total count
         $countQuery = "SELECT COUNT(*) as total
@@ -74,12 +89,14 @@ class AdminCommentsApiController extends BaseApiController
         $countStmt = Database::query($countQuery, $params);
         $total = (int) $countStmt->fetch()['total'];
 
-        // Get paginated results
+        // Get paginated results — join tenants table for cross-tenant name display
         $query = "SELECT c.*,
                          u.name as user_name,
-                         u.avatar_url as user_avatar
+                         u.avatar_url as user_avatar,
+                         t.name as tenant_name
                   FROM comments c
                   LEFT JOIN users u ON c.user_id = u.id
+                  LEFT JOIN tenants t ON c.tenant_id = t.id
                   WHERE {$where}
                   ORDER BY c.created_at DESC
                   LIMIT ? OFFSET ?";
@@ -94,6 +111,8 @@ class AdminCommentsApiController extends BaseApiController
             return [
                 'id' => (int) $comment['id'],
                 'user_id' => (int) $comment['user_id'],
+                'tenant_id' => (int) $comment['tenant_id'],
+                'tenant_name' => $comment['tenant_name'] ?? 'Unknown',
                 'user_name' => $comment['user_name'] ?? 'Unknown',
                 'user_avatar' => $comment['user_avatar'],
                 'target_type' => $comment['target_type'],
@@ -114,17 +133,33 @@ class AdminCommentsApiController extends BaseApiController
     public function show(int $id): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
-        $query = "SELECT c.*,
-                         u.name as user_name,
-                         u.email as user_email,
-                         u.avatar_url as user_avatar
-                  FROM comments c
-                  LEFT JOIN users u ON c.user_id = u.id
-                  WHERE c.id = ? AND c.tenant_id = ?";
-
-        $stmt = Database::query($query, [$id, $tenantId]);
+        // Super admins can view comments from any tenant
+        if ($isSuperAdmin) {
+            $query = "SELECT c.*,
+                             u.name as user_name,
+                             u.email as user_email,
+                             u.avatar_url as user_avatar,
+                             t.name as tenant_name
+                      FROM comments c
+                      LEFT JOIN users u ON c.user_id = u.id
+                      LEFT JOIN tenants t ON c.tenant_id = t.id
+                      WHERE c.id = ?";
+            $stmt = Database::query($query, [$id]);
+        } else {
+            $query = "SELECT c.*,
+                             u.name as user_name,
+                             u.email as user_email,
+                             u.avatar_url as user_avatar,
+                             t.name as tenant_name
+                      FROM comments c
+                      LEFT JOIN users u ON c.user_id = u.id
+                      LEFT JOIN tenants t ON c.tenant_id = t.id
+                      WHERE c.id = ? AND c.tenant_id = ?";
+            $stmt = Database::query($query, [$id, $tenantId]);
+        }
         $comment = $stmt->fetch();
 
         if (!$comment) {
@@ -135,6 +170,8 @@ class AdminCommentsApiController extends BaseApiController
         $formatted = [
             'id' => (int) $comment['id'],
             'user_id' => (int) $comment['user_id'],
+            'tenant_id' => (int) $comment['tenant_id'],
+            'tenant_name' => $comment['tenant_name'] ?? 'Unknown',
             'user_name' => $comment['user_name'] ?? 'Unknown',
             'user_email' => $comment['user_email'],
             'user_avatar' => $comment['user_avatar'],
@@ -156,14 +193,22 @@ class AdminCommentsApiController extends BaseApiController
     public function hide(int $id): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $adminId = $this->getAuthenticatedUserId();
 
-        // Verify comment exists
-        $stmt = Database::query(
-            "SELECT id, target_type, target_id FROM comments WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
-        );
+        // Verify comment exists — super admins can hide comments from any tenant
+        if ($isSuperAdmin) {
+            $stmt = Database::query(
+                "SELECT id, target_type, target_id, tenant_id FROM comments WHERE id = ?",
+                [$id]
+            );
+        } else {
+            $stmt = Database::query(
+                "SELECT id, target_type, target_id, tenant_id FROM comments WHERE id = ? AND tenant_id = ?",
+                [$id, $tenantId]
+            );
+        }
         $comment = $stmt->fetch();
 
         if (!$comment) {
@@ -171,18 +216,21 @@ class AdminCommentsApiController extends BaseApiController
             return;
         }
 
+        // Use the comment's own tenant_id for the feed_hidden record
+        $commentTenantId = (int) $comment['tenant_id'];
+
         // Insert into feed_hidden table with target_type='comment'
         Database::query(
             "INSERT IGNORE INTO feed_hidden (user_id, tenant_id, target_type, target_id, created_at)
              VALUES (?, ?, 'comment', ?, NOW())",
-            [$adminId, $tenantId, $id]
+            [$adminId, $commentTenantId, $id]
         );
 
         // Log activity
         ActivityLog::log(
             $adminId,
             'hide_comment',
-            "Hidden comment #{$id} on {$comment['target_type']} #{$comment['target_id']}"
+            "Hidden comment #{$id} on {$comment['target_type']} #{$comment['target_id']}" . ($isSuperAdmin ? " (tenant {$commentTenantId})" : '')
         );
 
         $this->respondWithData(['success' => true, 'message' => 'Comment hidden']);
@@ -194,14 +242,22 @@ class AdminCommentsApiController extends BaseApiController
     public function destroy(int $id): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $adminId = $this->getAuthenticatedUserId();
 
-        // Verify comment exists
-        $stmt = Database::query(
-            "SELECT id, target_type, user_id FROM comments WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
-        );
+        // Verify comment exists — super admins can delete comments from any tenant
+        if ($isSuperAdmin) {
+            $stmt = Database::query(
+                "SELECT id, target_type, target_id, user_id, tenant_id FROM comments WHERE id = ?",
+                [$id]
+            );
+        } else {
+            $stmt = Database::query(
+                "SELECT id, target_type, target_id, user_id, tenant_id FROM comments WHERE id = ? AND tenant_id = ?",
+                [$id, $tenantId]
+            );
+        }
         $comment = $stmt->fetch();
 
         if (!$comment) {
@@ -209,17 +265,25 @@ class AdminCommentsApiController extends BaseApiController
             return;
         }
 
-        // Delete comment (and child comments due to CASCADE)
+        $commentTenantId = (int) $comment['tenant_id'];
+
+        // Delete comment (and child comments due to CASCADE) using the comment's own tenant_id for safety
         Database::query(
             "DELETE FROM comments WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
+            [$id, $commentTenantId]
+        );
+
+        // Also clean up any feed_hidden records for this comment
+        Database::query(
+            "DELETE FROM feed_hidden WHERE target_type = 'comment' AND target_id = ? AND tenant_id = ?",
+            [$id, $commentTenantId]
         );
 
         // Log activity
         ActivityLog::log(
             $adminId,
             'delete_comment',
-            "Deleted comment #{$id} on {$comment['target_type']} #{$comment['target_id']}"
+            "Deleted comment #{$id} on {$comment['target_type']} #{$comment['target_id']}" . ($isSuperAdmin ? " (tenant {$commentTenantId})" : '')
         );
 
         $this->respondWithData(['success' => true, 'message' => 'Comment deleted']);

--- a/src/Controllers/Api/AdminFeedApiController.php
+++ b/src/Controllers/Api/AdminFeedApiController.php
@@ -40,6 +40,7 @@ class AdminFeedApiController extends BaseApiController
     public function index(): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $page = max(1, (int) ($_GET['page'] ?? 1));
@@ -49,9 +50,22 @@ class AdminFeedApiController extends BaseApiController
         $userId = isset($_GET['user_id']) ? (int) $_GET['user_id'] : null;
         $search = $_GET['search'] ?? null;
         $isHidden = isset($_GET['is_hidden']) ? (bool) $_GET['is_hidden'] : null;
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
-        $conditions = ['fp.tenant_id = ?'];
-        $params = [$tenantId];
+        $conditions = [];
+        $params = [];
+
+        // Tenant scoping: super admins can see all tenants or filter by one
+        if ($isSuperAdmin) {
+            if ($filterTenantId) {
+                $conditions[] = 'fp.tenant_id = ?';
+                $params[] = $filterTenantId;
+            }
+            // No tenant filter = all tenants for super admin
+        } else {
+            $conditions[] = 'fp.tenant_id = ?';
+            $params[] = $tenantId;
+        }
 
         // Type filter
         if ($type) {
@@ -82,7 +96,7 @@ class AdminFeedApiController extends BaseApiController
             $params[] = $searchPattern;
         }
 
-        $where = implode(' AND ', $conditions);
+        $where = !empty($conditions) ? implode(' AND ', $conditions) : '1=1';
 
         // Get total count
         $countQuery = "SELECT COUNT(*) as total
@@ -93,14 +107,16 @@ class AdminFeedApiController extends BaseApiController
         $countStmt = Database::query($countQuery, $params);
         $total = (int) $countStmt->fetch()['total'];
 
-        // Get paginated results
+        // Get paginated results — join tenants table for cross-tenant name display
         $query = "SELECT fp.*,
                          u.name as user_name,
                          u.avatar_url as user_avatar,
+                         t.name as tenant_name,
                          (fh.id IS NOT NULL) as is_hidden,
                          (SELECT COUNT(*) FROM comments WHERE target_type = 'post' AND target_id = fp.id) as comments_count
                   FROM feed_posts fp
                   LEFT JOIN users u ON fp.user_id = u.id
+                  LEFT JOIN tenants t ON fp.tenant_id = t.id
                   LEFT JOIN feed_hidden fh ON fh.target_type = 'post' AND fh.target_id = fp.id AND fh.tenant_id = fp.tenant_id
                   WHERE {$where}
                   ORDER BY fp.created_at DESC
@@ -116,6 +132,8 @@ class AdminFeedApiController extends BaseApiController
             return [
                 'id' => (int) $post['id'],
                 'user_id' => (int) $post['user_id'],
+                'tenant_id' => (int) $post['tenant_id'],
+                'tenant_name' => $post['tenant_name'] ?? 'Unknown',
                 'user_name' => $post['user_name'] ?? 'Unknown',
                 'user_avatar' => $post['user_avatar'],
                 'type' => $post['type'],
@@ -139,19 +157,37 @@ class AdminFeedApiController extends BaseApiController
     public function show(int $id): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
-        $query = "SELECT fp.*,
-                         u.name as user_name,
-                         u.email as user_email,
-                         u.avatar_url as user_avatar,
-                         (fh.id IS NOT NULL) as is_hidden
-                  FROM feed_posts fp
-                  LEFT JOIN users u ON fp.user_id = u.id
-                  LEFT JOIN feed_hidden fh ON fh.target_type = 'post' AND fh.target_id = fp.id AND fh.tenant_id = fp.tenant_id
-                  WHERE fp.id = ? AND fp.tenant_id = ?";
-
-        $stmt = Database::query($query, [$id, $tenantId]);
+        // Super admins can view posts from any tenant
+        if ($isSuperAdmin) {
+            $query = "SELECT fp.*,
+                             u.name as user_name,
+                             u.email as user_email,
+                             u.avatar_url as user_avatar,
+                             t.name as tenant_name,
+                             (fh.id IS NOT NULL) as is_hidden
+                      FROM feed_posts fp
+                      LEFT JOIN users u ON fp.user_id = u.id
+                      LEFT JOIN tenants t ON fp.tenant_id = t.id
+                      LEFT JOIN feed_hidden fh ON fh.target_type = 'post' AND fh.target_id = fp.id AND fh.tenant_id = fp.tenant_id
+                      WHERE fp.id = ?";
+            $stmt = Database::query($query, [$id]);
+        } else {
+            $query = "SELECT fp.*,
+                             u.name as user_name,
+                             u.email as user_email,
+                             u.avatar_url as user_avatar,
+                             t.name as tenant_name,
+                             (fh.id IS NOT NULL) as is_hidden
+                      FROM feed_posts fp
+                      LEFT JOIN users u ON fp.user_id = u.id
+                      LEFT JOIN tenants t ON fp.tenant_id = t.id
+                      LEFT JOIN feed_hidden fh ON fh.target_type = 'post' AND fh.target_id = fp.id AND fh.tenant_id = fp.tenant_id
+                      WHERE fp.id = ? AND fp.tenant_id = ?";
+            $stmt = Database::query($query, [$id, $tenantId]);
+        }
         $post = $stmt->fetch();
 
         if (!$post) {
@@ -159,7 +195,8 @@ class AdminFeedApiController extends BaseApiController
             return;
         }
 
-        // Get comments
+        // Get comments — use the post's own tenant_id for correct scoping
+        $postTenantId = (int) $post['tenant_id'];
         $commentsStmt = Database::query(
             "SELECT c.*, u.name as user_name
              FROM comments c
@@ -167,13 +204,15 @@ class AdminFeedApiController extends BaseApiController
              WHERE c.target_type = 'post' AND c.target_id = ? AND c.tenant_id = ?
              ORDER BY c.created_at DESC
              LIMIT 10",
-            [$id, $tenantId]
+            [$id, $postTenantId]
         );
         $post['recent_comments'] = $commentsStmt->fetchAll();
 
         $formatted = [
             'id' => (int) $post['id'],
             'user_id' => (int) $post['user_id'],
+            'tenant_id' => (int) $post['tenant_id'],
+            'tenant_name' => $post['tenant_name'] ?? 'Unknown',
             'user_name' => $post['user_name'] ?? 'Unknown',
             'user_email' => $post['user_email'],
             'user_avatar' => $post['user_avatar'],
@@ -197,14 +236,22 @@ class AdminFeedApiController extends BaseApiController
     public function hide(int $id): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $adminId = $this->getAuthenticatedUserId();
 
-        // Verify post exists
-        $stmt = Database::query(
-            "SELECT id, user_id FROM feed_posts WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
-        );
+        // Verify post exists — super admins can hide posts from any tenant
+        if ($isSuperAdmin) {
+            $stmt = Database::query(
+                "SELECT id, user_id, tenant_id FROM feed_posts WHERE id = ?",
+                [$id]
+            );
+        } else {
+            $stmt = Database::query(
+                "SELECT id, user_id, tenant_id FROM feed_posts WHERE id = ? AND tenant_id = ?",
+                [$id, $tenantId]
+            );
+        }
         $post = $stmt->fetch();
 
         if (!$post) {
@@ -212,18 +259,21 @@ class AdminFeedApiController extends BaseApiController
             return;
         }
 
+        // Use the post's own tenant_id for the feed_hidden record
+        $postTenantId = (int) $post['tenant_id'];
+
         // Insert into feed_hidden table
         Database::query(
             "INSERT IGNORE INTO feed_hidden (user_id, tenant_id, target_type, target_id, created_at)
              VALUES (?, ?, 'post', ?, NOW())",
-            [$adminId, $tenantId, $id]
+            [$adminId, $postTenantId, $id]
         );
 
         // Log activity
         ActivityLog::log(
             $adminId,
             'hide_feed_post',
-            "Hidden feed post #{$id}"
+            "Hidden feed post #{$id}" . ($isSuperAdmin ? " (tenant {$postTenantId})" : '')
         );
 
         $this->respondWithData(['success' => true, 'message' => 'Post hidden']);
@@ -235,14 +285,22 @@ class AdminFeedApiController extends BaseApiController
     public function destroy(int $id): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $adminId = $this->getAuthenticatedUserId();
 
-        // Verify post exists
-        $stmt = Database::query(
-            "SELECT id FROM feed_posts WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
-        );
+        // Verify post exists — super admins can delete posts from any tenant
+        if ($isSuperAdmin) {
+            $stmt = Database::query(
+                "SELECT id, tenant_id FROM feed_posts WHERE id = ?",
+                [$id]
+            );
+        } else {
+            $stmt = Database::query(
+                "SELECT id, tenant_id FROM feed_posts WHERE id = ? AND tenant_id = ?",
+                [$id, $tenantId]
+            );
+        }
         $post = $stmt->fetch();
 
         if (!$post) {
@@ -250,17 +308,25 @@ class AdminFeedApiController extends BaseApiController
             return;
         }
 
-        // Delete post
+        $postTenantId = (int) $post['tenant_id'];
+
+        // Delete post using the post's own tenant_id for safety
         Database::query(
             "DELETE FROM feed_posts WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
+            [$id, $postTenantId]
+        );
+
+        // Also clean up any feed_hidden records for this post
+        Database::query(
+            "DELETE FROM feed_hidden WHERE target_type = 'post' AND target_id = ? AND tenant_id = ?",
+            [$id, $postTenantId]
         );
 
         // Log activity
         ActivityLog::log(
             $adminId,
             'delete_feed_post',
-            "Deleted feed post #{$id}"
+            "Deleted feed post #{$id}" . ($isSuperAdmin ? " (tenant {$postTenantId})" : '')
         );
 
         $this->respondWithData(['success' => true, 'message' => 'Post deleted']);
@@ -272,17 +338,31 @@ class AdminFeedApiController extends BaseApiController
     public function stats(): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
-        $query = "SELECT
-                    COUNT(DISTINCT fp.id) as total,
-                    (SELECT COUNT(DISTINCT fh.target_id) FROM feed_hidden fh
-                     WHERE fh.target_type = 'post' AND fh.tenant_id = ?) as hidden,
-                    (SELECT COUNT(*) FROM comments WHERE target_type = 'post' AND tenant_id = ?) as total_comments
-                  FROM feed_posts fp
-                  WHERE fp.tenant_id = ?";
+        // Super admins: aggregate across all tenants or filter by one
+        if ($isSuperAdmin && !$filterTenantId) {
+            $query = "SELECT
+                        COUNT(DISTINCT fp.id) as total,
+                        (SELECT COUNT(DISTINCT fh.target_id) FROM feed_hidden fh
+                         WHERE fh.target_type = 'post') as hidden,
+                        (SELECT COUNT(*) FROM comments WHERE target_type = 'post') as total_comments
+                      FROM feed_posts fp";
+            $stmt = Database::query($query);
+        } else {
+            $scopeTenantId = ($isSuperAdmin && $filterTenantId) ? $filterTenantId : $tenantId;
+            $query = "SELECT
+                        COUNT(DISTINCT fp.id) as total,
+                        (SELECT COUNT(DISTINCT fh.target_id) FROM feed_hidden fh
+                         WHERE fh.target_type = 'post' AND fh.tenant_id = ?) as hidden,
+                        (SELECT COUNT(*) FROM comments WHERE target_type = 'post' AND tenant_id = ?) as total_comments
+                      FROM feed_posts fp
+                      WHERE fp.tenant_id = ?";
+            $stmt = Database::query($query, [$scopeTenantId, $scopeTenantId, $scopeTenantId]);
+        }
 
-        $stmt = Database::query($query, [$tenantId, $tenantId, $tenantId]);
         $stats = $stmt->fetch();
 
         $formatted = [

--- a/src/Controllers/Api/AdminGroupsApiController.php
+++ b/src/Controllers/Api/AdminGroupsApiController.php
@@ -38,6 +38,7 @@ class AdminGroupsApiController extends BaseApiController
     public function index(): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $page = max(1, (int) ($_GET['page'] ?? 1));
@@ -45,10 +46,23 @@ class AdminGroupsApiController extends BaseApiController
         $offset = ($page - 1) * $limit;
         $status = $_GET['status'] ?? null;
         $search = $_GET['search'] ?? null;
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
         try {
-            $conditions = ['g.tenant_id = ?'];
-            $params = [$tenantId];
+            $conditions = [];
+            $params = [];
+
+            // Tenant scoping: super admins can see all tenants or filter by one
+            if ($isSuperAdmin) {
+                if ($filterTenantId) {
+                    $conditions[] = 'g.tenant_id = ?';
+                    $params[] = $filterTenantId;
+                }
+                // No tenant filter = all tenants for super admin
+            } else {
+                $conditions[] = 'g.tenant_id = ?';
+                $params[] = $tenantId;
+            }
 
             // Status filter (groups use is_active column, not status)
             if ($status === 'active') {
@@ -65,7 +79,7 @@ class AdminGroupsApiController extends BaseApiController
                 $params[] = $searchTerm;
             }
 
-            $where = implode(' AND ', $conditions);
+            $where = !empty($conditions) ? implode(' AND ', $conditions) : '1=1';
 
             // Total count
             $total = (int) Database::query(
@@ -73,12 +87,14 @@ class AdminGroupsApiController extends BaseApiController
                 $params
             )->fetch()['cnt'];
 
-            // Paginated results with member count and creator name
+            // Paginated results with member count, creator name, and tenant name
             $items = Database::query(
                 "SELECT g.*, CONCAT(COALESCE(u.first_name, ''), ' ', COALESCE(u.last_name, '')) as creator_name,
+                    t.name as tenant_name,
                     (SELECT COUNT(*) FROM group_members gm WHERE gm.group_id = g.id AND gm.status = 'approved') as member_count
                  FROM `groups` g
                  LEFT JOIN users u ON g.owner_id = u.id
+                 LEFT JOIN tenants t ON g.tenant_id = t.id
                  WHERE {$where}
                  ORDER BY g.created_at DESC
                  LIMIT ? OFFSET ?",
@@ -89,6 +105,8 @@ class AdminGroupsApiController extends BaseApiController
             $formatted = array_map(function ($row) {
                 return [
                     'id' => (int) $row['id'],
+                    'tenant_id' => (int) $row['tenant_id'],
+                    'tenant_name' => $row['tenant_name'] ?? 'Unknown',
                     'name' => $row['name'] ?? '',
                     'description' => $row['description'] ?? '',
                     'image_url' => $row['image_url'] ?: null,
@@ -119,21 +137,41 @@ class AdminGroupsApiController extends BaseApiController
     public function analytics(): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
+
+        // Determine scope
+        if ($isSuperAdmin && $filterTenantId) {
+            $scopeTenantId = $filterTenantId;
+            $tenantCondition = 'tenant_id = ?';
+            $tenantJoinCondition = 'g.tenant_id = ?';
+            $tenantParams = [$scopeTenantId];
+        } elseif ($isSuperAdmin && !$filterTenantId) {
+            $scopeTenantId = null;
+            $tenantCondition = '1=1';
+            $tenantJoinCondition = '1=1';
+            $tenantParams = [];
+        } else {
+            $scopeTenantId = $tenantId;
+            $tenantCondition = 'tenant_id = ?';
+            $tenantJoinCondition = 'g.tenant_id = ?';
+            $tenantParams = [$scopeTenantId];
+        }
 
         try {
             // Total groups
             $totalGroups = (int) Database::query(
-                "SELECT COUNT(*) as cnt FROM `groups` WHERE tenant_id = ?",
-                [$tenantId]
+                "SELECT COUNT(*) as cnt FROM `groups` WHERE {$tenantCondition}",
+                $tenantParams
             )->fetch()['cnt'];
 
             // Total approved members across all groups
             $totalMembers = (int) Database::query(
                 "SELECT COUNT(*) as cnt FROM group_members gm
                  JOIN `groups` g ON gm.group_id = g.id
-                 WHERE g.tenant_id = ? AND gm.status = 'approved'",
-                [$tenantId]
+                 WHERE {$tenantJoinCondition} AND gm.status = 'approved'",
+                $tenantParams
             )->fetch()['cnt'];
 
             // Average members per group
@@ -141,33 +179,35 @@ class AdminGroupsApiController extends BaseApiController
 
             // Active groups (groups with is_active = 1)
             $activeGroups = (int) Database::query(
-                "SELECT COUNT(*) as cnt FROM `groups` WHERE tenant_id = ? AND is_active = 1",
-                [$tenantId]
+                "SELECT COUNT(*) as cnt FROM `groups` WHERE {$tenantCondition} AND is_active = 1",
+                $tenantParams
             )->fetch()['cnt'];
 
             // Pending approvals count
             $pendingApprovals = (int) Database::query(
                 "SELECT COUNT(*) as cnt FROM group_members gm
                  JOIN `groups` g ON gm.group_id = g.id
-                 WHERE g.tenant_id = ? AND gm.status = 'pending'",
-                [$tenantId]
+                 WHERE {$tenantJoinCondition} AND gm.status = 'pending'",
+                $tenantParams
             )->fetch()['cnt'];
 
             // Most active groups (by member count, top 5)
             $mostActive = Database::query(
-                "SELECT g.id, g.name,
+                "SELECT g.id, g.name, t.name as tenant_name,
                     (SELECT COUNT(*) FROM group_members gm WHERE gm.group_id = g.id AND gm.status = 'approved') as member_count
                  FROM `groups` g
-                 WHERE g.tenant_id = ?
+                 LEFT JOIN tenants t ON g.tenant_id = t.id
+                 WHERE {$tenantJoinCondition}
                  ORDER BY member_count DESC
                  LIMIT 5",
-                [$tenantId]
+                $tenantParams
             )->fetchAll();
 
             $mostActiveFormatted = array_map(function ($row) {
                 return [
                     'id' => (int) $row['id'],
                     'name' => $row['name'],
+                    'tenant_name' => $row['tenant_name'] ?? 'Unknown',
                     'member_count' => (int) $row['member_count'],
                 ];
             }, $mostActive);
@@ -198,18 +238,38 @@ class AdminGroupsApiController extends BaseApiController
     public function approvals(): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
         try {
+            $conditions = ['gm.status = \'pending\''];
+            $params = [];
+
+            // Tenant scoping: super admins can see all tenants or filter by one
+            if ($isSuperAdmin) {
+                if ($filterTenantId) {
+                    $conditions[] = 'g.tenant_id = ?';
+                    $params[] = $filterTenantId;
+                }
+                // No tenant filter = all tenants for super admin
+            } else {
+                $conditions[] = 'g.tenant_id = ?';
+                $params[] = $tenantId;
+            }
+
+            $where = implode(' AND ', $conditions);
+
             $items = Database::query(
-                "SELECT gm.*, g.name as group_name,
+                "SELECT gm.*, g.name as group_name, t.name as tenant_name, g.tenant_id,
                     CONCAT(COALESCE(u.first_name, ''), ' ', COALESCE(u.last_name, '')) as user_name
                  FROM group_members gm
                  JOIN `groups` g ON gm.group_id = g.id
                  JOIN users u ON gm.user_id = u.id
-                 WHERE g.tenant_id = ? AND gm.status = 'pending'
+                 LEFT JOIN tenants t ON g.tenant_id = t.id
+                 WHERE {$where}
                  ORDER BY gm.created_at DESC",
-                [$tenantId]
+                $params
             )->fetchAll();
 
             $formatted = array_map(function ($row) {
@@ -217,6 +277,8 @@ class AdminGroupsApiController extends BaseApiController
                     'id' => (int) $row['id'],
                     'group_id' => (int) $row['group_id'],
                     'group_name' => $row['group_name'] ?? '',
+                    'tenant_id' => (int) $row['tenant_id'],
+                    'tenant_name' => $row['tenant_name'] ?? 'Unknown',
                     'user_id' => (int) $row['user_id'],
                     'user_name' => trim($row['user_name'] ?? ''),
                     'status' => $row['status'] ?? 'pending',
@@ -243,17 +305,29 @@ class AdminGroupsApiController extends BaseApiController
     public function approveMember(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         try {
             // Verify the membership record exists and is pending
-            $membership = Database::query(
-                "SELECT gm.*, g.name as group_name
-                 FROM group_members gm
-                 JOIN `groups` g ON gm.group_id = g.id
-                 WHERE gm.id = ? AND g.tenant_id = ? AND gm.status = 'pending'",
-                [$id, $tenantId]
-            )->fetch();
+            // Super admins can approve memberships from any tenant
+            if ($isSuperAdmin) {
+                $membership = Database::query(
+                    "SELECT gm.*, g.name as group_name, g.tenant_id
+                     FROM group_members gm
+                     JOIN `groups` g ON gm.group_id = g.id
+                     WHERE gm.id = ? AND gm.status = 'pending'",
+                    [$id]
+                )->fetch();
+            } else {
+                $membership = Database::query(
+                    "SELECT gm.*, g.name as group_name, g.tenant_id
+                     FROM group_members gm
+                     JOIN `groups` g ON gm.group_id = g.id
+                     WHERE gm.id = ? AND g.tenant_id = ? AND gm.status = 'pending'",
+                    [$id, $tenantId]
+                )->fetch();
+            }
 
             if (!$membership) {
                 $this->respondWithError(
@@ -270,10 +344,11 @@ class AdminGroupsApiController extends BaseApiController
                 [$id]
             );
 
+            $memberTenantId = (int) $membership['tenant_id'];
             ActivityLog::log(
                 $adminId,
                 'admin_approve_group_member',
-                "Approved membership #{$id} for group \"{$membership['group_name']}\""
+                "Approved membership #{$id} for group \"{$membership['group_name']}\"" . ($isSuperAdmin ? " (tenant {$memberTenantId})" : '')
             );
 
             $this->respondWithData([
@@ -298,17 +373,29 @@ class AdminGroupsApiController extends BaseApiController
     public function rejectMember(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         try {
             // Verify the membership record exists and is pending
-            $membership = Database::query(
-                "SELECT gm.*, g.name as group_name
-                 FROM group_members gm
-                 JOIN `groups` g ON gm.group_id = g.id
-                 WHERE gm.id = ? AND g.tenant_id = ? AND gm.status = 'pending'",
-                [$id, $tenantId]
-            )->fetch();
+            // Super admins can reject memberships from any tenant
+            if ($isSuperAdmin) {
+                $membership = Database::query(
+                    "SELECT gm.*, g.name as group_name, g.tenant_id
+                     FROM group_members gm
+                     JOIN `groups` g ON gm.group_id = g.id
+                     WHERE gm.id = ? AND gm.status = 'pending'",
+                    [$id]
+                )->fetch();
+            } else {
+                $membership = Database::query(
+                    "SELECT gm.*, g.name as group_name, g.tenant_id
+                     FROM group_members gm
+                     JOIN `groups` g ON gm.group_id = g.id
+                     WHERE gm.id = ? AND g.tenant_id = ? AND gm.status = 'pending'",
+                    [$id, $tenantId]
+                )->fetch();
+            }
 
             if (!$membership) {
                 $this->respondWithError(
@@ -325,10 +412,11 @@ class AdminGroupsApiController extends BaseApiController
                 [$id]
             );
 
+            $memberTenantId = (int) $membership['tenant_id'];
             ActivityLog::log(
                 $adminId,
                 'admin_reject_group_member',
-                "Rejected membership #{$id} for group \"{$membership['group_name']}\""
+                "Rejected membership #{$id} for group \"{$membership['group_name']}\"" . ($isSuperAdmin ? " (tenant {$memberTenantId})" : '')
             );
 
             $this->respondWithData([
@@ -353,7 +441,21 @@ class AdminGroupsApiController extends BaseApiController
     public function moderation(): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
+
+        // Determine tenant scoping
+        if ($isSuperAdmin && $filterTenantId) {
+            $tenantCondition = 'g.tenant_id = ?';
+            $tenantParams = [$filterTenantId];
+        } elseif ($isSuperAdmin && !$filterTenantId) {
+            $tenantCondition = '1=1';
+            $tenantParams = [];
+        } else {
+            $tenantCondition = 'g.tenant_id = ?';
+            $tenantParams = [$tenantId];
+        }
 
         try {
             // Try to find groups referenced in the reports table
@@ -362,23 +464,25 @@ class AdminGroupsApiController extends BaseApiController
 
             try {
                 $items = Database::query(
-                    "SELECT g.id, g.name, g.is_active, g.created_at,
+                    "SELECT g.id, g.name, g.is_active, g.created_at, g.tenant_id, t.name as tenant_name,
                         COUNT(r.id) as report_count
                      FROM `groups` g
                      INNER JOIN reports r ON r.content_type = 'group' AND r.content_id = g.id
-                     WHERE g.tenant_id = ? AND r.status = 'pending'
-                     GROUP BY g.id, g.name, g.is_active, g.created_at
+                     LEFT JOIN tenants t ON g.tenant_id = t.id
+                     WHERE {$tenantCondition} AND r.status = 'pending'
+                     GROUP BY g.id, g.name, g.is_active, g.created_at, g.tenant_id, t.name
                      ORDER BY report_count DESC",
-                    [$tenantId]
+                    $tenantParams
                 )->fetchAll();
             } catch (\Exception $e) {
                 // If the reports table or columns don't exist, return inactive groups
                 $items = Database::query(
-                    "SELECT g.id, g.name, g.is_active, g.created_at, 0 as report_count
+                    "SELECT g.id, g.name, g.is_active, g.created_at, g.tenant_id, t.name as tenant_name, 0 as report_count
                      FROM `groups` g
-                     WHERE g.tenant_id = ? AND g.is_active = 0
+                     LEFT JOIN tenants t ON g.tenant_id = t.id
+                     WHERE {$tenantCondition} AND g.is_active = 0
                      ORDER BY g.created_at DESC",
-                    [$tenantId]
+                    $tenantParams
                 )->fetchAll();
             }
 
@@ -386,6 +490,8 @@ class AdminGroupsApiController extends BaseApiController
                 return [
                     'id' => (int) $row['id'],
                     'name' => $row['name'] ?? '',
+                    'tenant_id' => (int) $row['tenant_id'],
+                    'tenant_name' => $row['tenant_name'] ?? 'Unknown',
                     'status' => !empty($row['is_active']) ? 'active' : 'inactive',
                     'report_count' => (int) ($row['report_count'] ?? 0),
                     'created_at' => $row['created_at'],
@@ -411,6 +517,7 @@ class AdminGroupsApiController extends BaseApiController
     public function updateStatus(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $input = $this->getAllInput();
 
@@ -421,26 +528,36 @@ class AdminGroupsApiController extends BaseApiController
         }
 
         try {
-            $group = Database::query(
-                "SELECT id, name FROM `groups` WHERE id = ? AND tenant_id = ?",
-                [$id, $tenantId]
-            )->fetch();
+            // Super admins can update groups from any tenant
+            if ($isSuperAdmin) {
+                $group = Database::query(
+                    "SELECT id, name, tenant_id FROM `groups` WHERE id = ?",
+                    [$id]
+                )->fetch();
+            } else {
+                $group = Database::query(
+                    "SELECT id, name, tenant_id FROM `groups` WHERE id = ? AND tenant_id = ?",
+                    [$id, $tenantId]
+                )->fetch();
+            }
 
             if (!$group) {
                 $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'Group not found', null, 404);
                 return;
             }
 
+            // Use the record's own tenant_id for the UPDATE
+            $groupTenantId = (int) $group['tenant_id'];
             $isActive = $newStatus === 'active' ? 1 : 0;
             Database::query(
                 "UPDATE `groups` SET is_active = ?, updated_at = NOW() WHERE id = ? AND tenant_id = ?",
-                [$isActive, $id, $tenantId]
+                [$isActive, $id, $groupTenantId]
             );
 
             ActivityLog::log(
                 $adminId,
                 'admin_update_group_status',
-                "Set group #{$id} \"{$group['name']}\" to {$newStatus}"
+                "Set group #{$id} \"{$group['name']}\" to {$newStatus}" . ($isSuperAdmin ? " (tenant {$groupTenantId})" : '')
             );
 
             $this->respondWithData(['id' => $id, 'status' => $newStatus]);
@@ -457,13 +574,22 @@ class AdminGroupsApiController extends BaseApiController
     public function deleteGroup(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         try {
-            $group = Database::query(
-                "SELECT id, name FROM `groups` WHERE id = ? AND tenant_id = ?",
-                [$id, $tenantId]
-            )->fetch();
+            // Super admins can delete groups from any tenant
+            if ($isSuperAdmin) {
+                $group = Database::query(
+                    "SELECT id, name, tenant_id FROM `groups` WHERE id = ?",
+                    [$id]
+                )->fetch();
+            } else {
+                $group = Database::query(
+                    "SELECT id, name, tenant_id FROM `groups` WHERE id = ? AND tenant_id = ?",
+                    [$id, $tenantId]
+                )->fetch();
+            }
 
             if (!$group) {
                 $this->respondWithError(
@@ -475,6 +601,9 @@ class AdminGroupsApiController extends BaseApiController
                 return;
             }
 
+            // Use the record's own tenant_id for safe DELETE
+            $groupTenantId = (int) $group['tenant_id'];
+
             // Delete memberships first, then the group
             Database::query(
                 "DELETE FROM group_members WHERE group_id = ?",
@@ -483,13 +612,13 @@ class AdminGroupsApiController extends BaseApiController
 
             Database::query(
                 "DELETE FROM `groups` WHERE id = ? AND tenant_id = ?",
-                [$id, $tenantId]
+                [$id, $groupTenantId]
             );
 
             ActivityLog::log(
                 $adminId,
                 'admin_delete_group',
-                "Deleted group #{$id}: {$group['name']}"
+                "Deleted group #{$id}: {$group['name']}" . ($isSuperAdmin ? " (tenant {$groupTenantId})" : '')
             );
 
             $this->respondWithData(['deleted' => true, 'id' => $id]);
@@ -513,27 +642,71 @@ class AdminGroupsApiController extends BaseApiController
     public function getGroupTypes(): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
+
+        // Determine scope
+        if ($isSuperAdmin && $filterTenantId) {
+            $scopeTenantId = $filterTenantId;
+            $tenantCondition = 'gt.tenant_id = ?';
+            $tenantParams = [$scopeTenantId];
+            $groupCountCondition = 'g.tenant_id = ?';
+            $groupCountParams = [$scopeTenantId];
+        } elseif ($isSuperAdmin && !$filterTenantId) {
+            $scopeTenantId = null;
+            $tenantCondition = '1=1';
+            $tenantParams = [];
+            $groupCountCondition = '1=1';
+            $groupCountParams = [];
+        } else {
+            $scopeTenantId = $tenantId;
+            $tenantCondition = 'gt.tenant_id = ?';
+            $tenantParams = [$scopeTenantId];
+            $groupCountCondition = 'g.tenant_id = ?';
+            $groupCountParams = [$scopeTenantId];
+        }
 
         try {
-            $types = Database::query(
-                "SELECT gt.*,
-                    (SELECT COUNT(*) FROM `groups` g WHERE g.type_id = gt.id AND g.tenant_id = ?) as member_count
-                 FROM group_types gt
-                 WHERE gt.tenant_id = ?
-                 ORDER BY gt.sort_order ASC, gt.name ASC",
-                [$tenantId, $tenantId]
-            )->fetchAll();
+            if ($scopeTenantId !== null) {
+                $types = Database::query(
+                    "SELECT gt.*, t.name as tenant_name,
+                        (SELECT COUNT(*) FROM `groups` g WHERE g.type_id = gt.id AND g.tenant_id = ?) as member_count
+                     FROM group_types gt
+                     LEFT JOIN tenants t ON gt.tenant_id = t.id
+                     WHERE {$tenantCondition}
+                     ORDER BY gt.sort_order ASC, gt.name ASC",
+                    array_merge([$scopeTenantId], $tenantParams)
+                )->fetchAll();
+            } else {
+                // Super admin, no filter — show all types across all tenants
+                $types = Database::query(
+                    "SELECT gt.*, t.name as tenant_name,
+                        (SELECT COUNT(*) FROM `groups` g WHERE g.type_id = gt.id) as member_count
+                     FROM group_types gt
+                     LEFT JOIN tenants t ON gt.tenant_id = t.id
+                     ORDER BY gt.sort_order ASC, gt.name ASC"
+                )->fetchAll();
+            }
 
             // Get policy counts for each type
-            $formatted = array_map(function ($row) use ($tenantId) {
-                $policyCount = (int) Database::query(
-                    "SELECT COUNT(*) as cnt FROM group_policies WHERE tenant_id = ?",
-                    [$tenantId]
-                )->fetch()['cnt'];
+            $formatted = array_map(function ($row) use ($scopeTenantId) {
+                if ($scopeTenantId !== null) {
+                    $policyCount = (int) Database::query(
+                        "SELECT COUNT(*) as cnt FROM group_policies WHERE tenant_id = ?",
+                        [$scopeTenantId]
+                    )->fetch()['cnt'];
+                } else {
+                    $policyCount = (int) Database::query(
+                        "SELECT COUNT(*) as cnt FROM group_policies WHERE tenant_id = ?",
+                        [(int) $row['tenant_id']]
+                    )->fetch()['cnt'];
+                }
 
                 return [
                     'id' => (int) $row['id'],
+                    'tenant_id' => (int) $row['tenant_id'],
+                    'tenant_name' => $row['tenant_name'] ?? 'Unknown',
                     'name' => $row['name'],
                     'description' => $row['description'] ?? '',
                     'icon' => $row['icon'] ?? 'fa-layer-group',
@@ -563,6 +736,7 @@ class AdminGroupsApiController extends BaseApiController
     public function createGroupType(): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $input = $this->getAllInput();
 
@@ -572,12 +746,15 @@ class AdminGroupsApiController extends BaseApiController
             return;
         }
 
+        // Super admins can specify a target tenant_id; otherwise use current tenant
+        $targetTenantId = ($isSuperAdmin && isset($input['tenant_id'])) ? (int) $input['tenant_id'] : $tenantId;
+
         try {
             Database::query(
                 "INSERT INTO group_types (tenant_id, name, slug, description, icon, color, created_at)
                  VALUES (?, ?, ?, ?, ?, ?, NOW())",
                 [
-                    $tenantId,
+                    $targetTenantId,
                     $name,
                     \Nexus\Helpers\TextHelper::slugify($name),
                     $input['description'] ?? null,
@@ -588,7 +765,11 @@ class AdminGroupsApiController extends BaseApiController
 
             $id = Database::lastInsertId();
 
-            ActivityLog::log($adminId, 'admin_create_group_type', "Created group type: {$name}");
+            ActivityLog::log(
+                $adminId,
+                'admin_create_group_type',
+                "Created group type: {$name}" . ($isSuperAdmin ? " (tenant {$targetTenantId})" : '')
+            );
 
             $this->respondWithData(['id' => $id, 'name' => $name], 201);
         } catch (\Exception $e) {
@@ -609,20 +790,31 @@ class AdminGroupsApiController extends BaseApiController
     public function updateGroupType(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $input = $this->getAllInput();
 
         try {
-            $existing = Database::query(
-                "SELECT id, name FROM group_types WHERE id = ? AND tenant_id = ?",
-                [$id, $tenantId]
-            )->fetch();
+            // Super admins can update group types from any tenant
+            if ($isSuperAdmin) {
+                $existing = Database::query(
+                    "SELECT id, name, tenant_id FROM group_types WHERE id = ?",
+                    [$id]
+                )->fetch();
+            } else {
+                $existing = Database::query(
+                    "SELECT id, name, tenant_id FROM group_types WHERE id = ? AND tenant_id = ?",
+                    [$id, $tenantId]
+                )->fetch();
+            }
 
             if (!$existing) {
                 $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'Group type not found', null, 404);
                 return;
             }
 
+            // Use the record's own tenant_id for safe UPDATE
+            $recordTenantId = (int) $existing['tenant_id'];
             $name = trim($input['name'] ?? $existing['name']);
             Database::query(
                 "UPDATE group_types
@@ -634,11 +826,15 @@ class AdminGroupsApiController extends BaseApiController
                     $input['icon'] ?? 'fa-layer-group',
                     $input['color'] ?? '#6366f1',
                     $id,
-                    $tenantId
+                    $recordTenantId
                 ]
             );
 
-            ActivityLog::log($adminId, 'admin_update_group_type', "Updated group type #{$id}: {$name}");
+            ActivityLog::log(
+                $adminId,
+                'admin_update_group_type',
+                "Updated group type #{$id}: {$name}" . ($isSuperAdmin ? " (tenant {$recordTenantId})" : '')
+            );
 
             $this->respondWithData(['id' => $id, 'name' => $name]);
         } catch (\Exception $e) {
@@ -659,23 +855,35 @@ class AdminGroupsApiController extends BaseApiController
     public function deleteGroupType(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         try {
-            $type = Database::query(
-                "SELECT id, name FROM group_types WHERE id = ? AND tenant_id = ?",
-                [$id, $tenantId]
-            )->fetch();
+            // Super admins can delete group types from any tenant
+            if ($isSuperAdmin) {
+                $type = Database::query(
+                    "SELECT id, name, tenant_id FROM group_types WHERE id = ?",
+                    [$id]
+                )->fetch();
+            } else {
+                $type = Database::query(
+                    "SELECT id, name, tenant_id FROM group_types WHERE id = ? AND tenant_id = ?",
+                    [$id, $tenantId]
+                )->fetch();
+            }
 
             if (!$type) {
                 $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'Group type not found', null, 404);
                 return;
             }
 
+            // Use the record's own tenant_id for safe operations
+            $recordTenantId = (int) $type['tenant_id'];
+
             // Check if any groups use this type
             $count = (int) Database::query(
                 "SELECT COUNT(*) as cnt FROM `groups` WHERE type_id = ? AND tenant_id = ?",
-                [$id, $tenantId]
+                [$id, $recordTenantId]
             )->fetch()['cnt'];
 
             if ($count > 0) {
@@ -690,10 +898,14 @@ class AdminGroupsApiController extends BaseApiController
 
             Database::query(
                 "DELETE FROM group_types WHERE id = ? AND tenant_id = ?",
-                [$id, $tenantId]
+                [$id, $recordTenantId]
             );
 
-            ActivityLog::log($adminId, 'admin_delete_group_type', "Deleted group type #{$id}: {$type['name']}");
+            ActivityLog::log(
+                $adminId,
+                'admin_delete_group_type',
+                "Deleted group type #{$id}: {$type['name']}" . ($isSuperAdmin ? " (tenant {$recordTenantId})" : '')
+            );
 
             $this->respondWithData(['deleted' => true, 'id' => $id]);
         } catch (\Exception $e) {
@@ -716,10 +928,15 @@ class AdminGroupsApiController extends BaseApiController
     public function getPolicies(int $typeId): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
+
+        // Determine scope — policies are always tenant-scoped, so super admin must pick a tenant or use current
+        $scopeTenantId = ($isSuperAdmin && $filterTenantId) ? $filterTenantId : $tenantId;
 
         try {
-            $policies = \Nexus\Services\GroupPolicyRepository::getAllPolicies($tenantId);
+            $policies = \Nexus\Services\GroupPolicyRepository::getAllPolicies($scopeTenantId);
 
             // Transform to frontend format
             $formatted = [];
@@ -755,6 +972,7 @@ class AdminGroupsApiController extends BaseApiController
     public function setPolicy(int $typeId): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $input = $this->getAllInput();
 
@@ -766,6 +984,9 @@ class AdminGroupsApiController extends BaseApiController
             return;
         }
 
+        // Super admins can specify a target tenant_id; otherwise use current tenant
+        $targetTenantId = ($isSuperAdmin && isset($input['tenant_id'])) ? (int) $input['tenant_id'] : $tenantId;
+
         try {
             $category = $input['category'] ?? \Nexus\Services\GroupPolicyRepository::CATEGORY_FEATURES;
             $type = $input['type'] ?? \Nexus\Services\GroupPolicyRepository::TYPE_STRING;
@@ -776,10 +997,14 @@ class AdminGroupsApiController extends BaseApiController
                 $category,
                 $type,
                 $input['description'] ?? null,
-                $tenantId
+                $targetTenantId
             );
 
-            ActivityLog::log($adminId, 'admin_set_group_policy', "Set policy {$key} = " . json_encode($value));
+            ActivityLog::log(
+                $adminId,
+                'admin_set_group_policy',
+                "Set policy {$key} = " . json_encode($value) . ($isSuperAdmin ? " (tenant {$targetTenantId})" : '')
+            );
 
             $this->respondWithData(['key' => $key, 'value' => $value]);
         } catch (\Exception $e) {
@@ -802,12 +1027,14 @@ class AdminGroupsApiController extends BaseApiController
     public function getGroup(int $id): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         try {
             $group = \Nexus\Services\GroupService::getById($id);
 
-            if (!$group || $group['tenant_id'] ?? null != $tenantId) {
+            // Super admins can view groups from any tenant
+            if (!$group || (!$isSuperAdmin && ($group['tenant_id'] ?? null) != $tenantId)) {
                 $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'Group not found', null, 404);
                 return;
             }
@@ -826,6 +1053,15 @@ class AdminGroupsApiController extends BaseApiController
                 'events_count' => (int) ($stats['events_count'] ?? 0),
                 'activity_score' => (int) ($group['member_count'] ?? 0) * 10,
             ];
+
+            // Add tenant name for cross-tenant context
+            if (isset($group['tenant_id'])) {
+                $tenant = Database::query(
+                    "SELECT name FROM tenants WHERE id = ?",
+                    [(int) $group['tenant_id']]
+                )->fetch();
+                $group['tenant_name'] = $tenant['name'] ?? 'Unknown';
+            }
 
             $this->respondWithData($group);
         } catch (\Exception $e) {
@@ -846,19 +1082,31 @@ class AdminGroupsApiController extends BaseApiController
     public function updateGroup(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $input = $this->getAllInput();
 
         try {
-            $group = Database::query(
-                "SELECT id, name FROM `groups` WHERE id = ? AND tenant_id = ?",
-                [$id, $tenantId]
-            )->fetch();
+            // Super admins can update groups from any tenant
+            if ($isSuperAdmin) {
+                $group = Database::query(
+                    "SELECT id, name, tenant_id FROM `groups` WHERE id = ?",
+                    [$id]
+                )->fetch();
+            } else {
+                $group = Database::query(
+                    "SELECT id, name, tenant_id FROM `groups` WHERE id = ? AND tenant_id = ?",
+                    [$id, $tenantId]
+                )->fetch();
+            }
 
             if (!$group) {
                 $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'Group not found', null, 404);
                 return;
             }
+
+            // Use the record's own tenant_id for safe UPDATE
+            $groupTenantId = (int) $group['tenant_id'];
 
             $updates = [];
             $params = [];
@@ -887,14 +1135,18 @@ class AdminGroupsApiController extends BaseApiController
 
             $updates[] = 'updated_at = NOW()';
             $params[] = $id;
-            $params[] = $tenantId;
+            $params[] = $groupTenantId;
 
             Database::query(
                 "UPDATE `groups` SET " . implode(', ', $updates) . " WHERE id = ? AND tenant_id = ?",
                 $params
             );
 
-            ActivityLog::log($adminId, 'admin_update_group', "Updated group #{$id}: {$group['name']}");
+            ActivityLog::log(
+                $adminId,
+                'admin_update_group',
+                "Updated group #{$id}: {$group['name']}" . ($isSuperAdmin ? " (tenant {$groupTenantId})" : '')
+            );
 
             $this->respondWithData(['id' => $id, 'updated' => true]);
         } catch (\Exception $e) {
@@ -915,6 +1167,7 @@ class AdminGroupsApiController extends BaseApiController
     public function getMembers(int $groupId): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $role = $_GET['role'] ?? null;
@@ -922,8 +1175,14 @@ class AdminGroupsApiController extends BaseApiController
         $offset = (int) ($_GET['offset'] ?? 0);
 
         try {
-            $conditions = ['gm.group_id = ?', 'g.tenant_id = ?'];
-            $params = [$groupId, $tenantId];
+            $conditions = ['gm.group_id = ?'];
+            $params = [$groupId];
+
+            // Tenant scoping: super admins can view members from any tenant's groups
+            if (!$isSuperAdmin) {
+                $conditions[] = 'g.tenant_id = ?';
+                $params[] = $tenantId;
+            }
 
             if ($role) {
                 $conditions[] = 'gm.role = ?';
@@ -974,15 +1233,26 @@ class AdminGroupsApiController extends BaseApiController
     public function promoteMember(int $groupId, int $userId): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         try {
-            $member = Database::query(
-                "SELECT gm.role FROM group_members gm
-                 JOIN `groups` g ON gm.group_id = g.id
-                 WHERE gm.group_id = ? AND gm.user_id = ? AND g.tenant_id = ?",
-                [$groupId, $userId, $tenantId]
-            )->fetch();
+            // Super admins can promote members in groups from any tenant
+            if ($isSuperAdmin) {
+                $member = Database::query(
+                    "SELECT gm.role, g.tenant_id FROM group_members gm
+                     JOIN `groups` g ON gm.group_id = g.id
+                     WHERE gm.group_id = ? AND gm.user_id = ?",
+                    [$groupId, $userId]
+                )->fetch();
+            } else {
+                $member = Database::query(
+                    "SELECT gm.role, g.tenant_id FROM group_members gm
+                     JOIN `groups` g ON gm.group_id = g.id
+                     WHERE gm.group_id = ? AND gm.user_id = ? AND g.tenant_id = ?",
+                    [$groupId, $userId, $tenantId]
+                )->fetch();
+            }
 
             if (!$member) {
                 $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'Member not found', null, 404);
@@ -996,7 +1266,12 @@ class AdminGroupsApiController extends BaseApiController
                 [$newRole, $groupId, $userId]
             );
 
-            ActivityLog::log($adminId, 'admin_promote_group_member', "Promoted user #{$userId} to {$newRole} in group #{$groupId}");
+            $memberTenantId = (int) $member['tenant_id'];
+            ActivityLog::log(
+                $adminId,
+                'admin_promote_group_member',
+                "Promoted user #{$userId} to {$newRole} in group #{$groupId}" . ($isSuperAdmin ? " (tenant {$memberTenantId})" : '')
+            );
 
             $this->respondWithData(['role' => $newRole]);
         } catch (\Exception $e) {
@@ -1017,15 +1292,26 @@ class AdminGroupsApiController extends BaseApiController
     public function demoteMember(int $groupId, int $userId): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         try {
-            $member = Database::query(
-                "SELECT gm.role FROM group_members gm
-                 JOIN `groups` g ON gm.group_id = g.id
-                 WHERE gm.group_id = ? AND gm.user_id = ? AND g.tenant_id = ?",
-                [$groupId, $userId, $tenantId]
-            )->fetch();
+            // Super admins can demote members in groups from any tenant
+            if ($isSuperAdmin) {
+                $member = Database::query(
+                    "SELECT gm.role, g.tenant_id FROM group_members gm
+                     JOIN `groups` g ON gm.group_id = g.id
+                     WHERE gm.group_id = ? AND gm.user_id = ?",
+                    [$groupId, $userId]
+                )->fetch();
+            } else {
+                $member = Database::query(
+                    "SELECT gm.role, g.tenant_id FROM group_members gm
+                     JOIN `groups` g ON gm.group_id = g.id
+                     WHERE gm.group_id = ? AND gm.user_id = ? AND g.tenant_id = ?",
+                    [$groupId, $userId, $tenantId]
+                )->fetch();
+            }
 
             if (!$member) {
                 $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'Member not found', null, 404);
@@ -1039,7 +1325,12 @@ class AdminGroupsApiController extends BaseApiController
                 [$newRole, $groupId, $userId]
             );
 
-            ActivityLog::log($adminId, 'admin_demote_group_member', "Demoted user #{$userId} to {$newRole} in group #{$groupId}");
+            $memberTenantId = (int) $member['tenant_id'];
+            ActivityLog::log(
+                $adminId,
+                'admin_demote_group_member',
+                "Demoted user #{$userId} to {$newRole} in group #{$groupId}" . ($isSuperAdmin ? " (tenant {$memberTenantId})" : '')
+            );
 
             $this->respondWithData(['role' => $newRole]);
         } catch (\Exception $e) {
@@ -1060,15 +1351,26 @@ class AdminGroupsApiController extends BaseApiController
     public function kickMember(int $groupId, int $userId): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         try {
-            $member = Database::query(
-                "SELECT gm.role FROM group_members gm
-                 JOIN `groups` g ON gm.group_id = g.id
-                 WHERE gm.group_id = ? AND gm.user_id = ? AND g.tenant_id = ?",
-                [$groupId, $userId, $tenantId]
-            )->fetch();
+            // Super admins can kick members from groups in any tenant
+            if ($isSuperAdmin) {
+                $member = Database::query(
+                    "SELECT gm.role, g.tenant_id FROM group_members gm
+                     JOIN `groups` g ON gm.group_id = g.id
+                     WHERE gm.group_id = ? AND gm.user_id = ?",
+                    [$groupId, $userId]
+                )->fetch();
+            } else {
+                $member = Database::query(
+                    "SELECT gm.role, g.tenant_id FROM group_members gm
+                     JOIN `groups` g ON gm.group_id = g.id
+                     WHERE gm.group_id = ? AND gm.user_id = ? AND g.tenant_id = ?",
+                    [$groupId, $userId, $tenantId]
+                )->fetch();
+            }
 
             if (!$member) {
                 $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'Member not found', null, 404);
@@ -1080,7 +1382,12 @@ class AdminGroupsApiController extends BaseApiController
                 [$groupId, $userId]
             );
 
-            ActivityLog::log($adminId, 'admin_kick_group_member', "Kicked user #{$userId} from group #{$groupId}");
+            $memberTenantId = (int) $member['tenant_id'];
+            ActivityLog::log(
+                $adminId,
+                'admin_kick_group_member',
+                "Kicked user #{$userId} from group #{$groupId}" . ($isSuperAdmin ? " (tenant {$memberTenantId})" : '')
+            );
 
             $this->respondWithData(['kicked' => true]);
         } catch (\Exception $e) {
@@ -1103,13 +1410,22 @@ class AdminGroupsApiController extends BaseApiController
     public function geocodeGroup(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         try {
-            $group = Database::query(
-                "SELECT id, name, location FROM `groups` WHERE id = ? AND tenant_id = ?",
-                [$id, $tenantId]
-            )->fetch();
+            // Super admins can geocode groups from any tenant
+            if ($isSuperAdmin) {
+                $group = Database::query(
+                    "SELECT id, name, location, tenant_id FROM `groups` WHERE id = ?",
+                    [$id]
+                )->fetch();
+            } else {
+                $group = Database::query(
+                    "SELECT id, name, location, tenant_id FROM `groups` WHERE id = ? AND tenant_id = ?",
+                    [$id, $tenantId]
+                )->fetch();
+            }
 
             if (!$group) {
                 $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'Group not found', null, 404);
@@ -1128,12 +1444,18 @@ class AdminGroupsApiController extends BaseApiController
                 return;
             }
 
+            // Use the record's own tenant_id for safe UPDATE
+            $groupTenantId = (int) $group['tenant_id'];
             Database::query(
                 "UPDATE `groups` SET latitude = ?, longitude = ? WHERE id = ? AND tenant_id = ?",
-                [$coords['latitude'], $coords['longitude'], $id, $tenantId]
+                [$coords['latitude'], $coords['longitude'], $id, $groupTenantId]
             );
 
-            ActivityLog::log($adminId, 'admin_geocode_group', "Geocoded group #{$id}: {$group['name']}");
+            ActivityLog::log(
+                $adminId,
+                'admin_geocode_group',
+                "Geocoded group #{$id}: {$group['name']}" . ($isSuperAdmin ? " (tenant {$groupTenantId})" : '')
+            );
 
             $this->respondWithData([
                 'latitude' => $coords['latitude'],
@@ -1157,17 +1479,31 @@ class AdminGroupsApiController extends BaseApiController
     public function batchGeocode(): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
+
+        // Determine scope
+        if ($isSuperAdmin && $filterTenantId) {
+            $tenantCondition = 'tenant_id = ?';
+            $tenantParams = [$filterTenantId];
+        } elseif ($isSuperAdmin && !$filterTenantId) {
+            $tenantCondition = '1=1';
+            $tenantParams = [];
+        } else {
+            $tenantCondition = 'tenant_id = ?';
+            $tenantParams = [$tenantId];
+        }
 
         try {
             $groups = Database::query(
                 "SELECT id, location FROM `groups`
-                 WHERE tenant_id = ?
+                 WHERE {$tenantCondition}
                  AND location IS NOT NULL
                  AND location != ''
                  AND (latitude IS NULL OR longitude IS NULL)
                  LIMIT 50",
-                [$tenantId]
+                $tenantParams
             )->fetchAll();
 
             $success = 0;
@@ -1189,7 +1525,11 @@ class AdminGroupsApiController extends BaseApiController
                 usleep(100000); // 100ms delay
             }
 
-            ActivityLog::log($adminId, 'admin_batch_geocode_groups', "Batch geocoded {$success} groups, {$failed} failed");
+            ActivityLog::log(
+                $adminId,
+                'admin_batch_geocode_groups',
+                "Batch geocoded {$success} groups, {$failed} failed" . ($isSuperAdmin ? " (scope: " . ($filterTenantId ? "tenant {$filterTenantId}" : "all tenants") . ")" : '')
+            );
 
             $this->respondWithData([
                 'processed' => count($groups),
@@ -1216,7 +1556,21 @@ class AdminGroupsApiController extends BaseApiController
     public function getRecommendationData(): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
+
+        // Determine scope
+        if ($isSuperAdmin && $filterTenantId) {
+            $tenantCondition = 'g.tenant_id = ?';
+            $tenantParams = [$filterTenantId];
+        } elseif ($isSuperAdmin && !$filterTenantId) {
+            $tenantCondition = '1=1';
+            $tenantParams = [];
+        } else {
+            $tenantCondition = 'g.tenant_id = ?';
+            $tenantParams = [$tenantId];
+        }
 
         $limit = min(100, max(1, (int) ($_GET['limit'] ?? 20)));
         $offset = (int) ($_GET['offset'] ?? 0);
@@ -1225,17 +1579,18 @@ class AdminGroupsApiController extends BaseApiController
             // Try to get recommendation data from group_recommendations table
             try {
                 $recommendations = Database::query(
-                    "SELECT gr.user_id, gr.group_id, gr.score, gr.created_at,
+                    "SELECT gr.user_id, gr.group_id, gr.score, gr.created_at, g.tenant_id, t.name as tenant_name,
                         CONCAT(COALESCE(u.first_name, ''), ' ', COALESCE(u.last_name, '')) as user_name,
                         g.name as group_name,
                         (SELECT COUNT(*) FROM group_members gm WHERE gm.user_id = gr.user_id AND gm.group_id = gr.group_id) > 0 as joined
                      FROM group_recommendations gr
                      JOIN users u ON gr.user_id = u.id
                      JOIN `groups` g ON gr.group_id = g.id
-                     WHERE g.tenant_id = ?
+                     LEFT JOIN tenants t ON g.tenant_id = t.id
+                     WHERE {$tenantCondition}
                      ORDER BY gr.created_at DESC
                      LIMIT ? OFFSET ?",
-                    [$tenantId, $limit, $offset]
+                    array_merge($tenantParams, [$limit, $offset])
                 )->fetchAll();
 
                 $stats = Database::query(
@@ -1245,8 +1600,8 @@ class AdminGroupsApiController extends BaseApiController
                         SUM(CASE WHEN EXISTS(SELECT 1 FROM group_members gm WHERE gm.user_id = gr.user_id AND gm.group_id = gr.group_id) THEN 1 ELSE 0 END) as joined_count
                      FROM group_recommendations gr
                      JOIN `groups` g ON gr.group_id = g.id
-                     WHERE g.tenant_id = ?",
-                    [$tenantId]
+                     WHERE {$tenantCondition}",
+                    $tenantParams
                 )->fetch();
             } catch (\Exception $e) {
                 // Table doesn't exist or error - return mock data
@@ -1260,6 +1615,8 @@ class AdminGroupsApiController extends BaseApiController
                     'user_name' => trim($row['user_name']),
                     'group_id' => (int) $row['group_id'],
                     'group_name' => $row['group_name'],
+                    'tenant_id' => (int) $row['tenant_id'],
+                    'tenant_name' => $row['tenant_name'] ?? 'Unknown',
                     'score' => (float) $row['score'],
                     'joined' => (bool) $row['joined'],
                     'created_at' => $row['created_at'],
@@ -1296,10 +1653,15 @@ class AdminGroupsApiController extends BaseApiController
     public function getFeaturedGroups(): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
+
+        // Featured groups service requires a tenant_id — super admins can specify one
+        $scopeTenantId = ($isSuperAdmin && $filterTenantId) ? $filterTenantId : $tenantId;
 
         try {
-            $groups = \Nexus\Services\SmartGroupRankingService::getFeaturedGroupsWithScores($tenantId);
+            $groups = \Nexus\Services\SmartGroupRankingService::getFeaturedGroupsWithScores($scopeTenantId);
 
             $this->respondWithData($groups);
         } catch (\Exception $e) {
@@ -1320,15 +1682,20 @@ class AdminGroupsApiController extends BaseApiController
     public function updateFeaturedGroups(): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
+        // Super admins can specify a target tenant_id via request body or query param
+        $input = $this->getAllInput();
+        $targetTenantId = ($isSuperAdmin && isset($input['tenant_id'])) ? (int) $input['tenant_id'] : $tenantId;
+
         try {
-            $result = \Nexus\Services\SmartGroupRankingService::updateFeaturedLocalHubs($tenantId);
+            $result = \Nexus\Services\SmartGroupRankingService::updateFeaturedLocalHubs($targetTenantId);
 
             ActivityLog::log(
                 $adminId,
                 'admin_update_featured_groups',
-                "Updated featured groups: {$result['featured']} groups featured, {$result['cleared']} cleared"
+                "Updated featured groups: {$result['featured']} groups featured, {$result['cleared']} cleared" . ($isSuperAdmin ? " (tenant {$targetTenantId})" : '')
             );
 
             $this->respondWithData($result);
@@ -1350,30 +1717,41 @@ class AdminGroupsApiController extends BaseApiController
     public function toggleFeatured(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         try {
-            $group = Database::query(
-                "SELECT id, name, is_featured FROM `groups` WHERE id = ? AND tenant_id = ?",
-                [$id, $tenantId]
-            )->fetch();
+            // Super admins can toggle featured status for groups from any tenant
+            if ($isSuperAdmin) {
+                $group = Database::query(
+                    "SELECT id, name, is_featured, tenant_id FROM `groups` WHERE id = ?",
+                    [$id]
+                )->fetch();
+            } else {
+                $group = Database::query(
+                    "SELECT id, name, is_featured, tenant_id FROM `groups` WHERE id = ? AND tenant_id = ?",
+                    [$id, $tenantId]
+                )->fetch();
+            }
 
             if (!$group) {
                 $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'Group not found', null, 404);
                 return;
             }
 
+            // Use the record's own tenant_id for safe UPDATE
+            $groupTenantId = (int) $group['tenant_id'];
             $newStatus = $group['is_featured'] ? 0 : 1;
 
             Database::query(
                 "UPDATE `groups` SET is_featured = ? WHERE id = ? AND tenant_id = ?",
-                [$newStatus, $id, $tenantId]
+                [$newStatus, $id, $groupTenantId]
             );
 
             ActivityLog::log(
                 $adminId,
                 'admin_toggle_group_featured',
-                ($newStatus ? 'Featured' : 'Unfeatured') . " group #{$id}: {$group['name']}"
+                ($newStatus ? 'Featured' : 'Unfeatured') . " group #{$id}: {$group['name']}" . ($isSuperAdmin ? " (tenant {$groupTenantId})" : '')
             );
 
             $this->respondWithData(['is_featured' => (bool) $newStatus]);

--- a/src/Controllers/Api/AdminListingsApiController.php
+++ b/src/Controllers/Api/AdminListingsApiController.php
@@ -35,6 +35,7 @@ class AdminListingsApiController extends BaseApiController
     public function index(): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $page = max(1, (int) ($_GET['page'] ?? 1));
@@ -45,6 +46,7 @@ class AdminListingsApiController extends BaseApiController
         $search = $_GET['search'] ?? null;
         $sort = $_GET['sort'] ?? 'created_at';
         $order = strtoupper($_GET['order'] ?? 'DESC') === 'ASC' ? 'ASC' : 'DESC';
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
         // Whitelist sort columns
         $allowedSorts = ['title', 'type', 'status', 'created_at', 'user_name'];
@@ -52,8 +54,20 @@ class AdminListingsApiController extends BaseApiController
             $sort = 'created_at';
         }
 
-        $conditions = ['l.tenant_id = ?'];
-        $params = [$tenantId];
+        $conditions = [];
+        $params = [];
+
+        // Tenant scoping: super admins can see all tenants or filter by one
+        if ($isSuperAdmin) {
+            if ($filterTenantId) {
+                $conditions[] = 'l.tenant_id = ?';
+                $params[] = $filterTenantId;
+            }
+            // No tenant filter = all tenants for super admin
+        } else {
+            $conditions[] = 'l.tenant_id = ?';
+            $params[] = $tenantId;
+        }
 
         // Status filter
         if ($status && $status !== 'all') {
@@ -84,7 +98,7 @@ class AdminListingsApiController extends BaseApiController
             $params[] = $searchTerm;
         }
 
-        $where = implode(' AND ', $conditions);
+        $where = !empty($conditions) ? implode(' AND ', $conditions) : '1=1';
 
         // Map 'user_name' sort
         $sortColumn = $sort === 'user_name' ? 'user_name' : "l.{$sort}";
@@ -95,16 +109,18 @@ class AdminListingsApiController extends BaseApiController
             $params
         )->fetch()['cnt'];
 
-        // Paginated results
+        // Paginated results — join tenants table for cross-tenant name display
         $items = Database::query(
             "SELECT l.id, l.title, l.description, l.type, l.status, l.created_at, l.updated_at,
-                    l.user_id, l.category_id, l.price,
+                    l.user_id, l.category_id, l.price, l.tenant_id,
                     CONCAT(COALESCE(u.first_name, ''), ' ', COALESCE(u.last_name, '')) as user_name,
                     u.email as user_email, u.avatar_url as user_avatar,
-                    c.name as category_name
+                    c.name as category_name,
+                    t.name as tenant_name
              FROM listings l
              LEFT JOIN users u ON l.user_id = u.id
              LEFT JOIN categories c ON l.category_id = c.id
+             LEFT JOIN tenants t ON l.tenant_id = t.id
              WHERE {$where}
              ORDER BY {$sortColumn} {$order}
              LIMIT ? OFFSET ?",
@@ -119,6 +135,8 @@ class AdminListingsApiController extends BaseApiController
                 'description' => $row['description'] ?? '',
                 'type' => $row['type'] ?? 'listing',
                 'status' => $row['status'] ?? 'active',
+                'tenant_id' => (int) $row['tenant_id'],
+                'tenant_name' => $row['tenant_name'] ?? 'Unknown',
                 'user_id' => (int) ($row['user_id'] ?? 0),
                 'user_name' => trim($row['user_name'] ?? ''),
                 'user_email' => $row['user_email'] ?? '',
@@ -140,19 +158,39 @@ class AdminListingsApiController extends BaseApiController
     public function show(int $id): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
-        $item = Database::query(
-            "SELECT l.*,
-                    CONCAT(COALESCE(u.first_name, ''), ' ', COALESCE(u.last_name, '')) as user_name,
-                    u.email as user_email, u.avatar_url as user_avatar,
-                    c.name as category_name
-             FROM listings l
-             LEFT JOIN users u ON l.user_id = u.id
-             LEFT JOIN categories c ON l.category_id = c.id
-             WHERE l.id = ? AND l.tenant_id = ?",
-            [$id, $tenantId]
-        )->fetch();
+        // Super admins can view listings from any tenant
+        if ($isSuperAdmin) {
+            $item = Database::query(
+                "SELECT l.*,
+                        CONCAT(COALESCE(u.first_name, ''), ' ', COALESCE(u.last_name, '')) as user_name,
+                        u.email as user_email, u.avatar_url as user_avatar,
+                        c.name as category_name,
+                        t.name as tenant_name
+                 FROM listings l
+                 LEFT JOIN users u ON l.user_id = u.id
+                 LEFT JOIN categories c ON l.category_id = c.id
+                 LEFT JOIN tenants t ON l.tenant_id = t.id
+                 WHERE l.id = ?",
+                [$id]
+            )->fetch();
+        } else {
+            $item = Database::query(
+                "SELECT l.*,
+                        CONCAT(COALESCE(u.first_name, ''), ' ', COALESCE(u.last_name, '')) as user_name,
+                        u.email as user_email, u.avatar_url as user_avatar,
+                        c.name as category_name,
+                        t.name as tenant_name
+                 FROM listings l
+                 LEFT JOIN users u ON l.user_id = u.id
+                 LEFT JOIN categories c ON l.category_id = c.id
+                 LEFT JOIN tenants t ON l.tenant_id = t.id
+                 WHERE l.id = ? AND l.tenant_id = ?",
+                [$id, $tenantId]
+            )->fetch();
+        }
 
         if (!$item) {
             $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'Listing not found', null, 404);
@@ -165,6 +203,8 @@ class AdminListingsApiController extends BaseApiController
             'description' => $item['description'] ?? '',
             'type' => $item['type'] ?? 'listing',
             'status' => $item['status'] ?? 'active',
+            'tenant_id' => (int) $item['tenant_id'],
+            'tenant_name' => $item['tenant_name'] ?? 'Unknown',
             'user_id' => (int) ($item['user_id'] ?? 0),
             'user_name' => trim($item['user_name'] ?? ''),
             'user_email' => $item['user_email'] ?? '',
@@ -184,24 +224,40 @@ class AdminListingsApiController extends BaseApiController
     public function approve(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
-        $item = Database::query(
-            "SELECT id, title, status FROM listings WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
-        )->fetch();
+        // Super admins can approve listings from any tenant
+        if ($isSuperAdmin) {
+            $item = Database::query(
+                "SELECT id, title, status, tenant_id FROM listings WHERE id = ?",
+                [$id]
+            )->fetch();
+        } else {
+            $item = Database::query(
+                "SELECT id, title, status, tenant_id FROM listings WHERE id = ? AND tenant_id = ?",
+                [$id, $tenantId]
+            )->fetch();
+        }
 
         if (!$item) {
             $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'Listing not found', null, 404);
             return;
         }
 
+        // Use the record's own tenant_id for the write
+        $itemTenantId = (int) $item['tenant_id'];
+
         Database::query(
             "UPDATE listings SET status = 'active' WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
+            [$id, $itemTenantId]
         );
 
-        ActivityLog::log($adminId, 'admin_approve_listing', "Approved listing #{$id}: {$item['title']}");
+        ActivityLog::log(
+            $adminId,
+            'admin_approve_listing',
+            "Approved listing #{$id}: {$item['title']}" . ($isSuperAdmin ? " (tenant {$itemTenantId})" : '')
+        );
 
         $this->respondWithData(['approved' => true, 'id' => $id]);
     }
@@ -212,24 +268,40 @@ class AdminListingsApiController extends BaseApiController
     public function destroy(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
-        $item = Database::query(
-            "SELECT id, title FROM listings WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
-        )->fetch();
+        // Super admins can delete listings from any tenant
+        if ($isSuperAdmin) {
+            $item = Database::query(
+                "SELECT id, title, tenant_id FROM listings WHERE id = ?",
+                [$id]
+            )->fetch();
+        } else {
+            $item = Database::query(
+                "SELECT id, title, tenant_id FROM listings WHERE id = ? AND tenant_id = ?",
+                [$id, $tenantId]
+            )->fetch();
+        }
 
         if (!$item) {
             $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'Listing not found', null, 404);
             return;
         }
 
+        // Use the record's own tenant_id for the delete (safety: always keep AND tenant_id = ?)
+        $itemTenantId = (int) $item['tenant_id'];
+
         Database::query(
             "DELETE FROM listings WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
+            [$id, $itemTenantId]
         );
 
-        ActivityLog::log($adminId, 'admin_delete_listing', "Deleted listing #{$id}: {$item['title']}");
+        ActivityLog::log(
+            $adminId,
+            'admin_delete_listing',
+            "Deleted listing #{$id}: {$item['title']}" . ($isSuperAdmin ? " (tenant {$itemTenantId})" : '')
+        );
 
         $this->respondWithData(['deleted' => true, 'id' => $id]);
     }

--- a/src/Controllers/Api/AdminReportsApiController.php
+++ b/src/Controllers/Api/AdminReportsApiController.php
@@ -40,6 +40,7 @@ class AdminReportsApiController extends BaseApiController
     public function index(): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $page = max(1, (int) ($_GET['page'] ?? 1));
@@ -48,9 +49,22 @@ class AdminReportsApiController extends BaseApiController
         $type = $_GET['type'] ?? null;
         $status = $_GET['status'] ?? null;
         $search = $_GET['search'] ?? null;
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
-        $conditions = ['r.tenant_id = ?'];
-        $params = [$tenantId];
+        $conditions = [];
+        $params = [];
+
+        // Tenant scoping: super admins can see all tenants or filter by one
+        if ($isSuperAdmin) {
+            if ($filterTenantId) {
+                $conditions[] = 'r.tenant_id = ?';
+                $params[] = $filterTenantId;
+            }
+            // No tenant filter = all tenants for super admin
+        } else {
+            $conditions[] = 'r.tenant_id = ?';
+            $params[] = $tenantId;
+        }
 
         // Type filter (listing, user, message)
         if ($type && in_array($type, ['listing', 'user', 'message'], true)) {
@@ -72,7 +86,7 @@ class AdminReportsApiController extends BaseApiController
             $params[] = $searchPattern;
         }
 
-        $where = implode(' AND ', $conditions);
+        $where = !empty($conditions) ? implode(' AND ', $conditions) : '1=1';
 
         // Get total count
         $countQuery = "SELECT COUNT(*) as total
@@ -82,12 +96,14 @@ class AdminReportsApiController extends BaseApiController
         $countStmt = Database::query($countQuery, $params);
         $total = (int) $countStmt->fetch()['total'];
 
-        // Get paginated results
+        // Get paginated results — join tenants table for cross-tenant name display
         $query = "SELECT r.*,
                          reporter.name as reporter_name,
-                         reporter.avatar_url as reporter_avatar
+                         reporter.avatar_url as reporter_avatar,
+                         t.name as tenant_name
                   FROM reports r
                   LEFT JOIN users reporter ON r.reporter_id = reporter.id
+                  LEFT JOIN tenants t ON r.tenant_id = t.id
                   WHERE {$where}
                   ORDER BY r.created_at DESC
                   LIMIT ? OFFSET ?";
@@ -101,6 +117,8 @@ class AdminReportsApiController extends BaseApiController
         $formatted = array_map(function ($report) {
             return [
                 'id' => (int) $report['id'],
+                'tenant_id' => (int) $report['tenant_id'],
+                'tenant_name' => $report['tenant_name'] ?? 'Unknown',
                 'reporter_id' => (int) $report['reporter_id'],
                 'reporter_name' => $report['reporter_name'] ?? 'Unknown',
                 'reporter_avatar' => $report['reporter_avatar'],
@@ -123,16 +141,31 @@ class AdminReportsApiController extends BaseApiController
     public function show(int $id): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
-        $query = "SELECT r.*,
-                         reporter.name as reporter_name,
-                         reporter.avatar_url as reporter_avatar
-                  FROM reports r
-                  LEFT JOIN users reporter ON r.reporter_id = reporter.id
-                  WHERE r.id = ? AND r.tenant_id = ?";
-
-        $stmt = Database::query($query, [$id, $tenantId]);
+        // Super admins can view reports from any tenant
+        if ($isSuperAdmin) {
+            $query = "SELECT r.*,
+                             reporter.name as reporter_name,
+                             reporter.avatar_url as reporter_avatar,
+                             t.name as tenant_name
+                      FROM reports r
+                      LEFT JOIN users reporter ON r.reporter_id = reporter.id
+                      LEFT JOIN tenants t ON r.tenant_id = t.id
+                      WHERE r.id = ?";
+            $stmt = Database::query($query, [$id]);
+        } else {
+            $query = "SELECT r.*,
+                             reporter.name as reporter_name,
+                             reporter.avatar_url as reporter_avatar,
+                             t.name as tenant_name
+                      FROM reports r
+                      LEFT JOIN users reporter ON r.reporter_id = reporter.id
+                      LEFT JOIN tenants t ON r.tenant_id = t.id
+                      WHERE r.id = ? AND r.tenant_id = ?";
+            $stmt = Database::query($query, [$id, $tenantId]);
+        }
         $report = $stmt->fetch();
 
         if (!$report) {
@@ -142,6 +175,8 @@ class AdminReportsApiController extends BaseApiController
 
         $formatted = [
             'id' => (int) $report['id'],
+            'tenant_id' => (int) $report['tenant_id'],
+            'tenant_name' => $report['tenant_name'] ?? 'Unknown',
             'reporter_id' => (int) $report['reporter_id'],
             'reporter_name' => $report['reporter_name'] ?? 'Unknown',
             'reporter_avatar' => $report['reporter_avatar'],
@@ -163,14 +198,22 @@ class AdminReportsApiController extends BaseApiController
     public function resolve(int $id): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $adminId = $this->getAuthenticatedUserId();
 
-        // Check report exists and is not already resolved
-        $stmt = Database::query(
-            "SELECT id, status FROM reports WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
-        );
+        // Check report exists — super admins can resolve reports from any tenant
+        if ($isSuperAdmin) {
+            $stmt = Database::query(
+                "SELECT id, status, tenant_id FROM reports WHERE id = ?",
+                [$id]
+            );
+        } else {
+            $stmt = Database::query(
+                "SELECT id, status, tenant_id FROM reports WHERE id = ? AND tenant_id = ?",
+                [$id, $tenantId]
+            );
+        }
         $report = $stmt->fetch();
 
         if (!$report) {
@@ -183,14 +226,21 @@ class AdminReportsApiController extends BaseApiController
             return;
         }
 
+        // Use the report's own tenant_id for the update (safety: always include tenant_id in UPDATE)
+        $reportTenantId = (int) $report['tenant_id'];
+
         // Update status to resolved
         Database::query(
             "UPDATE reports SET status = 'resolved', updated_at = NOW() WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
+            [$id, $reportTenantId]
         );
 
-        // Log activity
-        ActivityLog::log($adminId, 'resolve_report', "Resolved report ID {$id}");
+        // Log activity — include tenant info for super admin actions
+        ActivityLog::log(
+            $adminId,
+            'resolve_report',
+            "Resolved report ID {$id}" . ($isSuperAdmin ? " (tenant {$reportTenantId})" : '')
+        );
 
         $this->respondWithData(['success' => true, 'message' => 'Report resolved']);
     }
@@ -201,14 +251,22 @@ class AdminReportsApiController extends BaseApiController
     public function dismiss(int $id): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $adminId = $this->getAuthenticatedUserId();
 
-        // Check report exists and is not already dismissed
-        $stmt = Database::query(
-            "SELECT id, status FROM reports WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
-        );
+        // Check report exists — super admins can dismiss reports from any tenant
+        if ($isSuperAdmin) {
+            $stmt = Database::query(
+                "SELECT id, status, tenant_id FROM reports WHERE id = ?",
+                [$id]
+            );
+        } else {
+            $stmt = Database::query(
+                "SELECT id, status, tenant_id FROM reports WHERE id = ? AND tenant_id = ?",
+                [$id, $tenantId]
+            );
+        }
         $report = $stmt->fetch();
 
         if (!$report) {
@@ -221,14 +279,21 @@ class AdminReportsApiController extends BaseApiController
             return;
         }
 
+        // Use the report's own tenant_id for the update (safety: always include tenant_id in UPDATE)
+        $reportTenantId = (int) $report['tenant_id'];
+
         // Update status to dismissed
         Database::query(
             "UPDATE reports SET status = 'dismissed', updated_at = NOW() WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
+            [$id, $reportTenantId]
         );
 
-        // Log activity
-        ActivityLog::log($adminId, 'dismiss_report', "Dismissed report ID {$id}");
+        // Log activity — include tenant info for super admin actions
+        ActivityLog::log(
+            $adminId,
+            'dismiss_report',
+            "Dismissed report ID {$id}" . ($isSuperAdmin ? " (tenant {$reportTenantId})" : '')
+        );
 
         $this->respondWithData(['success' => true, 'message' => 'Report dismissed']);
     }
@@ -239,17 +304,31 @@ class AdminReportsApiController extends BaseApiController
     public function stats(): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
-        $query = "SELECT
-                    COUNT(*) as total,
-                    SUM(CASE WHEN status = 'open' THEN 1 ELSE 0 END) as pending,
-                    SUM(CASE WHEN status = 'resolved' THEN 1 ELSE 0 END) as resolved,
-                    SUM(CASE WHEN status = 'dismissed' THEN 1 ELSE 0 END) as dismissed
-                  FROM reports
-                  WHERE tenant_id = ?";
+        // Super admins: aggregate across all tenants or filter by one
+        if ($isSuperAdmin && !$filterTenantId) {
+            $query = "SELECT
+                        COUNT(*) as total,
+                        SUM(CASE WHEN status = 'open' THEN 1 ELSE 0 END) as pending,
+                        SUM(CASE WHEN status = 'resolved' THEN 1 ELSE 0 END) as resolved,
+                        SUM(CASE WHEN status = 'dismissed' THEN 1 ELSE 0 END) as dismissed
+                      FROM reports";
+            $stmt = Database::query($query);
+        } else {
+            $scopeTenantId = ($isSuperAdmin && $filterTenantId) ? $filterTenantId : $tenantId;
+            $query = "SELECT
+                        COUNT(*) as total,
+                        SUM(CASE WHEN status = 'open' THEN 1 ELSE 0 END) as pending,
+                        SUM(CASE WHEN status = 'resolved' THEN 1 ELSE 0 END) as resolved,
+                        SUM(CASE WHEN status = 'dismissed' THEN 1 ELSE 0 END) as dismissed
+                      FROM reports
+                      WHERE tenant_id = ?";
+            $stmt = Database::query($query, [$scopeTenantId]);
+        }
 
-        $stmt = Database::query($query, [$tenantId]);
         $stats = $stmt->fetch();
 
         $formatted = [

--- a/src/Controllers/Api/AdminReviewsApiController.php
+++ b/src/Controllers/Api/AdminReviewsApiController.php
@@ -41,6 +41,7 @@ class AdminReviewsApiController extends BaseApiController
     public function index(): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $page = max(1, (int) ($_GET['page'] ?? 1));
@@ -49,9 +50,22 @@ class AdminReviewsApiController extends BaseApiController
         $rating = isset($_GET['rating']) ? (int) $_GET['rating'] : null;
         $status = $_GET['status'] ?? null;
         $search = $_GET['search'] ?? null;
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
-        $conditions = ['r.tenant_id = ?'];
-        $params = [$tenantId];
+        $conditions = [];
+        $params = [];
+
+        // Tenant scoping: super admins can see all tenants or filter by one
+        if ($isSuperAdmin) {
+            if ($filterTenantId) {
+                $conditions[] = 'r.tenant_id = ?';
+                $params[] = $filterTenantId;
+            }
+            // No tenant filter = all tenants for super admin
+        } else {
+            $conditions[] = 'r.tenant_id = ?';
+            $params[] = $tenantId;
+        }
 
         // Rating filter
         if ($rating !== null && $rating >= 1 && $rating <= 5) {
@@ -74,7 +88,7 @@ class AdminReviewsApiController extends BaseApiController
             $params[] = $searchPattern;
         }
 
-        $where = implode(' AND ', $conditions);
+        $where = !empty($conditions) ? implode(' AND ', $conditions) : '1=1';
 
         // Get total count
         $countQuery = "SELECT COUNT(*) as total
@@ -85,15 +99,17 @@ class AdminReviewsApiController extends BaseApiController
         $countStmt = Database::query($countQuery, $params);
         $total = (int) $countStmt->fetch()['total'];
 
-        // Get paginated results
+        // Get paginated results — join tenants table for cross-tenant name display
         $query = "SELECT r.*,
                          reviewer.name as reviewer_name,
                          reviewer.avatar_url as reviewer_avatar,
                          receiver.name as receiver_name,
-                         receiver.avatar_url as receiver_avatar
+                         receiver.avatar_url as receiver_avatar,
+                         t.name as tenant_name
                   FROM reviews r
                   LEFT JOIN users reviewer ON r.reviewer_id = reviewer.id
                   LEFT JOIN users receiver ON r.receiver_id = receiver.id
+                  LEFT JOIN tenants t ON r.tenant_id = t.id
                   WHERE {$where}
                   ORDER BY r.created_at DESC
                   LIMIT ? OFFSET ?";
@@ -107,6 +123,8 @@ class AdminReviewsApiController extends BaseApiController
         $formatted = array_map(function ($review) {
             return [
                 'id' => (int) $review['id'],
+                'tenant_id' => (int) $review['tenant_id'],
+                'tenant_name' => $review['tenant_name'] ?? 'Unknown',
                 'reviewer_id' => (int) $review['reviewer_id'],
                 'reviewer_name' => $review['reviewer_name'] ?? 'Unknown',
                 'reviewer_avatar' => $review['reviewer_avatar'],
@@ -131,21 +149,41 @@ class AdminReviewsApiController extends BaseApiController
     public function show(int $id): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
-        $query = "SELECT r.*,
-                         reviewer.name as reviewer_name,
-                         reviewer.email as reviewer_email,
-                         reviewer.avatar_url as reviewer_avatar,
-                         receiver.name as receiver_name,
-                         receiver.email as receiver_email,
-                         receiver.avatar_url as receiver_avatar
-                  FROM reviews r
-                  LEFT JOIN users reviewer ON r.reviewer_id = reviewer.id
-                  LEFT JOIN users receiver ON r.receiver_id = receiver.id
-                  WHERE r.id = ? AND r.tenant_id = ?";
-
-        $stmt = Database::query($query, [$id, $tenantId]);
+        // Super admins can view reviews from any tenant
+        if ($isSuperAdmin) {
+            $query = "SELECT r.*,
+                             reviewer.name as reviewer_name,
+                             reviewer.email as reviewer_email,
+                             reviewer.avatar_url as reviewer_avatar,
+                             receiver.name as receiver_name,
+                             receiver.email as receiver_email,
+                             receiver.avatar_url as receiver_avatar,
+                             t.name as tenant_name
+                      FROM reviews r
+                      LEFT JOIN users reviewer ON r.reviewer_id = reviewer.id
+                      LEFT JOIN users receiver ON r.receiver_id = receiver.id
+                      LEFT JOIN tenants t ON r.tenant_id = t.id
+                      WHERE r.id = ?";
+            $stmt = Database::query($query, [$id]);
+        } else {
+            $query = "SELECT r.*,
+                             reviewer.name as reviewer_name,
+                             reviewer.email as reviewer_email,
+                             reviewer.avatar_url as reviewer_avatar,
+                             receiver.name as receiver_name,
+                             receiver.email as receiver_email,
+                             receiver.avatar_url as receiver_avatar,
+                             t.name as tenant_name
+                      FROM reviews r
+                      LEFT JOIN users reviewer ON r.reviewer_id = reviewer.id
+                      LEFT JOIN users receiver ON r.receiver_id = receiver.id
+                      LEFT JOIN tenants t ON r.tenant_id = t.id
+                      WHERE r.id = ? AND r.tenant_id = ?";
+            $stmt = Database::query($query, [$id, $tenantId]);
+        }
         $review = $stmt->fetch();
 
         if (!$review) {
@@ -155,6 +193,8 @@ class AdminReviewsApiController extends BaseApiController
 
         $formatted = [
             'id' => (int) $review['id'],
+            'tenant_id' => (int) $review['tenant_id'],
+            'tenant_name' => $review['tenant_name'] ?? 'Unknown',
             'reviewer_id' => (int) $review['reviewer_id'],
             'reviewer_name' => $review['reviewer_name'] ?? 'Unknown',
             'reviewer_email' => $review['reviewer_email'],
@@ -183,14 +223,22 @@ class AdminReviewsApiController extends BaseApiController
     public function flag(int $id): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $adminId = $this->getAuthenticatedUserId();
 
-        // Verify review exists
-        $stmt = Database::query(
-            "SELECT id, status FROM reviews WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
-        );
+        // Verify review exists — super admins can flag reviews from any tenant
+        if ($isSuperAdmin) {
+            $stmt = Database::query(
+                "SELECT id, status, tenant_id FROM reviews WHERE id = ?",
+                [$id]
+            );
+        } else {
+            $stmt = Database::query(
+                "SELECT id, status, tenant_id FROM reviews WHERE id = ? AND tenant_id = ?",
+                [$id, $tenantId]
+            );
+        }
         $review = $stmt->fetch();
 
         if (!$review) {
@@ -198,17 +246,20 @@ class AdminReviewsApiController extends BaseApiController
             return;
         }
 
+        // Use the review's own tenant_id for the update
+        $reviewTenantId = (int) $review['tenant_id'];
+
         // Update review status to pending (flagged for review)
         Database::query(
             "UPDATE reviews SET status = 'pending' WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
+            [$id, $reviewTenantId]
         );
 
         // Log activity
         ActivityLog::log(
             $adminId,
             'flag_review',
-            "Flagged review #{$id} for admin review (set status to pending)"
+            "Flagged review #{$id} for admin review (set status to pending)" . ($isSuperAdmin ? " (tenant {$reviewTenantId})" : '')
         );
 
         $this->respondWithData(['success' => true, 'message' => 'Review flagged for attention']);
@@ -220,14 +271,22 @@ class AdminReviewsApiController extends BaseApiController
     public function hide(int $id): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $adminId = $this->getAuthenticatedUserId();
 
-        // Verify review exists
-        $stmt = Database::query(
-            "SELECT id, status FROM reviews WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
-        );
+        // Verify review exists — super admins can hide reviews from any tenant
+        if ($isSuperAdmin) {
+            $stmt = Database::query(
+                "SELECT id, status, tenant_id FROM reviews WHERE id = ?",
+                [$id]
+            );
+        } else {
+            $stmt = Database::query(
+                "SELECT id, status, tenant_id FROM reviews WHERE id = ? AND tenant_id = ?",
+                [$id, $tenantId]
+            );
+        }
         $review = $stmt->fetch();
 
         if (!$review) {
@@ -235,17 +294,20 @@ class AdminReviewsApiController extends BaseApiController
             return;
         }
 
+        // Use the review's own tenant_id for the update
+        $reviewTenantId = (int) $review['tenant_id'];
+
         // Update review status to rejected (hidden)
         Database::query(
             "UPDATE reviews SET status = 'rejected' WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
+            [$id, $reviewTenantId]
         );
 
         // Log activity
         ActivityLog::log(
             $adminId,
             'hide_review',
-            "Hidden review #{$id} (set status to rejected)"
+            "Hidden review #{$id} (set status to rejected)" . ($isSuperAdmin ? " (tenant {$reviewTenantId})" : '')
         );
 
         $this->respondWithData(['success' => true, 'message' => 'Review hidden']);
@@ -257,14 +319,22 @@ class AdminReviewsApiController extends BaseApiController
     public function destroy(int $id): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $adminId = $this->getAuthenticatedUserId();
 
-        // Verify review exists
-        $stmt = Database::query(
-            "SELECT id FROM reviews WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
-        );
+        // Verify review exists — super admins can delete reviews from any tenant
+        if ($isSuperAdmin) {
+            $stmt = Database::query(
+                "SELECT id, tenant_id FROM reviews WHERE id = ?",
+                [$id]
+            );
+        } else {
+            $stmt = Database::query(
+                "SELECT id, tenant_id FROM reviews WHERE id = ? AND tenant_id = ?",
+                [$id, $tenantId]
+            );
+        }
         $review = $stmt->fetch();
 
         if (!$review) {
@@ -272,17 +342,19 @@ class AdminReviewsApiController extends BaseApiController
             return;
         }
 
-        // Delete review
+        $reviewTenantId = (int) $review['tenant_id'];
+
+        // Delete review using the review's own tenant_id for safety
         Database::query(
             "DELETE FROM reviews WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
+            [$id, $reviewTenantId]
         );
 
         // Log activity
         ActivityLog::log(
             $adminId,
             'delete_review',
-            "Deleted review #{$id}"
+            "Deleted review #{$id}" . ($isSuperAdmin ? " (tenant {$reviewTenantId})" : '')
         );
 
         $this->respondWithData(['success' => true, 'message' => 'Review deleted']);

--- a/src/Controllers/Api/AdminUsersApiController.php
+++ b/src/Controllers/Api/AdminUsersApiController.php
@@ -50,6 +50,7 @@ class AdminUsersApiController extends BaseApiController
     public function index(): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $page = max(1, (int) ($_GET['page'] ?? 1));
@@ -60,6 +61,7 @@ class AdminUsersApiController extends BaseApiController
         $role = $_GET['role'] ?? null;
         $sort = $_GET['sort'] ?? 'created_at';
         $order = strtoupper($_GET['order'] ?? 'DESC') === 'ASC' ? 'ASC' : 'DESC';
+        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
         // Whitelist sort columns
         $allowedSorts = ['name', 'email', 'role', 'created_at', 'balance', 'status'];
@@ -67,8 +69,20 @@ class AdminUsersApiController extends BaseApiController
             $sort = 'created_at';
         }
 
-        $conditions = ['u.tenant_id = ?'];
-        $params = [$tenantId];
+        $conditions = [];
+        $params = [];
+
+        // Tenant scoping: super admins can see all tenants or filter by one
+        if ($isSuperAdmin) {
+            if ($filterTenantId) {
+                $conditions[] = 'u.tenant_id = ?';
+                $params[] = $filterTenantId;
+            }
+            // No tenant filter = all tenants for super admin
+        } else {
+            $conditions[] = 'u.tenant_id = ?';
+            $params[] = $tenantId;
+        }
 
         // Status filter
         if ($status && $status !== 'all') {
@@ -104,7 +118,7 @@ class AdminUsersApiController extends BaseApiController
             $params[] = $searchTerm;
         }
 
-        $where = implode(' AND ', $conditions);
+        $where = !empty($conditions) ? implode(' AND ', $conditions) : '1=1';
 
         // Map 'name' sort to computed column
         $sortColumn = $sort === 'name' ? 'name' : "u.{$sort}";
@@ -119,7 +133,7 @@ class AdminUsersApiController extends BaseApiController
             $params
         )->fetch()['cnt'];
 
-        // Get paginated users
+        // Get paginated users — join tenants table for cross-tenant name display
         $users = Database::query(
             "SELECT u.id, u.first_name, u.last_name,
                 CASE
@@ -129,9 +143,12 @@ class AdminUsersApiController extends BaseApiController
                 END as name,
                 u.email, u.avatar_url, u.location, u.role, u.is_approved, u.is_super_admin,
                 u.status, u.created_at, u.last_active_at, u.profile_type, u.organization_name,
+                u.tenant_id,
+                t.name as tenant_name,
                 COALESCE(u.balance, 0) as balance,
                 (SELECT COUNT(*) FROM listings l WHERE l.user_id = u.id AND l.status = 'active') as listing_count
              FROM users u
+             LEFT JOIN tenants t ON u.tenant_id = t.id
              WHERE {$where}
              ORDER BY {$sortColumn} {$order}
              LIMIT ? OFFSET ?",
@@ -172,6 +189,8 @@ class AdminUsersApiController extends BaseApiController
                 'balance' => (float) ($row['balance'] ?? 0),
                 'listing_count' => (int) ($row['listing_count'] ?? 0),
                 'profile_type' => $row['profile_type'] ?? 'individual',
+                'tenant_id' => (int) $row['tenant_id'],
+                'tenant_name' => $row['tenant_name'] ?? 'Unknown',
                 'has_2fa_enabled' => $has2fa ? !empty($row['totp_secret'] ?? null) : false,
                 'created_at' => $row['created_at'],
                 'last_active_at' => $row['last_active_at'] ?? null,
@@ -187,15 +206,33 @@ class AdminUsersApiController extends BaseApiController
     public function show(int $id): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
-        $user = Database::query(
-            "SELECT id, first_name, last_name, email, avatar_url, location, bio, tagline, phone,
-                    role, status, is_approved, is_super_admin, balance, profile_type,
-                    organization_name, vetting_status, insurance_status, created_at, last_active_at
-             FROM users WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
-        )->fetch();
+        // Super admins can view users from any tenant
+        if ($isSuperAdmin) {
+            $user = Database::query(
+                "SELECT u.id, u.first_name, u.last_name, u.email, u.avatar_url, u.location, u.bio, u.tagline, u.phone,
+                        u.role, u.status, u.is_approved, u.is_super_admin, u.balance, u.profile_type,
+                        u.organization_name, u.vetting_status, u.insurance_status, u.created_at, u.last_active_at,
+                        u.tenant_id, t.name as tenant_name
+                 FROM users u
+                 LEFT JOIN tenants t ON u.tenant_id = t.id
+                 WHERE u.id = ?",
+                [$id]
+            )->fetch();
+        } else {
+            $user = Database::query(
+                "SELECT u.id, u.first_name, u.last_name, u.email, u.avatar_url, u.location, u.bio, u.tagline, u.phone,
+                        u.role, u.status, u.is_approved, u.is_super_admin, u.balance, u.profile_type,
+                        u.organization_name, u.vetting_status, u.insurance_status, u.created_at, u.last_active_at,
+                        u.tenant_id, t.name as tenant_name
+                 FROM users u
+                 LEFT JOIN tenants t ON u.tenant_id = t.id
+                 WHERE u.id = ? AND u.tenant_id = ?",
+                [$id, $tenantId]
+            )->fetch();
+        }
 
         if (!$user) {
             $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
@@ -254,6 +291,8 @@ class AdminUsersApiController extends BaseApiController
             'balance' => (float) ($user['balance'] ?? 0),
             'profile_type' => $user['profile_type'] ?? 'individual',
             'organization_name' => $user['organization_name'] ?? null,
+            'tenant_id' => (int) $user['tenant_id'],
+            'tenant_name' => $user['tenant_name'] ?? 'Unknown',
             'badges' => $badges,
             'vetting_status' => $user['vetting_status'] ?? 'none',
             'insurance_status' => $user['insurance_status'] ?? 'none',
@@ -385,13 +424,23 @@ class AdminUsersApiController extends BaseApiController
     public function update(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $user = User::findById($id);
-        if (!$user || $user['tenant_id'] != $tenantId) {
+        if (!$user) {
             $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
             return;
         }
+
+        // Regular admins can only update users in their own tenant
+        if (!$isSuperAdmin && $user['tenant_id'] != $tenantId) {
+            $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
+            return;
+        }
+
+        // Use the user's own tenant_id for the UPDATE query (safety)
+        $userTenantId = (int) $user['tenant_id'];
 
         $input = $this->getAllInput();
 
@@ -464,14 +513,14 @@ class AdminUsersApiController extends BaseApiController
         }
 
         $params[] = $id;
-        $params[] = $tenantId;
+        $params[] = $userTenantId;
 
         Database::query(
             "UPDATE users SET " . implode(', ', $updates) . " WHERE id = ? AND tenant_id = ?",
             $params
         );
 
-        ActivityLog::log($adminId, 'admin_update_user', "Updated user #{$id}");
+        ActivityLog::log($adminId, 'admin_update_user', "Updated user #{$id}" . ($isSuperAdmin ? " (tenant {$userTenantId})" : ''));
 
         // Audit log: track which fields changed
         $changedFields = array_keys($input);
@@ -492,6 +541,7 @@ class AdminUsersApiController extends BaseApiController
     public function destroy(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         // Prevent self-deletion
@@ -501,7 +551,13 @@ class AdminUsersApiController extends BaseApiController
         }
 
         $user = User::findById($id);
-        if (!$user || $user['tenant_id'] != $tenantId) {
+        if (!$user) {
+            $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
+            return;
+        }
+
+        // Regular admins can only delete users in their own tenant
+        if (!$isSuperAdmin && $user['tenant_id'] != $tenantId) {
             $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
             return;
         }
@@ -512,9 +568,12 @@ class AdminUsersApiController extends BaseApiController
             return;
         }
 
-        Database::query("DELETE FROM users WHERE id = ? AND tenant_id = ?", [$id, $tenantId]);
+        // Use the user's own tenant_id for the DELETE query (safety)
+        $userTenantId = (int) $user['tenant_id'];
 
-        ActivityLog::log($adminId, 'admin_delete_user', "Deleted user #{$id} ({$user['email']})");
+        Database::query("DELETE FROM users WHERE id = ? AND tenant_id = ?", [$id, $userTenantId]);
+
+        ActivityLog::log($adminId, 'admin_delete_user', "Deleted user #{$id} ({$user['email']})" . ($isSuperAdmin ? " (tenant {$userTenantId})" : ''));
         AuditLogService::logUserDeleted($adminId, $id, $user['email']);
 
         $this->respondWithData(['deleted' => true, 'id' => $id]);
@@ -526,17 +585,24 @@ class AdminUsersApiController extends BaseApiController
     public function approve(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $user = User::findById($id);
-        if (!$user || $user['tenant_id'] != $tenantId) {
+        if (!$user) {
+            $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
+            return;
+        }
+
+        // Regular admins can only approve users in their own tenant
+        if (!$isSuperAdmin && $user['tenant_id'] != $tenantId) {
             $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
             return;
         }
 
         User::updateAdminFields($id, $user['role'] ?? 'member', 1);
 
-        ActivityLog::log($adminId, 'admin_approve_user', "Approved user #{$id} ({$user['email']})");
+        ActivityLog::log($adminId, 'admin_approve_user', "Approved user #{$id} ({$user['email']})" . ($isSuperAdmin ? " (tenant {$user['tenant_id']})" : ''));
         AuditLogService::logUserApproved($adminId, $id, $user['email']);
 
         $this->respondWithData(['approved' => true, 'id' => $id]);
@@ -550,6 +616,7 @@ class AdminUsersApiController extends BaseApiController
     public function suspend(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         if ($id === $adminId) {
@@ -558,7 +625,13 @@ class AdminUsersApiController extends BaseApiController
         }
 
         $user = User::findById($id);
-        if (!$user || $user['tenant_id'] != $tenantId) {
+        if (!$user) {
+            $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
+            return;
+        }
+
+        // Regular admins can only suspend users in their own tenant
+        if (!$isSuperAdmin && $user['tenant_id'] != $tenantId) {
             $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
             return;
         }
@@ -568,15 +641,18 @@ class AdminUsersApiController extends BaseApiController
             return;
         }
 
+        // Use the user's own tenant_id for the UPDATE query (safety)
+        $userTenantId = (int) $user['tenant_id'];
+
         $input = $this->getAllInput();
         $reason = $input['reason'] ?? 'Suspended by admin';
 
         Database::query(
             "UPDATE users SET status = 'suspended' WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
+            [$id, $userTenantId]
         );
 
-        ActivityLog::log($adminId, 'admin_suspend_user', "Suspended user #{$id}: {$reason}");
+        ActivityLog::log($adminId, 'admin_suspend_user', "Suspended user #{$id}: {$reason}" . ($isSuperAdmin ? " (tenant {$userTenantId})" : ''));
         AuditLogService::logUserSuspended($adminId, $id, $reason);
 
         $this->respondWithData(['suspended' => true, 'id' => $id]);
@@ -590,6 +666,7 @@ class AdminUsersApiController extends BaseApiController
     public function ban(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         if ($id === $adminId) {
@@ -598,7 +675,13 @@ class AdminUsersApiController extends BaseApiController
         }
 
         $user = User::findById($id);
-        if (!$user || $user['tenant_id'] != $tenantId) {
+        if (!$user) {
+            $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
+            return;
+        }
+
+        // Regular admins can only ban users in their own tenant
+        if (!$isSuperAdmin && $user['tenant_id'] != $tenantId) {
             $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
             return;
         }
@@ -608,15 +691,18 @@ class AdminUsersApiController extends BaseApiController
             return;
         }
 
+        // Use the user's own tenant_id for the UPDATE query (safety)
+        $userTenantId = (int) $user['tenant_id'];
+
         $input = $this->getAllInput();
         $reason = $input['reason'] ?? 'Banned by admin';
 
         Database::query(
             "UPDATE users SET status = 'banned' WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
+            [$id, $userTenantId]
         );
 
-        ActivityLog::log($adminId, 'admin_ban_user', "Banned user #{$id}: {$reason}");
+        ActivityLog::log($adminId, 'admin_ban_user', "Banned user #{$id}: {$reason}" . ($isSuperAdmin ? " (tenant {$userTenantId})" : ''));
         AuditLogService::logUserBanned($adminId, $id, $reason);
 
         $this->respondWithData(['banned' => true, 'id' => $id]);
@@ -628,20 +714,30 @@ class AdminUsersApiController extends BaseApiController
     public function reactivate(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $user = User::findById($id);
-        if (!$user || $user['tenant_id'] != $tenantId) {
+        if (!$user) {
             $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
             return;
         }
 
+        // Regular admins can only reactivate users in their own tenant
+        if (!$isSuperAdmin && $user['tenant_id'] != $tenantId) {
+            $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
+            return;
+        }
+
+        // Use the user's own tenant_id for the UPDATE query (safety)
+        $userTenantId = (int) $user['tenant_id'];
+
         Database::query(
             "UPDATE users SET status = 'active', is_approved = 1 WHERE id = ? AND tenant_id = ?",
-            [$id, $tenantId]
+            [$id, $userTenantId]
         );
 
-        ActivityLog::log($adminId, 'admin_reactivate_user', "Reactivated user #{$id} ({$user['email']})");
+        ActivityLog::log($adminId, 'admin_reactivate_user', "Reactivated user #{$id} ({$user['email']})" . ($isSuperAdmin ? " (tenant {$userTenantId})" : ''));
         AuditLogService::logUserReactivated($adminId, $id, $user['status'] ?? 'unknown');
 
         $this->respondWithData(['reactivated' => true, 'id' => $id]);
@@ -655,13 +751,23 @@ class AdminUsersApiController extends BaseApiController
     public function reset2fa(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $user = User::findById($id);
-        if (!$user || $user['tenant_id'] != $tenantId) {
+        if (!$user) {
             $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
             return;
         }
+
+        // Regular admins can only reset 2FA for users in their own tenant
+        if (!$isSuperAdmin && $user['tenant_id'] != $tenantId) {
+            $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
+            return;
+        }
+
+        // Use the user's own tenant_id for all writes (safety)
+        $userTenantId = (int) $user['tenant_id'];
 
         $input = $this->getAllInput();
         $reason = $input['reason'] ?? 'Reset by admin';
@@ -670,21 +776,21 @@ class AdminUsersApiController extends BaseApiController
         try {
             Database::query(
                 "DELETE FROM user_totp_settings WHERE user_id = ? AND tenant_id = ?",
-                [$id, $tenantId]
+                [$id, $userTenantId]
             );
             Database::query(
                 "DELETE FROM user_backup_codes WHERE user_id = ? AND tenant_id = ?",
-                [$id, $tenantId]
+                [$id, $userTenantId]
             );
             // Clear the quick-check flag on users table
             Database::query(
                 "UPDATE users SET totp_enabled = 0 WHERE id = ? AND tenant_id = ?",
-                [$id, $tenantId]
+                [$id, $userTenantId]
             );
             // Revoke all trusted devices
             Database::query(
                 "UPDATE user_trusted_devices SET is_revoked = 1, revoked_at = NOW(), revoked_reason = 'admin_reset' WHERE user_id = ? AND tenant_id = ?",
-                [$id, $tenantId]
+                [$id, $userTenantId]
             );
         } catch (\Throwable $e) {
             error_log("[AdminUsers] Failed to reset 2FA for user #{$id}: " . $e->getMessage());
@@ -692,7 +798,7 @@ class AdminUsersApiController extends BaseApiController
             return;
         }
 
-        ActivityLog::log($adminId, 'admin_reset_2fa', "Reset 2FA for user #{$id}: {$reason}");
+        ActivityLog::log($adminId, 'admin_reset_2fa', "Reset 2FA for user #{$id}: {$reason}" . ($isSuperAdmin ? " (tenant {$userTenantId})" : ''));
         AuditLogService::log2faReset($adminId, $id, $reason);
 
         $this->respondWithData(['reset' => true, 'id' => $id]);
@@ -707,10 +813,17 @@ class AdminUsersApiController extends BaseApiController
     public function addBadge(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $user = User::findById($id);
-        if (!$user || $user['tenant_id'] != $tenantId) {
+        if (!$user) {
+            $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
+            return;
+        }
+
+        // Regular admins can only add badges for users in their own tenant
+        if (!$isSuperAdmin && $user['tenant_id'] != $tenantId) {
             $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
             return;
         }
@@ -726,7 +839,7 @@ class AdminUsersApiController extends BaseApiController
         try {
             \Nexus\Services\GamificationService::awardBadgeByKey($id, $badgeSlug);
 
-            ActivityLog::log($adminId, 'admin_award_badge', "Awarded badge '{$badgeSlug}' to user #{$id}");
+            ActivityLog::log($adminId, 'admin_award_badge', "Awarded badge '{$badgeSlug}' to user #{$id}" . ($isSuperAdmin ? " (tenant {$user['tenant_id']})" : ''));
 
             $this->respondWithData([
                 'awarded' => true,
@@ -746,18 +859,28 @@ class AdminUsersApiController extends BaseApiController
     public function removeBadge(int $id, int $badgeId): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $user = User::findById($id);
-        if (!$user || $user['tenant_id'] != $tenantId) {
+        if (!$user) {
             $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
             return;
         }
 
+        // Regular admins can only remove badges for users in their own tenant
+        if (!$isSuperAdmin && $user['tenant_id'] != $tenantId) {
+            $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
+            return;
+        }
+
+        // Use the user's own tenant_id for badge queries (safety)
+        $userTenantId = (int) $user['tenant_id'];
+
         try {
             $badge = Database::query(
                 "SELECT * FROM user_badges WHERE id = ? AND user_id = ? AND tenant_id = ?",
-                [$badgeId, $id, $tenantId]
+                [$badgeId, $id, $userTenantId]
             )->fetch();
 
             if (!$badge) {
@@ -765,9 +888,9 @@ class AdminUsersApiController extends BaseApiController
                 return;
             }
 
-            Database::query("DELETE FROM user_badges WHERE id = ? AND user_id = ? AND tenant_id = ?", [$badgeId, $id, $tenantId]);
+            Database::query("DELETE FROM user_badges WHERE id = ? AND user_id = ? AND tenant_id = ?", [$badgeId, $id, $userTenantId]);
 
-            ActivityLog::log($adminId, 'admin_remove_badge', "Removed badge #{$badgeId} from user #{$id}");
+            ActivityLog::log($adminId, 'admin_remove_badge', "Removed badge #{$badgeId} from user #{$id}" . ($isSuperAdmin ? " (tenant {$userTenantId})" : ''));
 
             $this->respondWithData(['removed' => true, 'user_id' => $id, 'badge_id' => $badgeId]);
         } catch (\Throwable $e) {
@@ -940,10 +1063,17 @@ class AdminUsersApiController extends BaseApiController
     public function impersonate(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $user = User::findById($id);
-        if (!$user || $user['tenant_id'] != $tenantId) {
+        if (!$user) {
+            $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
+            return;
+        }
+
+        // Regular admins can only impersonate users in their own tenant
+        if (!$isSuperAdmin && $user['tenant_id'] != $tenantId) {
             $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
             return;
         }
@@ -960,13 +1090,16 @@ class AdminUsersApiController extends BaseApiController
             return;
         }
 
+        // Use the user's own tenant_id for the token (so the impersonated session is in the correct tenant)
+        $userTenantId = (int) $user['tenant_id'];
+
         try {
             // Generate an access token for the target user with impersonation claim
-            $token = \Nexus\Services\TokenService::generateToken($id, $tenantId, [
+            $token = \Nexus\Services\TokenService::generateToken($id, $userTenantId, [
                 'impersonated_by' => $adminId,
             ]);
 
-            ActivityLog::log($adminId, 'admin_impersonate', "Impersonated user #{$id} ({$user['email']})");
+            ActivityLog::log($adminId, 'admin_impersonate', "Impersonated user #{$id} ({$user['email']})" . ($isSuperAdmin ? " (tenant {$userTenantId})" : ''));
             AuditLogService::logUserImpersonated($adminId, $id, $user['email']);
 
             $this->respondWithData([
@@ -989,15 +1122,11 @@ class AdminUsersApiController extends BaseApiController
     public function setSuperAdmin(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         // Only super admins can grant/revoke super admin status
-        $admin = Database::query(
-            "SELECT is_super_admin FROM users WHERE id = ?",
-            [$adminId]
-        )->fetch();
-
-        if (empty($admin['is_super_admin'])) {
+        if (!$isSuperAdmin) {
             $this->respondWithError(ApiErrorCodes::AUTH_INSUFFICIENT_PERMISSIONS, 'Only super admins can manage super admin status', null, 403);
             return;
         }
@@ -1011,9 +1140,10 @@ class AdminUsersApiController extends BaseApiController
         $grant = (bool) ($this->input('grant', false));
 
         try {
+            // Super admins can manage users across all tenants
             $user = Database::query(
-                "SELECT id, email, first_name, last_name FROM users WHERE id = ? AND tenant_id = ?",
-                [$id, $tenantId]
+                "SELECT id, email, first_name, last_name, tenant_id FROM users WHERE id = ?",
+                [$id]
             )->fetch();
 
             if (!$user) {
@@ -1027,7 +1157,7 @@ class AdminUsersApiController extends BaseApiController
             );
 
             $action = $grant ? 'grant_super_admin' : 'revoke_super_admin';
-            ActivityLog::log($adminId, $action, ($grant ? 'Granted' : 'Revoked') . " super admin for user #{$id}: {$user['email']}");
+            ActivityLog::log($adminId, $action, ($grant ? 'Granted' : 'Revoked') . " super admin for user #{$id}: {$user['email']} (tenant {$user['tenant_id']})");
             if ($grant) {
                 AuditLogService::logAdminAction('grant_super_admin', $adminId, $id, ['email' => $user['email']]);
             } else {
@@ -1048,10 +1178,17 @@ class AdminUsersApiController extends BaseApiController
     public function recheckBadges(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $user = User::findById($id);
-        if (!$user || $user['tenant_id'] != $tenantId) {
+        if (!$user) {
+            $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
+            return;
+        }
+
+        // Regular admins can only recheck badges for users in their own tenant
+        if (!$isSuperAdmin && $user['tenant_id'] != $tenantId) {
             $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
             return;
         }
@@ -1059,7 +1196,7 @@ class AdminUsersApiController extends BaseApiController
         try {
             \Nexus\Services\GamificationService::runAllBadgeChecks($id);
 
-            ActivityLog::log($adminId, 'admin_recheck_badges', "Rechecked badges for user #{$id} ({$user['email']})");
+            ActivityLog::log($adminId, 'admin_recheck_badges', "Rechecked badges for user #{$id} ({$user['email']})" . ($isSuperAdmin ? " (tenant {$user['tenant_id']})" : ''));
 
             // Fetch updated badges
             $badgeRows = Database::query(
@@ -1099,16 +1236,26 @@ class AdminUsersApiController extends BaseApiController
     public function getConsents(int $id): void
     {
         $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $user = User::findById($id);
-        if (!$user || $user['tenant_id'] != $tenantId) {
+        if (!$user) {
             $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
             return;
         }
 
+        // Regular admins can only view consents for users in their own tenant
+        if (!$isSuperAdmin && $user['tenant_id'] != $tenantId) {
+            $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
+            return;
+        }
+
+        // Use the user's own tenant_id for the GDPR service
+        $userTenantId = (int) $user['tenant_id'];
+
         try {
-            $gdprService = new \Nexus\Services\Enterprise\GdprService($tenantId);
+            $gdprService = new \Nexus\Services\Enterprise\GdprService($userTenantId);
             $consents = $gdprService->getUserConsents($id);
 
             $formatted = array_map(function ($c) {
@@ -1141,13 +1288,23 @@ class AdminUsersApiController extends BaseApiController
     public function setPassword(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $user = User::findById($id);
-        if (!$user || $user['tenant_id'] != $tenantId) {
+        if (!$user) {
             $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
             return;
         }
+
+        // Regular admins can only set passwords for users in their own tenant
+        if (!$isSuperAdmin && $user['tenant_id'] != $tenantId) {
+            $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
+            return;
+        }
+
+        // Use the user's own tenant_id for the UPDATE query (safety)
+        $userTenantId = (int) $user['tenant_id'];
 
         $input = $this->getAllInput();
         $password = $input['password'] ?? '';
@@ -1161,10 +1318,10 @@ class AdminUsersApiController extends BaseApiController
 
         Database::query(
             "UPDATE users SET password_hash = ? WHERE id = ? AND tenant_id = ?",
-            [$hashed, $id, $tenantId]
+            [$hashed, $id, $userTenantId]
         );
 
-        ActivityLog::log($adminId, 'admin_set_password', "Admin set password for user #{$id} ({$user['email']})");
+        ActivityLog::log($adminId, 'admin_set_password', "Admin set password for user #{$id} ({$user['email']})" . ($isSuperAdmin ? " (tenant {$userTenantId})" : ''));
         AuditLogService::logAdminAction('admin_set_password', $adminId, $id, ['email' => $user['email']]);
 
         $this->respondWithData(['password_set' => true, 'id' => $id]);
@@ -1178,13 +1335,23 @@ class AdminUsersApiController extends BaseApiController
     public function sendPasswordReset(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $user = User::findById($id);
-        if (!$user || $user['tenant_id'] != $tenantId) {
+        if (!$user) {
             $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
             return;
         }
+
+        // Regular admins can only send password resets for users in their own tenant
+        if (!$isSuperAdmin && $user['tenant_id'] != $tenantId) {
+            $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
+            return;
+        }
+
+        // Use the user's own tenant_id for the UPDATE query (safety)
+        $userTenantId = (int) $user['tenant_id'];
 
         try {
             $token = bin2hex(random_bytes(32));
@@ -1192,7 +1359,7 @@ class AdminUsersApiController extends BaseApiController
 
             Database::query(
                 "UPDATE users SET reset_token = ?, reset_token_expiry = ? WHERE id = ? AND tenant_id = ?",
-                [$token, $expiry, $id, $tenantId]
+                [$token, $expiry, $id, $userTenantId]
             );
 
             $tenant = TenantContext::get();
@@ -1213,7 +1380,7 @@ class AdminUsersApiController extends BaseApiController
             $mailer = new \Nexus\Core\Mailer();
             $mailer->send($user['email'], "Password Reset - {$tenantName}", $html);
 
-            ActivityLog::log($adminId, 'admin_send_password_reset', "Sent password reset email to user #{$id} ({$user['email']})");
+            ActivityLog::log($adminId, 'admin_send_password_reset', "Sent password reset email to user #{$id} ({$user['email']})" . ($isSuperAdmin ? " (tenant {$userTenantId})" : ''));
 
             $this->respondWithData(['sent' => true, 'id' => $id]);
         } catch (\Throwable $e) {
@@ -1229,10 +1396,17 @@ class AdminUsersApiController extends BaseApiController
     public function sendWelcomeEmail(int $id): void
     {
         $adminId = $this->requireAdmin();
+        $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
         $user = User::findById($id);
-        if (!$user || $user['tenant_id'] != $tenantId) {
+        if (!$user) {
+            $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
+            return;
+        }
+
+        // Regular admins can only send welcome emails to users in their own tenant
+        if (!$isSuperAdmin && $user['tenant_id'] != $tenantId) {
             $this->respondWithError(ApiErrorCodes::RESOURCE_NOT_FOUND, 'User not found', null, 404);
             return;
         }
@@ -1273,7 +1447,7 @@ class AdminUsersApiController extends BaseApiController
             $mailer = new \Nexus\Core\Mailer();
             $mailer->send($user['email'], $subject, $html);
 
-            ActivityLog::log($adminId, 'admin_resend_welcome', "Resent welcome email to user #{$id} ({$user['email']})");
+            ActivityLog::log($adminId, 'admin_resend_welcome', "Resent welcome email to user #{$id} ({$user['email']})" . ($isSuperAdmin ? " (tenant {$user['tenant_id']})" : ''));
 
             $this->respondWithData(['sent' => true, 'id' => $id]);
         } catch (\Throwable $e) {


### PR DESCRIPTION
## Summary
- **All 8 admin API controllers** now support cross-tenant access for super admins (~80+ methods total)
- Super admin on `timebank.global` can now view, moderate, and manage data from **all tenants** (including tenant 6 for Matt)
- All 4 React moderation components updated with tenant filter dropdown + TENANT column for super admins

**Root Cause:** All admin API controllers hardcoded tenant scoping via `TenantContext::getId()` in every query. When a super admin logged in on `timebank.global` (tenant 4), all queries filtered by `tenant_id = 4`, making data from other tenants (e.g. tenant 2, 6) invisible and actions like delete/hide fail silently with "not found" errors.

**Prevention:** The cross-tenant pattern is now established consistently across all 8 admin controllers — each method checks `$this->isAuthenticatedSuperAdmin()` and conditionally bypasses tenant scoping. This same pattern should be applied to any new admin endpoints going forward.

## Controllers Updated
| Controller | Methods |
|---|---|
| AdminFeedApiController | 5 |
| AdminCommentsApiController | 4 |
| AdminReviewsApiController | 5 |
| AdminReportsApiController | 5 |
| AdminListingsApiController | 4 |
| AdminUsersApiController | 18 |
| AdminGroupsApiController | 25+ |
| AdminBrokerApiController | 19 |

## Pattern
- Each method checks `isAuthenticatedSuperAdmin()` and bypasses `tenant_id` scoping
- Optional `?tenant_id=X` query param allows filtering to a specific tenant
- Action methods (delete/hide/update) use the record's own `tenant_id` for safety
- React components show tenant name column and tenant filter dropdown for super admins

## Test plan
- [ ] Log in as super admin on `timebank.global`
- [ ] Verify Feed Moderation shows posts from all tenants
- [ ] Verify Comments Moderation shows comments from all tenants
- [ ] Verify Reviews Moderation shows reviews from all tenants
- [ ] Verify Reports Management shows reports from all tenants
- [ ] Test tenant filter dropdown filters correctly per tenant
- [ ] Test hide/delete actions work on posts from other tenants (e.g., tenant 6)
- [ ] Verify regular tenant admins still only see their own tenant data
- [ ] Verify TypeScript builds cleanly (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)