### PR TITLE
fix(admin): default moderation pages to current tenant, prevent cross-tenant bleed

### DIFF
--- a/react-frontend/src/admin/modules/moderation/CommentsModeration.tsx
+++ b/react-frontend/src/admin/modules/moderation/CommentsModeration.tsx
@@ -24,6 +24,7 @@ import { Search, RefreshCw, EyeOff, Trash2 } from 'lucide-react';
 import { usePageTitle } from '@/hooks/usePageTitle';
 import { useApi } from '@/hooks/useApi';
 import { useAuth } from '@/contexts/AuthContext';
+import { useTenant } from '@/contexts/TenantContext';
 import { useToast } from '@/contexts/ToastContext';
 import PageHeader from '@/admin/components/PageHeader';
 import ConfirmModal from '@/admin/components/ConfirmModal';
@@ -44,6 +45,8 @@ export default function CommentsModeration() {
 
   const toast = useToast();
   const { user } = useAuth();
+  const { tenant } = useTenant();
+  const currentTenantId = tenant?.id ? String(tenant.id) : '';
   const userRecord = user as Record<string, unknown> | null;
   const isSuperAdmin =
     (user?.role as string) === 'super_admin' ||
@@ -53,10 +56,10 @@ export default function CommentsModeration() {
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState('');
   const [contentTypeFilter, setContentTypeFilter] = useState('');
-  const [tenantFilter, setTenantFilter] = useState('');
+  const [tenantFilter, setTenantFilter] = useState(currentTenantId);
   const [activeSearch, setActiveSearch] = useState('');
   const [activeContentType, setActiveContentType] = useState('');
-  const [activeTenant, setActiveTenant] = useState('');
+  const [activeTenant, setActiveTenant] = useState(currentTenantId);
   const [actionLoading, setActionLoading] = useState(false);
   const [confirmAction, setConfirmAction] = useState<{
     type: 'hide' | 'delete';
@@ -86,7 +89,7 @@ export default function CommentsModeration() {
     params.append('limit', '20');
     if (activeSearch) params.append('search', activeSearch);
     if (activeContentType) params.append('content_type', activeContentType);
-    if (isSuperAdmin && activeTenant) params.append('tenant_id', activeTenant);
+    if (isSuperAdmin && activeTenant && activeTenant !== 'all') params.append('tenant_id', activeTenant);
     return params.toString();
   };
 
@@ -105,10 +108,10 @@ export default function CommentsModeration() {
   const handleClear = () => {
     setSearch('');
     setContentTypeFilter('');
-    setTenantFilter('');
+    setTenantFilter(currentTenantId);
     setActiveSearch('');
     setActiveContentType('');
-    setActiveTenant('');
+    setActiveTenant(currentTenantId);
     setPage(1);
   };
 
@@ -272,7 +275,7 @@ export default function CommentsModeration() {
             className="w-full sm:w-56"
           >
             {[
-              <SelectItem key="">All Tenants</SelectItem>,
+              <SelectItem key="all">All Tenants</SelectItem>,
               ...tenants.map((t) => (
                 <SelectItem key={t.id.toString()}>
                   {t.name}
@@ -295,7 +298,7 @@ export default function CommentsModeration() {
       {meta && (
         <div className="text-sm text-default-500">
           Showing {comments.length} of {meta.total ?? comments.length} comments
-          {isSuperAdmin && !activeTenant && ' (all tenants)'}
+          {isSuperAdmin && activeTenant === 'all' && ' (all tenants)'}
         </div>
       )}
 

--- a/react-frontend/src/admin/modules/moderation/FeedModeration.tsx
+++ b/react-frontend/src/admin/modules/moderation/FeedModeration.tsx
@@ -24,6 +24,7 @@ import { Search, RefreshCw, EyeOff, Trash2 } from 'lucide-react';
 import { usePageTitle } from '@/hooks/usePageTitle';
 import { useApi } from '@/hooks/useApi';
 import { useAuth } from '@/contexts/AuthContext';
+import { useTenant } from '@/contexts/TenantContext';
 import { useToast } from '@/contexts/ToastContext';
 import PageHeader from '@/admin/components/PageHeader';
 import ConfirmModal from '@/admin/components/ConfirmModal';
@@ -44,6 +45,8 @@ export default function FeedModeration() {
 
   const toast = useToast();
   const { user } = useAuth();
+  const { tenant } = useTenant();
+  const currentTenantId = tenant?.id ? String(tenant.id) : '';
   const userRecord = user as Record<string, unknown> | null;
   const isSuperAdmin =
     (user?.role as string) === 'super_admin' ||
@@ -53,10 +56,10 @@ export default function FeedModeration() {
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState('');
   const [typeFilter, setTypeFilter] = useState('');
-  const [tenantFilter, setTenantFilter] = useState('');
+  const [tenantFilter, setTenantFilter] = useState(currentTenantId);
   const [activeSearch, setActiveSearch] = useState('');
   const [activeType, setActiveType] = useState('');
-  const [activeTenant, setActiveTenant] = useState('');
+  const [activeTenant, setActiveTenant] = useState(currentTenantId);
   const [actionLoading, setActionLoading] = useState(false);
   const [confirmAction, setConfirmAction] = useState<{
     type: 'hide' | 'delete';
@@ -86,7 +89,7 @@ export default function FeedModeration() {
     params.append('limit', '20');
     if (activeSearch) params.append('search', activeSearch);
     if (activeType) params.append('type', activeType);
-    if (isSuperAdmin && activeTenant) params.append('tenant_id', activeTenant);
+    if (isSuperAdmin && activeTenant && activeTenant !== 'all') params.append('tenant_id', activeTenant);
     return params.toString();
   };
 
@@ -105,10 +108,10 @@ export default function FeedModeration() {
   const handleClear = () => {
     setSearch('');
     setTypeFilter('');
-    setTenantFilter('');
+    setTenantFilter(currentTenantId);
     setActiveSearch('');
     setActiveType('');
-    setActiveTenant('');
+    setActiveTenant(currentTenantId);
     setPage(1);
   };
 
@@ -281,7 +284,7 @@ export default function FeedModeration() {
             className="w-full sm:w-56"
           >
             {[
-              <SelectItem key="">All Tenants</SelectItem>,
+              <SelectItem key="all">All Tenants</SelectItem>,
               ...tenants.map((t) => (
                 <SelectItem key={t.id.toString()}>
                   {t.name}
@@ -304,7 +307,7 @@ export default function FeedModeration() {
       {meta && (
         <div className="text-sm text-default-500">
           Showing {posts.length} of {meta.total ?? posts.length} posts
-          {isSuperAdmin && !activeTenant && ' (all tenants)'}
+          {isSuperAdmin && activeTenant === 'all' && ' (all tenants)'}
         </div>
       )}
 

--- a/react-frontend/src/admin/modules/moderation/ReportsManagement.tsx
+++ b/react-frontend/src/admin/modules/moderation/ReportsManagement.tsx
@@ -26,6 +26,7 @@ import { Search, RefreshCw, CheckCircle2, XCircle, AlertCircle, Flag } from 'luc
 import { usePageTitle } from '@/hooks/usePageTitle';
 import { useApi } from '@/hooks/useApi';
 import { useAuth } from '@/contexts/AuthContext';
+import { useTenant } from '@/contexts/TenantContext';
 import { useToast } from '@/contexts/ToastContext';
 import PageHeader from '@/admin/components/PageHeader';
 import ConfirmModal from '@/admin/components/ConfirmModal';
@@ -54,6 +55,8 @@ export default function ReportsManagement() {
 
   const toast = useToast();
   const { user } = useAuth();
+  const { tenant } = useTenant();
+  const currentTenantId = tenant?.id ? String(tenant.id) : '';
   const userRecord = user as Record<string, unknown> | null;
   const isSuperAdmin =
     (user?.role as string) === 'super_admin' ||
@@ -64,11 +67,11 @@ export default function ReportsManagement() {
   const [search, setSearch] = useState('');
   const [typeFilter, setTypeFilter] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
-  const [tenantFilter, setTenantFilter] = useState('');
+  const [tenantFilter, setTenantFilter] = useState(currentTenantId);
   const [activeSearch, setActiveSearch] = useState('');
   const [activeType, setActiveType] = useState('');
   const [activeStatus, setActiveStatus] = useState('');
-  const [activeTenant, setActiveTenant] = useState('');
+  const [activeTenant, setActiveTenant] = useState(currentTenantId);
   const [actionLoading, setActionLoading] = useState(false);
   const [confirmAction, setConfirmAction] = useState<{
     type: 'resolve' | 'dismiss';
@@ -104,7 +107,7 @@ export default function ReportsManagement() {
     if (activeSearch) params.append('search', activeSearch);
     if (activeType) params.append('type', activeType);
     if (activeStatus) params.append('status', activeStatus);
-    if (isSuperAdmin && activeTenant) params.append('tenant_id', activeTenant);
+    if (isSuperAdmin && activeTenant && activeTenant !== 'all') params.append('tenant_id', activeTenant);
     return params.toString();
   };
 
@@ -125,11 +128,11 @@ export default function ReportsManagement() {
     setSearch('');
     setTypeFilter('');
     setStatusFilter('');
-    setTenantFilter('');
+    setTenantFilter(currentTenantId);
     setActiveSearch('');
     setActiveType('');
     setActiveStatus('');
-    setActiveTenant('');
+    setActiveTenant(currentTenantId);
     setPage(1);
   };
 
@@ -373,7 +376,7 @@ export default function ReportsManagement() {
             className="w-full sm:w-56"
           >
             {[
-              <SelectItem key="">All Tenants</SelectItem>,
+              <SelectItem key="all">All Tenants</SelectItem>,
               ...tenants.map((t) => (
                 <SelectItem key={t.id.toString()}>
                   {t.name}
@@ -396,7 +399,7 @@ export default function ReportsManagement() {
       {meta && (
         <div className="text-sm text-default-500">
           Showing {reports.length} of {meta.total ?? reports.length} reports
-          {isSuperAdmin && !activeTenant && ' (all tenants)'}
+          {isSuperAdmin && activeTenant === 'all' && ' (all tenants)'}
         </div>
       )}
 

--- a/react-frontend/src/admin/modules/moderation/ReviewsModeration.tsx
+++ b/react-frontend/src/admin/modules/moderation/ReviewsModeration.tsx
@@ -24,6 +24,7 @@ import { Search, RefreshCw, Flag, EyeOff, Trash2, Star } from 'lucide-react';
 import { usePageTitle } from '@/hooks/usePageTitle';
 import { useApi } from '@/hooks/useApi';
 import { useAuth } from '@/contexts/AuthContext';
+import { useTenant } from '@/contexts/TenantContext';
 import { useToast } from '@/contexts/ToastContext';
 import PageHeader from '@/admin/components/PageHeader';
 import ConfirmModal from '@/admin/components/ConfirmModal';
@@ -45,6 +46,8 @@ export default function ReviewsModeration() {
 
   const toast = useToast();
   const { user } = useAuth();
+  const { tenant } = useTenant();
+  const currentTenantId = tenant?.id ? String(tenant.id) : '';
   const userRecord = user as Record<string, unknown> | null;
   const isSuperAdmin =
     (user?.role as string) === 'super_admin' ||
@@ -54,10 +57,10 @@ export default function ReviewsModeration() {
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState('');
   const [ratingFilter, setRatingFilter] = useState('');
-  const [tenantFilter, setTenantFilter] = useState('');
+  const [tenantFilter, setTenantFilter] = useState(currentTenantId);
   const [activeSearch, setActiveSearch] = useState('');
   const [activeRating, setActiveRating] = useState('');
-  const [activeTenant, setActiveTenant] = useState('');
+  const [activeTenant, setActiveTenant] = useState(currentTenantId);
   const [actionLoading, setActionLoading] = useState(false);
   const [confirmAction, setConfirmAction] = useState<{
     type: 'flag' | 'hide' | 'delete';
@@ -87,7 +90,7 @@ export default function ReviewsModeration() {
     params.append('limit', '20');
     if (activeSearch) params.append('search', activeSearch);
     if (activeRating) params.append('rating', activeRating);
-    if (isSuperAdmin && activeTenant) params.append('tenant_id', activeTenant);
+    if (isSuperAdmin && activeTenant && activeTenant !== 'all') params.append('tenant_id', activeTenant);
     return params.toString();
   };
 
@@ -106,10 +109,10 @@ export default function ReviewsModeration() {
   const handleClear = () => {
     setSearch('');
     setRatingFilter('');
-    setTenantFilter('');
+    setTenantFilter(currentTenantId);
     setActiveSearch('');
     setActiveRating('');
-    setActiveTenant('');
+    setActiveTenant(currentTenantId);
     setPage(1);
   };
 
@@ -321,7 +324,7 @@ export default function ReviewsModeration() {
             className="w-full sm:w-56"
           >
             {[
-              <SelectItem key="">All Tenants</SelectItem>,
+              <SelectItem key="all">All Tenants</SelectItem>,
               ...tenants.map((t) => (
                 <SelectItem key={t.id.toString()}>
                   {t.name}
@@ -344,7 +347,7 @@ export default function ReviewsModeration() {
       {meta && (
         <div className="text-sm text-default-500">
           Showing {reviews.length} of {meta.total ?? reviews.length} reviews
-          {isSuperAdmin && !activeTenant && ' (all tenants)'}
+          {isSuperAdmin && activeTenant === 'all' && ' (all tenants)'}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Hotfix for cross-tenant data visibility issue introduced in PR #25
- Super admin moderation pages now default to **current tenant** instead of showing all tenants
- "All Tenants" is still available as an explicit opt-in via the tenant filter dropdown

**Root Cause:** The 4 moderation React components (Feed, Comments, Reviews, Reports) initialized `tenantFilter` and `activeTenant` state to empty string `''`. Since `buildQueryString` only sent the `tenant_id` param when the value was truthy, an empty default meant no tenant filter was applied — causing the API to return data from ALL tenants on page load.

**Prevention:** Default state now uses `currentTenantId` from `useTenant()` context. The "All Tenants" dropdown option uses the explicit key `'all'` instead of empty string, so cross-tenant view requires deliberate selection. `handleClear` also resets to current tenant rather than empty.

## Test plan
- [ ] Visit `/admin/moderation/feed` as super admin on `timebank.global` — should show only timebank.global posts by default
- [ ] Select "All Tenants" from dropdown and click Apply — should show all tenants' data
- [ ] Click "Clear" — should reset back to current tenant only
- [ ] Verify same behavior on Comments, Reviews, and Reports moderation pages
- [ ] Verify regular (non-super) admins see no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)