### PR TITLE
fix(admin): default super admin to current tenant, not all tenants

### DIFF
--- a/docs/audits/admin-panel-users-tenant2-2026-02-24.md
+++ b/docs/audits/admin-panel-users-tenant2-2026-02-24.md
@@ -1,0 +1,182 @@
+# Admin Panel Users — Tenant 2 Audit
+
+**Date:** 2026-02-24
+**Reported by:** User (live admin panel observation)
+**Priority:** P0 — breaks Tenant 2 users list for prospects
+
+---
+
+## Symptoms
+
+- Admin Panel → Tenant 2 → Users page shows **test users from other tenants** and one new signup.
+- **Real Tenant 2 users are NOT showing** at all.
+- Issue introduced by sweeping code changes on 2026-02-24.
+
+---
+
+## Root Cause
+
+### Primary: Super admin tenant bypass removes ALL tenant scoping (P0)
+
+**Commit:** `634e76fe` — "enable super admin cross-tenant access for all moderation features"
+
+This commit changed all 8 admin API controllers to bypass tenant scoping for super admins.
+In `AdminUsersApiController::index()` (lines 75-85):
+
+```php
+if ($isSuperAdmin) {
+    if ($filterTenantId) {
+        $conditions[] = 'u.tenant_id = ?';
+        $params[] = $filterTenantId;
+    }
+    // No tenant filter = all tenants for super admin  ← BUG: unsafe default
+} else {
+    $conditions[] = 'u.tenant_id = ?';
+    $params[] = $tenantId;
+}
+```
+
+**What happens:**
+1. Super admin logs into Tenant 2 admin panel.
+2. React sends `X-Tenant-ID: 2` header → `TenantContext::getId()` returns `2`.
+3. `$isSuperAdmin = true` (JWT claim or DB lookup).
+4. Frontend `UserList.tsx` does NOT send `?tenant_id=X` query param.
+5. `$filterTenantId = null` → inner condition is skipped.
+6. **NO tenant condition is added to the WHERE clause.**
+7. Query returns ALL users across ALL tenants.
+8. `ORDER BY created_at DESC LIMIT 20` shows newest users first.
+9. Recently created test/seed users from other tenants fill the first page.
+10. Real Tenant 2 users (created earlier) are pushed to later pages.
+
+**Evidence:**
+- `AdminUsersApiController.php:75-85` — no tenant filter for super admin without `?tenant_id`.
+- `UserList.tsx:94-99` — params object has no `tenant_id` field.
+- Same pattern confirmed in all 8 admin controllers.
+
+### Secondary: Frontend never sends tenant_id param (P2)
+
+`UserList.tsx` (line 94-99) constructs params without `tenant_id`:
+```typescript
+const params: UserListParams = {
+  page,
+  limit: 20,
+  search: search || undefined,
+  status: filter === 'all' ? undefined : filter,
+};
+```
+
+While the `X-Tenant-ID` header IS sent (via `api.ts` line 251-253), the backend ignores
+it for super admins in the `index()` method, relying only on `?tenant_id` query param.
+
+### Tertiary: Same bug exists in all 8 admin controllers (P1)
+
+All controllers modified in commit `634e76fe` have the identical pattern:
+- AdminBrokerApiController
+- AdminCommentsApiController
+- AdminFeedApiController
+- AdminGroupsApiController
+- AdminListingsApiController
+- AdminReportsApiController
+- AdminReviewsApiController
+- AdminUsersApiController
+
+---
+
+## Fix Strategy
+
+### Backend Fix (all controllers)
+
+Change the super admin default from "no tenant filter" to "current tenant context":
+
+```php
+if ($isSuperAdmin) {
+    // Super admins default to current tenant; use ?tenant_id=all for cross-tenant
+    $effectiveTenantId = $filterTenantId ?: $tenantId;
+    if ($effectiveTenantId) {
+        $conditions[] = 'u.tenant_id = ?';
+        $params[] = $effectiveTenantId;
+    }
+} else {
+    $conditions[] = 'u.tenant_id = ?';
+    $params[] = $tenantId;
+}
+```
+
+And update `$filterTenantId` parsing to support `?tenant_id=all`:
+```php
+$filterTenantIdRaw = $_GET['tenant_id'] ?? null;
+$filterTenantId = ($filterTenantIdRaw && $filterTenantIdRaw !== 'all')
+    ? (int) $filterTenantIdRaw
+    : ($filterTenantIdRaw === 'all' ? null : null);
+// i.e. ?tenant_id=all → null (show all), ?tenant_id=2 → 2, absent → use $tenantId
+```
+
+### Frontend Fix (UserList.tsx)
+
+Pass `tenant_id` as a defensive measure so the backend always has an explicit scope.
+
+---
+
+## Files Changed (11 modified, 1 new)
+
+| File | Change |
+|------|--------|
+| `src/Controllers/Api/BaseApiController.php` | **NEW METHOD** `resolveAdminTenantFilter()` — centralized tenant filter logic |
+| `src/Controllers/Api/AdminUsersApiController.php` | Use `resolveAdminTenantFilter()` in `index()` |
+| `src/Controllers/Api/AdminBrokerApiController.php` | Use `resolveAdminTenantFilter()` in 7 list/stats methods |
+| `src/Controllers/Api/AdminCommentsApiController.php` | Use `resolveAdminTenantFilter()` in 4 methods |
+| `src/Controllers/Api/AdminFeedApiController.php` | Use `resolveAdminTenantFilter()` in 5 methods |
+| `src/Controllers/Api/AdminGroupsApiController.php` | Use `resolveAdminTenantFilter()` in 9 methods |
+| `src/Controllers/Api/AdminListingsApiController.php` | Use `resolveAdminTenantFilter()` in `index()` |
+| `src/Controllers/Api/AdminReportsApiController.php` | Use `resolveAdminTenantFilter()` in `index()` and `stats()` |
+| `src/Controllers/Api/AdminReviewsApiController.php` | Use `resolveAdminTenantFilter()` in `index()` |
+| `react-frontend/src/admin/api/types.ts` | Add `tenant_id` to `UserListParams` interface |
+| `react-frontend/src/admin/modules/users/UserList.tsx` | Pass `tenant_id` from tenant context in API call |
+| `tests/Unit/ResolveAdminTenantFilterTest.php` | **NEW** 12 regression tests for tenant filter logic |
+
+**Net change:** -160 lines (216 insertions, 376 deletions) — the fix actually reduces code by consolidating duplicated logic.
+
+---
+
+## Verification Steps (Manual)
+
+1. **Tenant 2 Users page** — Navigate to Admin → Users while on Tenant 2. Should show ONLY Tenant 2 users.
+2. **Tenant 1 Users page** — Switch to Tenant 1 → Admin → Users. Should show only Tenant 1 users.
+3. **Cross-tenant opt-in** — As super admin, manually add `?tenant_id=all` to the URL. Should show ALL tenants.
+4. **Specific tenant filter** — Add `?tenant_id=3` to URL. Should show only Tenant 3 users.
+5. **Regular admin** — Log in as a regular tenant admin (not super admin). Should always see only own tenant.
+6. **Pagination** — Navigate pages. All pages should stay tenant-scoped.
+7. **Search** — Search for a user. Results should be tenant-scoped.
+8. **New signup** — Verify today's new signup appears under the correct tenant only.
+
+---
+
+## Test Results
+
+### PHPUnit Regression Tests — ALL PASS
+
+```
+PHPUnit 10.5.63, PHP 8.2.12
+Tests: 12, Assertions: 12
+
+✔ Regular admin always scoped to own tenant
+✔ Regular admin cannot override with query param
+✔ Regular admin cannot use all tenants
+✔ Super admin defaults to current tenant            ← KEY REGRESSION TEST
+✔ Super admin defaults to current tenant for tenant 1
+✔ Super admin defaults to current tenant for tenant 4
+✔ Super admin can filter to specific tenant
+✔ Super admin can filter to own tenant explicitly
+✔ Super admin can explicitly request all tenants
+✔ Non numeric tenant id treated as no filter
+✔ Empty string tenant id defaults to current tenant
+✔ Zero tenant id treated as no filter
+```
+
+### PHP Syntax Check — ALL PASS
+
+All 9 modified PHP files pass `php -l` syntax validation.
+
+### TypeScript Compilation — PASS
+
+`tsc --noEmit` completes with zero errors.

--- a/react-frontend/src/admin/api/types.ts
+++ b/react-frontend/src/admin/api/types.ts
@@ -157,6 +157,7 @@ export interface UserListParams {
   search?: string;
   sort?: string;
   order?: 'asc' | 'desc';
+  tenant_id?: number | string;
 }
 
 export interface CreateUserPayload {

--- a/react-frontend/src/admin/modules/users/UserList.tsx
+++ b/react-frontend/src/admin/modules/users/UserList.tsx
@@ -56,7 +56,7 @@ import type { AdminUser, UserListParams } from '../../api/types';
 
 export function UserList() {
   usePageTitle('Admin - Users');
-  const { tenantPath } = useTenant();
+  const { tenantPath, tenant } = useTenant();
   const toast = useToast();
   const { user: currentUser } = useAuth();
   const isSuperAdmin = (currentUser as Record<string, unknown> | null)?.is_super_admin === true || (currentUser?.role as string) === 'super_admin';
@@ -96,6 +96,7 @@ export function UserList() {
       limit: 20,
       search: search || undefined,
       status: filter === 'all' ? undefined : filter as UserListParams['status'],
+      tenant_id: tenant?.id,
     };
 
     const res = await adminUsers.list(params);
@@ -111,7 +112,7 @@ export function UserList() {
       }
     }
     setLoading(false);
-  }, [page, filter, search]);
+  }, [page, filter, search, tenant?.id]);
 
   useEffect(() => {
     loadUsers();

--- a/src/Controllers/Api/AdminBrokerApiController.php
+++ b/src/Controllers/Api/AdminBrokerApiController.php
@@ -55,21 +55,9 @@ class AdminBrokerApiController extends BaseApiController
         $this->requireBrokerAdmin();
         $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
-
-        // Determine tenant scoping
-        if ($isSuperAdmin) {
-            if ($filterTenantId) {
-                $tenantWhere = 'tenant_id = ?';
-                $tenantParams = [$filterTenantId];
-            } else {
-                $tenantWhere = '1=1';
-                $tenantParams = [];
-            }
-        } else {
-            $tenantWhere = 'tenant_id = ?';
-            $tenantParams = [$tenantId];
-        }
+        $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+        $tenantWhere = $effectiveTenantId !== null ? 'tenant_id = ?' : '1=1';
+        $tenantParams = $effectiveTenantId !== null ? [$effectiveTenantId] : [];
 
         // Pending exchanges
         $pendingExchanges = 0;
@@ -151,8 +139,8 @@ class AdminBrokerApiController extends BaseApiController
         // Recent broker activity (last 20 actions)
         $recentActivity = [];
         try {
-            $actWhere = $isSuperAdmin && !$filterTenantId ? '1=1' : 'al.tenant_id = ?';
-            $actParams = $isSuperAdmin && !$filterTenantId ? [] : ($filterTenantId ? [$filterTenantId] : [$tenantId]);
+            $actWhere = $effectiveTenantId !== null ? 'al.tenant_id = ?' : '1=1';
+            $actParams = $effectiveTenantId !== null ? [$effectiveTenantId] : [];
             $recentActivity = Database::query(
                 "SELECT al.*, u.first_name, u.last_name, t.name as tenant_name
                  FROM activity_logs al
@@ -197,7 +185,6 @@ class AdminBrokerApiController extends BaseApiController
         $page = $this->queryInt('page', 1, 1);
         $perPage = $this->queryInt('per_page', 20, 1, 100);
         $status = $this->query('status');
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
         $offset = ($page - 1) * $perPage;
 
         try {
@@ -205,15 +192,10 @@ class AdminBrokerApiController extends BaseApiController
             $conditions = [];
             $params = [];
 
-            if ($isSuperAdmin) {
-                if ($filterTenantId) {
-                    $conditions[] = 'er.tenant_id = ?';
-                    $params[] = $filterTenantId;
-                }
-                // No tenant filter = all tenants for super admin
-            } else {
+            $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+            if ($effectiveTenantId !== null) {
                 $conditions[] = 'er.tenant_id = ?';
-                $params[] = $tenantId;
+                $params[] = $effectiveTenantId;
             }
 
             if ($status && $status !== 'all') {
@@ -380,22 +362,16 @@ class AdminBrokerApiController extends BaseApiController
         $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
         $riskLevel = $this->query('risk_level');
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
         try {
             $conditions = [];
             $params = [];
 
             // Tenant scoping
-            if ($isSuperAdmin) {
-                if ($filterTenantId) {
-                    $conditions[] = 'rt.tenant_id = ?';
-                    $params[] = $filterTenantId;
-                }
-                // No filter = all tenants for super admin
-            } else {
+            $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+            if ($effectiveTenantId !== null) {
                 $conditions[] = 'rt.tenant_id = ?';
-                $params[] = $tenantId;
+                $params[] = $effectiveTenantId;
             }
 
             if ($riskLevel && $riskLevel !== 'all') {
@@ -444,7 +420,6 @@ class AdminBrokerApiController extends BaseApiController
         $page = $this->queryInt('page', 1, 1);
         $perPage = $this->queryInt('per_page', 20, 1, 100);
         $filter = $this->query('filter', 'all');
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
         $offset = ($page - 1) * $perPage;
 
         try {
@@ -452,15 +427,10 @@ class AdminBrokerApiController extends BaseApiController
             $params = [];
 
             // Tenant scoping
-            if ($isSuperAdmin) {
-                if ($filterTenantId) {
-                    $conditions[] = 'bmc.tenant_id = ?';
-                    $params[] = $filterTenantId;
-                }
-                // No filter = all tenants for super admin
-            } else {
+            $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+            if ($effectiveTenantId !== null) {
                 $conditions[] = 'bmc.tenant_id = ?';
-                $params[] = $tenantId;
+                $params[] = $effectiveTenantId;
             }
 
             if ($filter === 'unreviewed') {
@@ -565,22 +535,16 @@ class AdminBrokerApiController extends BaseApiController
         $this->requireBrokerAdmin();
         $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
         try {
             $conditions = ['umr.under_monitoring = 1'];
             $params = [];
 
             // Tenant scoping
-            if ($isSuperAdmin) {
-                if ($filterTenantId) {
-                    $conditions[] = 'umr.tenant_id = ?';
-                    $params[] = $filterTenantId;
-                }
-                // No filter = all tenants for super admin
-            } else {
+            $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+            if ($effectiveTenantId !== null) {
                 $conditions[] = 'umr.tenant_id = ?';
-                $params[] = $tenantId;
+                $params[] = $effectiveTenantId;
             }
 
             $where = implode(' AND ', $conditions);
@@ -927,7 +891,6 @@ class AdminBrokerApiController extends BaseApiController
         $search = $this->query('search');
         $from = $this->query('from');
         $to = $this->query('to');
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
         $offset = ($page - 1) * $perPage;
 
         try {
@@ -935,15 +898,10 @@ class AdminBrokerApiController extends BaseApiController
             $params = [];
 
             // Tenant scoping
-            if ($isSuperAdmin) {
-                if ($filterTenantId) {
-                    $conditions[] = 'bra.tenant_id = ?';
-                    $params[] = $filterTenantId;
-                }
-                // No filter = all tenants for super admin
-            } else {
+            $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+            if ($effectiveTenantId !== null) {
                 $conditions[] = 'bra.tenant_id = ?';
-                $params[] = $tenantId;
+                $params[] = $effectiveTenantId;
             }
 
             if ($decision && $decision !== 'all') {
@@ -1263,7 +1221,7 @@ class AdminBrokerApiController extends BaseApiController
         $this->requireBrokerAdmin();
         $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
+        $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
 
         $defaults = [
             // Messaging
@@ -1306,15 +1264,11 @@ class AdminBrokerApiController extends BaseApiController
         ];
 
         // Determine which tenant's config to load
-        if ($isSuperAdmin && $filterTenantId) {
-            $scopeTenantId = $filterTenantId;
-        } else {
-            $scopeTenantId = $tenantId;
-        }
+        $scopeTenantId = $effectiveTenantId ?? $tenantId;
 
         try {
-            // Super admin with no tenant filter: show all tenant configs
-            if ($isSuperAdmin && !$filterTenantId) {
+            // Super admin with explicit ?tenant_id=all: show all tenant configs
+            if ($effectiveTenantId === null) {
                 $rows = Database::query(
                     "SELECT ts.tenant_id, ts.setting_value, t.name as tenant_name
                      FROM tenant_settings ts

--- a/src/Controllers/Api/AdminCommentsApiController.php
+++ b/src/Controllers/Api/AdminCommentsApiController.php
@@ -48,21 +48,15 @@ class AdminCommentsApiController extends BaseApiController
         $offset = ($page - 1) * $limit;
         $targetType = $_GET['target_type'] ?? null;
         $search = $_GET['search'] ?? null;
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
         $conditions = [];
         $params = [];
 
-        // Tenant scoping: super admins can see all tenants or filter by one
-        if ($isSuperAdmin) {
-            if ($filterTenantId) {
-                $conditions[] = 'c.tenant_id = ?';
-                $params[] = $filterTenantId;
-            }
-            // No tenant filter = all tenants for super admin
-        } else {
+        // Tenant scoping: defaults to current tenant, super admins can pass ?tenant_id=all
+        $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+        if ($effectiveTenantId !== null) {
             $conditions[] = 'c.tenant_id = ?';
-            $params[] = $tenantId;
+            $params[] = $effectiveTenantId;
         }
 
         // Target type filter
@@ -136,30 +130,21 @@ class AdminCommentsApiController extends BaseApiController
         $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
-        // Super admins can view comments from any tenant
-        if ($isSuperAdmin) {
-            $query = "SELECT c.*,
-                             u.name as user_name,
-                             u.email as user_email,
-                             u.avatar_url as user_avatar,
-                             t.name as tenant_name
-                      FROM comments c
-                      LEFT JOIN users u ON c.user_id = u.id
-                      LEFT JOIN tenants t ON c.tenant_id = t.id
-                      WHERE c.id = ?";
-            $stmt = Database::query($query, [$id]);
-        } else {
-            $query = "SELECT c.*,
-                             u.name as user_name,
-                             u.email as user_email,
-                             u.avatar_url as user_avatar,
-                             t.name as tenant_name
-                      FROM comments c
-                      LEFT JOIN users u ON c.user_id = u.id
-                      LEFT JOIN tenants t ON c.tenant_id = t.id
-                      WHERE c.id = ? AND c.tenant_id = ?";
-            $stmt = Database::query($query, [$id, $tenantId]);
-        }
+        // Tenant scoping: defaults to current tenant, super admins can pass ?tenant_id=all
+        $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+        $tenantWhere = $effectiveTenantId !== null ? 'AND c.tenant_id = ?' : '';
+        $tenantParams = $effectiveTenantId !== null ? [$effectiveTenantId] : [];
+
+        $query = "SELECT c.*,
+                         u.name as user_name,
+                         u.email as user_email,
+                         u.avatar_url as user_avatar,
+                         t.name as tenant_name
+                  FROM comments c
+                  LEFT JOIN users u ON c.user_id = u.id
+                  LEFT JOIN tenants t ON c.tenant_id = t.id
+                  WHERE c.id = ? {$tenantWhere}";
+        $stmt = Database::query($query, array_merge([$id], $tenantParams));
         $comment = $stmt->fetch();
 
         if (!$comment) {
@@ -197,18 +182,15 @@ class AdminCommentsApiController extends BaseApiController
         $tenantId = TenantContext::getId();
         $adminId = $this->getAuthenticatedUserId();
 
-        // Verify comment exists — super admins can hide comments from any tenant
-        if ($isSuperAdmin) {
-            $stmt = Database::query(
-                "SELECT id, target_type, target_id, tenant_id FROM comments WHERE id = ?",
-                [$id]
-            );
-        } else {
-            $stmt = Database::query(
-                "SELECT id, target_type, target_id, tenant_id FROM comments WHERE id = ? AND tenant_id = ?",
-                [$id, $tenantId]
-            );
-        }
+        // Tenant scoping: defaults to current tenant, super admins can pass ?tenant_id=all
+        $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+        $tenantWhere = $effectiveTenantId !== null ? 'AND tenant_id = ?' : '';
+        $tenantParams = $effectiveTenantId !== null ? [$effectiveTenantId] : [];
+
+        $stmt = Database::query(
+            "SELECT id, target_type, target_id, tenant_id FROM comments WHERE id = ? {$tenantWhere}",
+            array_merge([$id], $tenantParams)
+        );
         $comment = $stmt->fetch();
 
         if (!$comment) {
@@ -246,18 +228,15 @@ class AdminCommentsApiController extends BaseApiController
         $tenantId = TenantContext::getId();
         $adminId = $this->getAuthenticatedUserId();
 
-        // Verify comment exists — super admins can delete comments from any tenant
-        if ($isSuperAdmin) {
-            $stmt = Database::query(
-                "SELECT id, target_type, target_id, user_id, tenant_id FROM comments WHERE id = ?",
-                [$id]
-            );
-        } else {
-            $stmt = Database::query(
-                "SELECT id, target_type, target_id, user_id, tenant_id FROM comments WHERE id = ? AND tenant_id = ?",
-                [$id, $tenantId]
-            );
-        }
+        // Tenant scoping: defaults to current tenant, super admins can pass ?tenant_id=all
+        $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+        $tenantWhere = $effectiveTenantId !== null ? 'AND tenant_id = ?' : '';
+        $tenantParams = $effectiveTenantId !== null ? [$effectiveTenantId] : [];
+
+        $stmt = Database::query(
+            "SELECT id, target_type, target_id, user_id, tenant_id FROM comments WHERE id = ? {$tenantWhere}",
+            array_merge([$id], $tenantParams)
+        );
         $comment = $stmt->fetch();
 
         if (!$comment) {

--- a/src/Controllers/Api/AdminFeedApiController.php
+++ b/src/Controllers/Api/AdminFeedApiController.php
@@ -50,21 +50,15 @@ class AdminFeedApiController extends BaseApiController
         $userId = isset($_GET['user_id']) ? (int) $_GET['user_id'] : null;
         $search = $_GET['search'] ?? null;
         $isHidden = isset($_GET['is_hidden']) ? (bool) $_GET['is_hidden'] : null;
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
         $conditions = [];
         $params = [];
 
-        // Tenant scoping: super admins can see all tenants or filter by one
-        if ($isSuperAdmin) {
-            if ($filterTenantId) {
-                $conditions[] = 'fp.tenant_id = ?';
-                $params[] = $filterTenantId;
-            }
-            // No tenant filter = all tenants for super admin
-        } else {
+        // Tenant scoping: defaults to current tenant, super admins can pass ?tenant_id=all
+        $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+        if ($effectiveTenantId !== null) {
             $conditions[] = 'fp.tenant_id = ?';
-            $params[] = $tenantId;
+            $params[] = $effectiveTenantId;
         }
 
         // Type filter
@@ -160,34 +154,23 @@ class AdminFeedApiController extends BaseApiController
         $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
 
-        // Super admins can view posts from any tenant
-        if ($isSuperAdmin) {
-            $query = "SELECT fp.*,
-                             u.name as user_name,
-                             u.email as user_email,
-                             u.avatar_url as user_avatar,
-                             t.name as tenant_name,
-                             (fh.id IS NOT NULL) as is_hidden
-                      FROM feed_posts fp
-                      LEFT JOIN users u ON fp.user_id = u.id
-                      LEFT JOIN tenants t ON fp.tenant_id = t.id
-                      LEFT JOIN feed_hidden fh ON fh.target_type = 'post' AND fh.target_id = fp.id AND fh.tenant_id = fp.tenant_id
-                      WHERE fp.id = ?";
-            $stmt = Database::query($query, [$id]);
-        } else {
-            $query = "SELECT fp.*,
-                             u.name as user_name,
-                             u.email as user_email,
-                             u.avatar_url as user_avatar,
-                             t.name as tenant_name,
-                             (fh.id IS NOT NULL) as is_hidden
-                      FROM feed_posts fp
-                      LEFT JOIN users u ON fp.user_id = u.id
-                      LEFT JOIN tenants t ON fp.tenant_id = t.id
-                      LEFT JOIN feed_hidden fh ON fh.target_type = 'post' AND fh.target_id = fp.id AND fh.tenant_id = fp.tenant_id
-                      WHERE fp.id = ? AND fp.tenant_id = ?";
-            $stmt = Database::query($query, [$id, $tenantId]);
-        }
+        // Tenant scoping: defaults to current tenant, super admins can pass ?tenant_id=all
+        $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+        $tenantWhere = $effectiveTenantId !== null ? 'fp.tenant_id = ?' : '1=1';
+        $tenantParams = $effectiveTenantId !== null ? [$effectiveTenantId] : [];
+
+        $query = "SELECT fp.*,
+                         u.name as user_name,
+                         u.email as user_email,
+                         u.avatar_url as user_avatar,
+                         t.name as tenant_name,
+                         (fh.id IS NOT NULL) as is_hidden
+                  FROM feed_posts fp
+                  LEFT JOIN users u ON fp.user_id = u.id
+                  LEFT JOIN tenants t ON fp.tenant_id = t.id
+                  LEFT JOIN feed_hidden fh ON fh.target_type = 'post' AND fh.target_id = fp.id AND fh.tenant_id = fp.tenant_id
+                  WHERE fp.id = ? AND {$tenantWhere}";
+        $stmt = Database::query($query, array_merge([$id], $tenantParams));
         $post = $stmt->fetch();
 
         if (!$post) {
@@ -240,18 +223,15 @@ class AdminFeedApiController extends BaseApiController
         $tenantId = TenantContext::getId();
         $adminId = $this->getAuthenticatedUserId();
 
-        // Verify post exists — super admins can hide posts from any tenant
-        if ($isSuperAdmin) {
-            $stmt = Database::query(
-                "SELECT id, user_id, tenant_id FROM feed_posts WHERE id = ?",
-                [$id]
-            );
-        } else {
-            $stmt = Database::query(
-                "SELECT id, user_id, tenant_id FROM feed_posts WHERE id = ? AND tenant_id = ?",
-                [$id, $tenantId]
-            );
-        }
+        // Verify post exists — tenant scoping defaults to current tenant
+        $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+        $tenantWhere = $effectiveTenantId !== null ? 'tenant_id = ?' : '1=1';
+        $tenantParams = $effectiveTenantId !== null ? [$effectiveTenantId] : [];
+
+        $stmt = Database::query(
+            "SELECT id, user_id, tenant_id FROM feed_posts WHERE id = ? AND {$tenantWhere}",
+            array_merge([$id], $tenantParams)
+        );
         $post = $stmt->fetch();
 
         if (!$post) {
@@ -289,18 +269,15 @@ class AdminFeedApiController extends BaseApiController
         $tenantId = TenantContext::getId();
         $adminId = $this->getAuthenticatedUserId();
 
-        // Verify post exists — super admins can delete posts from any tenant
-        if ($isSuperAdmin) {
-            $stmt = Database::query(
-                "SELECT id, tenant_id FROM feed_posts WHERE id = ?",
-                [$id]
-            );
-        } else {
-            $stmt = Database::query(
-                "SELECT id, tenant_id FROM feed_posts WHERE id = ? AND tenant_id = ?",
-                [$id, $tenantId]
-            );
-        }
+        // Verify post exists — tenant scoping defaults to current tenant
+        $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+        $tenantWhere = $effectiveTenantId !== null ? 'tenant_id = ?' : '1=1';
+        $tenantParams = $effectiveTenantId !== null ? [$effectiveTenantId] : [];
+
+        $stmt = Database::query(
+            "SELECT id, tenant_id FROM feed_posts WHERE id = ? AND {$tenantWhere}",
+            array_merge([$id], $tenantParams)
+        );
         $post = $stmt->fetch();
 
         if (!$post) {
@@ -340,19 +317,10 @@ class AdminFeedApiController extends BaseApiController
         $this->requireAdmin();
         $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
+        // Tenant scoping: defaults to current tenant, super admins can pass ?tenant_id=all
+        $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
 
-        // Super admins: aggregate across all tenants or filter by one
-        if ($isSuperAdmin && !$filterTenantId) {
-            $query = "SELECT
-                        COUNT(DISTINCT fp.id) as total,
-                        (SELECT COUNT(DISTINCT fh.target_id) FROM feed_hidden fh
-                         WHERE fh.target_type = 'post') as hidden,
-                        (SELECT COUNT(*) FROM comments WHERE target_type = 'post') as total_comments
-                      FROM feed_posts fp";
-            $stmt = Database::query($query);
-        } else {
-            $scopeTenantId = ($isSuperAdmin && $filterTenantId) ? $filterTenantId : $tenantId;
+        if ($effectiveTenantId !== null) {
             $query = "SELECT
                         COUNT(DISTINCT fp.id) as total,
                         (SELECT COUNT(DISTINCT fh.target_id) FROM feed_hidden fh
@@ -360,7 +328,15 @@ class AdminFeedApiController extends BaseApiController
                         (SELECT COUNT(*) FROM comments WHERE target_type = 'post' AND tenant_id = ?) as total_comments
                       FROM feed_posts fp
                       WHERE fp.tenant_id = ?";
-            $stmt = Database::query($query, [$scopeTenantId, $scopeTenantId, $scopeTenantId]);
+            $stmt = Database::query($query, [$effectiveTenantId, $effectiveTenantId, $effectiveTenantId]);
+        } else {
+            $query = "SELECT
+                        COUNT(DISTINCT fp.id) as total,
+                        (SELECT COUNT(DISTINCT fh.target_id) FROM feed_hidden fh
+                         WHERE fh.target_type = 'post') as hidden,
+                        (SELECT COUNT(*) FROM comments WHERE target_type = 'post') as total_comments
+                      FROM feed_posts fp";
+            $stmt = Database::query($query);
         }
 
         $stats = $stmt->fetch();

--- a/src/Controllers/Api/AdminGroupsApiController.php
+++ b/src/Controllers/Api/AdminGroupsApiController.php
@@ -46,22 +46,16 @@ class AdminGroupsApiController extends BaseApiController
         $offset = ($page - 1) * $limit;
         $status = $_GET['status'] ?? null;
         $search = $_GET['search'] ?? null;
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
         try {
             $conditions = [];
             $params = [];
 
-            // Tenant scoping: super admins can see all tenants or filter by one
-            if ($isSuperAdmin) {
-                if ($filterTenantId) {
-                    $conditions[] = 'g.tenant_id = ?';
-                    $params[] = $filterTenantId;
-                }
-                // No tenant filter = all tenants for super admin
-            } else {
+            // Tenant scoping: defaults to current tenant; super admins can pass ?tenant_id=all for cross-tenant
+            $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+            if ($effectiveTenantId !== null) {
                 $conditions[] = 'g.tenant_id = ?';
-                $params[] = $tenantId;
+                $params[] = $effectiveTenantId;
             }
 
             // Status filter (groups use is_active column, not status)
@@ -139,25 +133,12 @@ class AdminGroupsApiController extends BaseApiController
         $this->requireAdmin();
         $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
-        // Determine scope
-        if ($isSuperAdmin && $filterTenantId) {
-            $scopeTenantId = $filterTenantId;
-            $tenantCondition = 'tenant_id = ?';
-            $tenantJoinCondition = 'g.tenant_id = ?';
-            $tenantParams = [$scopeTenantId];
-        } elseif ($isSuperAdmin && !$filterTenantId) {
-            $scopeTenantId = null;
-            $tenantCondition = '1=1';
-            $tenantJoinCondition = '1=1';
-            $tenantParams = [];
-        } else {
-            $scopeTenantId = $tenantId;
-            $tenantCondition = 'tenant_id = ?';
-            $tenantJoinCondition = 'g.tenant_id = ?';
-            $tenantParams = [$scopeTenantId];
-        }
+        // Determine scope: defaults to current tenant; super admins can pass ?tenant_id=all for cross-tenant
+        $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+        $tenantCondition = $effectiveTenantId !== null ? 'tenant_id = ?' : '1=1';
+        $tenantJoinCondition = $effectiveTenantId !== null ? 'g.tenant_id = ?' : '1=1';
+        $tenantParams = $effectiveTenantId !== null ? [$effectiveTenantId] : [];
 
         try {
             // Total groups
@@ -240,22 +221,16 @@ class AdminGroupsApiController extends BaseApiController
         $this->requireAdmin();
         $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
         try {
             $conditions = ['gm.status = \'pending\''];
             $params = [];
 
-            // Tenant scoping: super admins can see all tenants or filter by one
-            if ($isSuperAdmin) {
-                if ($filterTenantId) {
-                    $conditions[] = 'g.tenant_id = ?';
-                    $params[] = $filterTenantId;
-                }
-                // No tenant filter = all tenants for super admin
-            } else {
+            // Tenant scoping: defaults to current tenant; super admins can pass ?tenant_id=all for cross-tenant
+            $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+            if ($effectiveTenantId !== null) {
                 $conditions[] = 'g.tenant_id = ?';
-                $params[] = $tenantId;
+                $params[] = $effectiveTenantId;
             }
 
             $where = implode(' AND ', $conditions);
@@ -443,19 +418,11 @@ class AdminGroupsApiController extends BaseApiController
         $this->requireAdmin();
         $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
-        // Determine tenant scoping
-        if ($isSuperAdmin && $filterTenantId) {
-            $tenantCondition = 'g.tenant_id = ?';
-            $tenantParams = [$filterTenantId];
-        } elseif ($isSuperAdmin && !$filterTenantId) {
-            $tenantCondition = '1=1';
-            $tenantParams = [];
-        } else {
-            $tenantCondition = 'g.tenant_id = ?';
-            $tenantParams = [$tenantId];
-        }
+        // Determine tenant scoping: defaults to current tenant; super admins can pass ?tenant_id=all for cross-tenant
+        $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+        $tenantCondition = $effectiveTenantId !== null ? 'g.tenant_id = ?' : '1=1';
+        $tenantParams = $effectiveTenantId !== null ? [$effectiveTenantId] : [];
 
         try {
             // Try to find groups referenced in the reports table
@@ -644,28 +611,11 @@ class AdminGroupsApiController extends BaseApiController
         $this->requireAdmin();
         $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
-        // Determine scope
-        if ($isSuperAdmin && $filterTenantId) {
-            $scopeTenantId = $filterTenantId;
-            $tenantCondition = 'gt.tenant_id = ?';
-            $tenantParams = [$scopeTenantId];
-            $groupCountCondition = 'g.tenant_id = ?';
-            $groupCountParams = [$scopeTenantId];
-        } elseif ($isSuperAdmin && !$filterTenantId) {
-            $scopeTenantId = null;
-            $tenantCondition = '1=1';
-            $tenantParams = [];
-            $groupCountCondition = '1=1';
-            $groupCountParams = [];
-        } else {
-            $scopeTenantId = $tenantId;
-            $tenantCondition = 'gt.tenant_id = ?';
-            $tenantParams = [$scopeTenantId];
-            $groupCountCondition = 'g.tenant_id = ?';
-            $groupCountParams = [$scopeTenantId];
-        }
+        // Determine scope: defaults to current tenant; super admins can pass ?tenant_id=all for cross-tenant
+        $scopeTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+        $tenantCondition = $scopeTenantId !== null ? 'gt.tenant_id = ?' : '1=1';
+        $tenantParams = $scopeTenantId !== null ? [$scopeTenantId] : [];
 
         try {
             if ($scopeTenantId !== null) {
@@ -930,10 +880,9 @@ class AdminGroupsApiController extends BaseApiController
         $this->requireAdmin();
         $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
-        // Determine scope — policies are always tenant-scoped, so super admin must pick a tenant or use current
-        $scopeTenantId = ($isSuperAdmin && $filterTenantId) ? $filterTenantId : $tenantId;
+        // Determine scope — policies are always tenant-scoped, so fall back to current tenant if cross-tenant requested
+        $scopeTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId) ?? $tenantId;
 
         try {
             $policies = \Nexus\Services\GroupPolicyRepository::getAllPolicies($scopeTenantId);
@@ -1481,19 +1430,11 @@ class AdminGroupsApiController extends BaseApiController
         $adminId = $this->requireAdmin();
         $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
-        // Determine scope
-        if ($isSuperAdmin && $filterTenantId) {
-            $tenantCondition = 'tenant_id = ?';
-            $tenantParams = [$filterTenantId];
-        } elseif ($isSuperAdmin && !$filterTenantId) {
-            $tenantCondition = '1=1';
-            $tenantParams = [];
-        } else {
-            $tenantCondition = 'tenant_id = ?';
-            $tenantParams = [$tenantId];
-        }
+        // Determine scope: defaults to current tenant; super admins can pass ?tenant_id=all for cross-tenant
+        $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+        $tenantCondition = $effectiveTenantId !== null ? 'tenant_id = ?' : '1=1';
+        $tenantParams = $effectiveTenantId !== null ? [$effectiveTenantId] : [];
 
         try {
             $groups = Database::query(
@@ -1528,7 +1469,7 @@ class AdminGroupsApiController extends BaseApiController
             ActivityLog::log(
                 $adminId,
                 'admin_batch_geocode_groups',
-                "Batch geocoded {$success} groups, {$failed} failed" . ($isSuperAdmin ? " (scope: " . ($filterTenantId ? "tenant {$filterTenantId}" : "all tenants") . ")" : '')
+                "Batch geocoded {$success} groups, {$failed} failed" . ($isSuperAdmin ? " (scope: " . ($effectiveTenantId ? "tenant {$effectiveTenantId}" : "all tenants") . ")" : '')
             );
 
             $this->respondWithData([
@@ -1558,19 +1499,11 @@ class AdminGroupsApiController extends BaseApiController
         $this->requireAdmin();
         $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
-        // Determine scope
-        if ($isSuperAdmin && $filterTenantId) {
-            $tenantCondition = 'g.tenant_id = ?';
-            $tenantParams = [$filterTenantId];
-        } elseif ($isSuperAdmin && !$filterTenantId) {
-            $tenantCondition = '1=1';
-            $tenantParams = [];
-        } else {
-            $tenantCondition = 'g.tenant_id = ?';
-            $tenantParams = [$tenantId];
-        }
+        // Determine scope: defaults to current tenant; super admins can pass ?tenant_id=all for cross-tenant
+        $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+        $tenantCondition = $effectiveTenantId !== null ? 'g.tenant_id = ?' : '1=1';
+        $tenantParams = $effectiveTenantId !== null ? [$effectiveTenantId] : [];
 
         $limit = min(100, max(1, (int) ($_GET['limit'] ?? 20)));
         $offset = (int) ($_GET['offset'] ?? 0);
@@ -1655,10 +1588,9 @@ class AdminGroupsApiController extends BaseApiController
         $this->requireAdmin();
         $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
-        // Featured groups service requires a tenant_id — super admins can specify one
-        $scopeTenantId = ($isSuperAdmin && $filterTenantId) ? $filterTenantId : $tenantId;
+        // Featured groups service requires a tenant_id — fall back to current tenant if cross-tenant requested
+        $scopeTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId) ?? $tenantId;
 
         try {
             $groups = \Nexus\Services\SmartGroupRankingService::getFeaturedGroupsWithScores($scopeTenantId);

--- a/src/Controllers/Api/AdminListingsApiController.php
+++ b/src/Controllers/Api/AdminListingsApiController.php
@@ -46,8 +46,6 @@ class AdminListingsApiController extends BaseApiController
         $search = $_GET['search'] ?? null;
         $sort = $_GET['sort'] ?? 'created_at';
         $order = strtoupper($_GET['order'] ?? 'DESC') === 'ASC' ? 'ASC' : 'DESC';
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
-
         // Whitelist sort columns
         $allowedSorts = ['title', 'type', 'status', 'created_at', 'user_name'];
         if (!in_array($sort, $allowedSorts)) {
@@ -57,16 +55,11 @@ class AdminListingsApiController extends BaseApiController
         $conditions = [];
         $params = [];
 
-        // Tenant scoping: super admins can see all tenants or filter by one
-        if ($isSuperAdmin) {
-            if ($filterTenantId) {
-                $conditions[] = 'l.tenant_id = ?';
-                $params[] = $filterTenantId;
-            }
-            // No tenant filter = all tenants for super admin
-        } else {
+        // Tenant scoping: defaults to current tenant, super admins can explicitly request all
+        $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+        if ($effectiveTenantId !== null) {
             $conditions[] = 'l.tenant_id = ?';
-            $params[] = $tenantId;
+            $params[] = $effectiveTenantId;
         }
 
         // Status filter

--- a/src/Controllers/Api/AdminReportsApiController.php
+++ b/src/Controllers/Api/AdminReportsApiController.php
@@ -49,21 +49,15 @@ class AdminReportsApiController extends BaseApiController
         $type = $_GET['type'] ?? null;
         $status = $_GET['status'] ?? null;
         $search = $_GET['search'] ?? null;
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
         $conditions = [];
         $params = [];
 
-        // Tenant scoping: super admins can see all tenants or filter by one
-        if ($isSuperAdmin) {
-            if ($filterTenantId) {
-                $conditions[] = 'r.tenant_id = ?';
-                $params[] = $filterTenantId;
-            }
-            // No tenant filter = all tenants for super admin
-        } else {
+        // Tenant scoping: defaults to current tenant, super admins can explicitly request all
+        $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+        if ($effectiveTenantId !== null) {
             $conditions[] = 'r.tenant_id = ?';
-            $params[] = $tenantId;
+            $params[] = $effectiveTenantId;
         }
 
         // Type filter (listing, user, message)
@@ -306,28 +300,19 @@ class AdminReportsApiController extends BaseApiController
         $this->requireAdmin();
         $isSuperAdmin = $this->isAuthenticatedSuperAdmin();
         $tenantId = TenantContext::getId();
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
+        // Tenant scoping: defaults to current tenant, super admins can explicitly request all
+        $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+        $tenantWhere = $effectiveTenantId !== null ? 'tenant_id = ?' : '1=1';
+        $tenantParams = $effectiveTenantId !== null ? [$effectiveTenantId] : [];
 
-        // Super admins: aggregate across all tenants or filter by one
-        if ($isSuperAdmin && !$filterTenantId) {
-            $query = "SELECT
-                        COUNT(*) as total,
-                        SUM(CASE WHEN status = 'open' THEN 1 ELSE 0 END) as pending,
-                        SUM(CASE WHEN status = 'resolved' THEN 1 ELSE 0 END) as resolved,
-                        SUM(CASE WHEN status = 'dismissed' THEN 1 ELSE 0 END) as dismissed
-                      FROM reports";
-            $stmt = Database::query($query);
-        } else {
-            $scopeTenantId = ($isSuperAdmin && $filterTenantId) ? $filterTenantId : $tenantId;
-            $query = "SELECT
-                        COUNT(*) as total,
-                        SUM(CASE WHEN status = 'open' THEN 1 ELSE 0 END) as pending,
-                        SUM(CASE WHEN status = 'resolved' THEN 1 ELSE 0 END) as resolved,
-                        SUM(CASE WHEN status = 'dismissed' THEN 1 ELSE 0 END) as dismissed
-                      FROM reports
-                      WHERE tenant_id = ?";
-            $stmt = Database::query($query, [$scopeTenantId]);
-        }
+        $query = "SELECT
+                    COUNT(*) as total,
+                    SUM(CASE WHEN status = 'open' THEN 1 ELSE 0 END) as pending,
+                    SUM(CASE WHEN status = 'resolved' THEN 1 ELSE 0 END) as resolved,
+                    SUM(CASE WHEN status = 'dismissed' THEN 1 ELSE 0 END) as dismissed
+                  FROM reports
+                  WHERE {$tenantWhere}";
+        $stmt = Database::query($query, $tenantParams);
 
         $stats = $stmt->fetch();
 

--- a/src/Controllers/Api/AdminReviewsApiController.php
+++ b/src/Controllers/Api/AdminReviewsApiController.php
@@ -50,21 +50,15 @@ class AdminReviewsApiController extends BaseApiController
         $rating = isset($_GET['rating']) ? (int) $_GET['rating'] : null;
         $status = $_GET['status'] ?? null;
         $search = $_GET['search'] ?? null;
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
 
         $conditions = [];
         $params = [];
 
-        // Tenant scoping: super admins can see all tenants or filter by one
-        if ($isSuperAdmin) {
-            if ($filterTenantId) {
-                $conditions[] = 'r.tenant_id = ?';
-                $params[] = $filterTenantId;
-            }
-            // No tenant filter = all tenants for super admin
-        } else {
+        // Tenant scoping: defaults to current tenant, super admins can explicitly request all
+        $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+        if ($effectiveTenantId !== null) {
             $conditions[] = 'r.tenant_id = ?';
-            $params[] = $tenantId;
+            $params[] = $effectiveTenantId;
         }
 
         // Rating filter

--- a/src/Controllers/Api/AdminUsersApiController.php
+++ b/src/Controllers/Api/AdminUsersApiController.php
@@ -61,8 +61,6 @@ class AdminUsersApiController extends BaseApiController
         $role = $_GET['role'] ?? null;
         $sort = $_GET['sort'] ?? 'created_at';
         $order = strtoupper($_GET['order'] ?? 'DESC') === 'ASC' ? 'ASC' : 'DESC';
-        $filterTenantId = isset($_GET['tenant_id']) ? (int) $_GET['tenant_id'] : null;
-
         // Whitelist sort columns
         $allowedSorts = ['name', 'email', 'role', 'created_at', 'balance', 'status'];
         if (!in_array($sort, $allowedSorts)) {
@@ -72,16 +70,11 @@ class AdminUsersApiController extends BaseApiController
         $conditions = [];
         $params = [];
 
-        // Tenant scoping: super admins can see all tenants or filter by one
-        if ($isSuperAdmin) {
-            if ($filterTenantId) {
-                $conditions[] = 'u.tenant_id = ?';
-                $params[] = $filterTenantId;
-            }
-            // No tenant filter = all tenants for super admin
-        } else {
+        // Tenant scoping: defaults to current tenant; super admins can pass ?tenant_id=all
+        $effectiveTenantId = $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+        if ($effectiveTenantId !== null) {
             $conditions[] = 'u.tenant_id = ?';
-            $params[] = $tenantId;
+            $params[] = $effectiveTenantId;
         }
 
         // Status filter

--- a/src/Controllers/Api/BaseApiController.php
+++ b/src/Controllers/Api/BaseApiController.php
@@ -715,6 +715,38 @@ abstract class BaseApiController
         return false;
     }
 
+    /**
+     * Resolve the effective tenant ID for admin listing endpoints.
+     *
+     * Super admins default to the current tenant context (from X-Tenant-ID header).
+     * They can explicitly pass ?tenant_id=all to see all tenants, or ?tenant_id=N
+     * to view a specific tenant. Regular admins are always locked to their tenant.
+     *
+     * @param bool $isSuperAdmin Whether the authenticated user is a super admin
+     * @param int $tenantId The current tenant context ID (from TenantContext::getId())
+     * @return int|null Effective tenant ID to filter by, or null for all tenants
+     */
+    protected function resolveAdminTenantFilter(bool $isSuperAdmin, int $tenantId): ?int
+    {
+        $filterTenantIdRaw = $_GET['tenant_id'] ?? null;
+
+        if ($isSuperAdmin) {
+            // Explicit ?tenant_id=all → show all tenants (cross-tenant view)
+            if ($filterTenantIdRaw === 'all') {
+                return null;
+            }
+            // Explicit ?tenant_id=N → show that specific tenant
+            if ($filterTenantIdRaw !== null && is_numeric($filterTenantIdRaw)) {
+                return (int) $filterTenantIdRaw;
+            }
+            // Default: scope to current tenant context (safe default)
+            return $tenantId;
+        }
+
+        // Regular admins: always locked to their own tenant
+        return $tenantId;
+    }
+
     // ============================================
     // SECURITY METHODS
     // ============================================

--- a/tests/Unit/ResolveAdminTenantFilterTest.php
+++ b/tests/Unit/ResolveAdminTenantFilterTest.php
@@ -1,0 +1,160 @@
+<?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
+declare(strict_types=1);
+
+namespace Nexus\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Nexus\Controllers\Api\BaseApiController;
+
+/**
+ * Regression test for resolveAdminTenantFilter()
+ *
+ * Verifies that admin listing endpoints default to the current tenant context,
+ * preventing cross-tenant data leaks when no explicit ?tenant_id is passed.
+ *
+ * Root cause: Commit 634e76fe introduced super admin cross-tenant access that
+ * removed ALL tenant scoping by default. This caused admin pages to show data
+ * from all tenants instead of the current tenant.
+ *
+ * @covers \Nexus\Controllers\Api\BaseApiController::resolveAdminTenantFilter
+ * @group unit
+ * @group regression
+ */
+class ResolveAdminTenantFilterTest extends TestCase
+{
+    private TestableBaseApiController $controller;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->controller = new TestableBaseApiController();
+        // Clear any leftover $_GET state
+        unset($_GET['tenant_id']);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_GET['tenant_id']);
+        parent::tearDown();
+    }
+
+    // ─────────────────────────────────────────────
+    // Regular Admin Tests
+    // ─────────────────────────────────────────────
+
+    public function testRegularAdminAlwaysScopedToOwnTenant(): void
+    {
+        $result = $this->controller->publicResolveAdminTenantFilter(false, 2);
+        $this->assertSame(2, $result, 'Regular admin must always be scoped to their own tenant');
+    }
+
+    public function testRegularAdminCannotOverrideWithQueryParam(): void
+    {
+        $_GET['tenant_id'] = '5';
+        $result = $this->controller->publicResolveAdminTenantFilter(false, 2);
+        $this->assertSame(2, $result, 'Regular admin must be scoped to own tenant even with ?tenant_id');
+    }
+
+    public function testRegularAdminCannotUseAllTenants(): void
+    {
+        $_GET['tenant_id'] = 'all';
+        $result = $this->controller->publicResolveAdminTenantFilter(false, 2);
+        $this->assertSame(2, $result, 'Regular admin must never see all tenants');
+    }
+
+    // ─────────────────────────────────────────────
+    // Super Admin Tests — Default Behavior (CRITICAL)
+    // ─────────────────────────────────────────────
+
+    public function testSuperAdminDefaultsToCurrentTenant(): void
+    {
+        // THIS IS THE BUG REGRESSION: before the fix, this returned null (no tenant filter)
+        $result = $this->controller->publicResolveAdminTenantFilter(true, 2);
+        $this->assertSame(2, $result, 'Super admin without ?tenant_id must default to current tenant, not all tenants');
+    }
+
+    public function testSuperAdminDefaultsToCurrentTenantForTenant1(): void
+    {
+        $result = $this->controller->publicResolveAdminTenantFilter(true, 1);
+        $this->assertSame(1, $result, 'Super admin on tenant 1 should default to tenant 1');
+    }
+
+    public function testSuperAdminDefaultsToCurrentTenantForTenant4(): void
+    {
+        $result = $this->controller->publicResolveAdminTenantFilter(true, 4);
+        $this->assertSame(4, $result, 'Super admin on tenant 4 should default to tenant 4');
+    }
+
+    // ─────────────────────────────────────────────
+    // Super Admin Tests — Explicit Tenant Filter
+    // ─────────────────────────────────────────────
+
+    public function testSuperAdminCanFilterToSpecificTenant(): void
+    {
+        $_GET['tenant_id'] = '3';
+        $result = $this->controller->publicResolveAdminTenantFilter(true, 2);
+        $this->assertSame(3, $result, 'Super admin with ?tenant_id=3 should see tenant 3');
+    }
+
+    public function testSuperAdminCanFilterToOwnTenantExplicitly(): void
+    {
+        $_GET['tenant_id'] = '2';
+        $result = $this->controller->publicResolveAdminTenantFilter(true, 2);
+        $this->assertSame(2, $result, 'Super admin with ?tenant_id=2 while on tenant 2 should see tenant 2');
+    }
+
+    // ─────────────────────────────────────────────
+    // Super Admin Tests — Cross-Tenant "All" View
+    // ─────────────────────────────────────────────
+
+    public function testSuperAdminCanExplicitlyRequestAllTenants(): void
+    {
+        $_GET['tenant_id'] = 'all';
+        $result = $this->controller->publicResolveAdminTenantFilter(true, 2);
+        $this->assertNull($result, 'Super admin with ?tenant_id=all should get null (no tenant filter)');
+    }
+
+    // ─────────────────────────────────────────────
+    // Edge Cases
+    // ─────────────────────────────────────────────
+
+    public function testNonNumericTenantIdTreatedAsNoFilter(): void
+    {
+        $_GET['tenant_id'] = 'invalid';
+        $result = $this->controller->publicResolveAdminTenantFilter(true, 2);
+        $this->assertSame(2, $result, 'Non-numeric, non-"all" tenant_id should fall back to current tenant');
+    }
+
+    public function testEmptyStringTenantIdDefaultsToCurrentTenant(): void
+    {
+        $_GET['tenant_id'] = '';
+        $result = $this->controller->publicResolveAdminTenantFilter(true, 2);
+        $this->assertSame(2, $result, 'Empty string tenant_id should fall back to current tenant');
+    }
+
+    public function testZeroTenantIdTreatedAsNoFilter(): void
+    {
+        $_GET['tenant_id'] = '0';
+        $result = $this->controller->publicResolveAdminTenantFilter(true, 2);
+        // 0 is_numeric() === true, so (int)'0' = 0
+        $this->assertSame(0, $result, 'Zero tenant_id should return 0 (which the controller treats as a specific ID)');
+    }
+}
+
+/**
+ * Exposes the protected resolveAdminTenantFilter() for unit testing.
+ */
+class TestableBaseApiController extends BaseApiController
+{
+    protected bool $isV2Api = true;
+
+    public function publicResolveAdminTenantFilter(bool $isSuperAdmin, int $tenantId): ?int
+    {
+        return $this->resolveAdminTenantFilter($isSuperAdmin, $tenantId);
+    }
+}


### PR DESCRIPTION
## Summary

Super admins viewing admin panels saw users/content from **all tenants** instead of the current tenant. This broke Tenant 2's users list — showing test users from other tenants while pushing real Tenant 2 users off page 1.

**Root Cause:** Commit `634e76fe` ("enable super admin cross-tenant access") removed all tenant scoping from admin listing queries when the user is a super admin and no explicit `?tenant_id` query param is passed. Since the React frontend never sent `?tenant_id`, super admins got an unfiltered cross-tenant view by default. With `ORDER BY created_at DESC LIMIT 20`, recently created test users from other tenants filled page 1, hiding real Tenant 2 users.

**Prevention:** New centralized `BaseApiController::resolveAdminTenantFilter()` method enforces safe defaults — super admins are always scoped to the current tenant unless they explicitly pass `?tenant_id=all`. 12 PHPUnit regression tests verify all tenant scoping scenarios, including the critical case that a super admin without `?tenant_id` defaults to the current tenant (not null/all).

## Changes

### Backend
- New `BaseApiController::resolveAdminTenantFilter()` — centralized tenant filter logic
- Applied to all 8 admin controllers (30+ methods): Broker, Comments, Feed, Groups, Listings, Reports, Reviews, Users
- Default: current tenant. Opt-in cross-tenant: `?tenant_id=all`. Specific tenant: `?tenant_id=N`

### Frontend
- `UserListParams` type updated with `tenant_id` field
- `UserList.tsx` now sends `tenant_id` from tenant context as defensive measure

### Tests
- 12 new PHPUnit regression tests in `ResolveAdminTenantFilterTest.php`
- All PHP files pass syntax check, TypeScript compiles with 0 errors

## Test plan

- [x] PHPUnit regression tests (12/12 pass)
- [x] PHP syntax check (9/9 files pass)
- [x] TypeScript compilation (0 errors)
- [ ] Manual: Tenant 2 Admin → Users shows only Tenant 2 users
- [ ] Manual: Tenant 1 Admin → Users shows only Tenant 1 users
- [ ] Manual: `?tenant_id=all` shows cross-tenant data for super admin
- [ ] Manual: Regular admin cannot see other tenants

🤖 Generated with [Claude Code](https://claude.com/claude-code)