### PR TITLE
fix(messages): repair broken real-time updates and soft-delete filtering

### DIFF
--- a/docs/incidents/messaging-missing-new-message-tenant2-2026-02-24.md
+++ b/docs/incidents/messaging-missing-new-message-tenant2-2026-02-24.md
@@ -1,0 +1,94 @@
+# Incident: Messages Not Appearing in React Frontend (Tenant 2)
+
+**Date:** 2026-02-24
+**Severity:** P0 — Messages received via email notification but invisible in React frontend
+**Tenant:** 2 (hour-timebank)
+**Status:** Fixed (pending deploy)
+
+---
+
+## Symptom
+
+User received an **email notification** about a new message in Tenant 2 but sees **nothing** in the React frontend Messages page. The conversation list shows no mention of the message, and unread indicators do not reflect it.
+
+## Root Causes (7 bugs found)
+
+### CRITICAL #1: Pusher `new-message` event payload mismatch
+
+**File:** `src/Services/RealtimeService.php` (line 79)
+**Impact:** Real-time message updates on MessagesPage are **completely non-functional** for all messages.
+
+The backend `broadcastMessage()` sends two Pusher events:
+1. **Chat channel** (`private-tenant.{tid}.chat.{chatId}`): Event `message` with `{id, sender_id, receiver_id, body, created_at, ...}` — correct payload.
+2. **User channel** (`private-tenant.{tid}.user.{receiverId}`): Event `new-message` with `{from_user_id, preview, timestamp}` — **missing** `sender_id`, `id`, `body`, `created_at`.
+
+The frontend `PusherContext.tsx` binds to the user channel's `new-message` event and types it as `NewMessageEvent {id, sender_id, receiver_id, body, created_at, timestamp}`. Since the backend sends `from_user_id` instead of `sender_id`, the field is `undefined`, causing:
+- `event.sender_id` → `undefined` → `findIndex()` returns -1 → falls through to "new conversation" branch
+- Both existing and new conversation updates silently fail
+
+### CRITICAL #2: New conversation handler returns stale state (no reload)
+
+**File:** `react-frontend/src/pages/messages/MessagesPage.tsx` (line 115-117, pre-fix)
+**Impact:** Messages from first-time senders never appear until manual page refresh.
+
+When `handleNewMessage` can't find an existing conversation (either due to bug #1 or genuinely new sender), it returns `prev` unchanged with a comment saying "This triggers a refresh" — but no refresh is triggered. The conversation list stays stale.
+
+### CRITICAL #3: `getMessages()` missing soft-delete filter
+
+**File:** `src/Services/MessageService.php` — `getMessages()` method
+**Impact:** Soft-deleted messages (body = "[Message deleted]") still appear in conversation threads.
+
+The query had no `AND m.is_deleted = 0` clause. Deleted messages were visible to both sender and receiver.
+
+### MEDIUM #4: `getUnreadCount()` counts soft-deleted messages
+
+**File:** `src/Services/MessageService.php` — `getUnreadCount()` method
+**Impact:** Unread badge count inflated by deleted messages.
+
+### MEDIUM #5: `getConversations()` unread subquery counts deleted messages
+
+**File:** `src/Services/MessageService.php` — `getConversations()` unread_count subquery
+**Impact:** Per-conversation unread badges inflated by deleted messages.
+
+### MEDIUM #6: ConversationPage polling disabled when Pusher connected
+
+**File:** `react-frontend/src/pages/messages/ConversationPage.tsx` (line 282, pre-fix)
+**Impact:** If Pusher silently drops messages, there is zero fallback — messages never appear.
+
+The condition `if (!isDocumentVisible || isNewConversation || !lastMessageIdRef.current || pusher?.isConnected) return;` completely disables polling when Pusher reports connected, even though Pusher can silently fail to deliver messages.
+
+### MINOR #7: NotificationsContext toast shows fallback text
+
+**File:** `react-frontend/src/contexts/NotificationsContext.tsx` (line 292, pre-fix)
+**Impact:** Toast notification always says "You have a new message" instead of showing message preview.
+
+Handler expects `data.message` but backend sends `data.preview` and `data.body`. The field `data.message` is always `undefined`, triggering the fallback string.
+
+## Fixes Applied
+
+| Bug | File | Fix |
+|-----|------|-----|
+| #1 | `src/Services/RealtimeService.php` | Enriched user channel `new-message` payload with `id`, `sender_id`, `receiver_id`, `body`, `created_at` (kept `from_user_id`/`preview` for backward compat) |
+| #2 | `react-frontend/src/pages/messages/MessagesPage.tsx` | Moved `loadConversations` before `handleNewMessage`; handler now normalizes `sender_id`/`from_user_id`, does optimistic update for existing convos, and **always** calls `loadConversations()` to catch new conversations |
+| #3 | `src/Services/MessageService.php` `getMessages()` | Added conditional `AND m.is_deleted = 0` filter (gated by `hasColumn` check) |
+| #4 | `src/Services/MessageService.php` `getUnreadCount()` | Added conditional `AND is_deleted = 0` filter |
+| #5 | `src/Services/MessageService.php` `getConversations()` | Added conditional `is_deleted = 0` to unread_count subquery |
+| #6 | `react-frontend/src/pages/messages/ConversationPage.tsx` | Changed polling to use 30s interval when Pusher connected (was disabled entirely), 5s when disconnected |
+| #7 | `react-frontend/src/contexts/NotificationsContext.tsx` | Fixed toast to read `data.body \|\| data.preview \|\| data.message` |
+
+## Verification
+
+- [x] PHP syntax check passes (`php -l` on all modified files)
+- [x] TypeScript compiles cleanly (`tsc --noEmit`)
+- [x] Vite production build succeeds
+- [ ] Manual test: Send message from User A to User B (first time) in Tenant 2 — verify conversation appears
+- [ ] Manual test: Verify unread badge increments on new message
+- [ ] Manual test: Verify toast shows message preview (not fallback text)
+- [ ] Manual test: Delete a message and verify it disappears from thread and unread count adjusts
+- [ ] Manual test: Open ConversationPage, disconnect network briefly, reconnect — verify polling recovers messages
+
+## Prevention
+
+1. **Type-safe Pusher events**: Backend and frontend should share event type definitions (or at minimum have tests that assert field names match)
+2. **Integration test**: Send message → assert it appears in inbox API response within 5 seconds
+3. **Monitoring**: Add structured logging for Pusher broadcast failures and API inbox queries returning empty for users with known unread messages

--- a/react-frontend/src/contexts/NotificationsContext.tsx
+++ b/react-frontend/src/contexts/NotificationsContext.tsx
@@ -280,7 +280,8 @@ export function NotificationsProvider({ children }: NotificationsProviderProps) 
       channel.bind('new-notification', handleNewNotification);
 
       // Message events (update unread count)
-      channel.bind('new-message', (data: { conversation_id: number; message: string }) => {
+      // Backend sends: { sender_id, body, preview, from_user_id, ... }
+      channel.bind('new-message', (data: { body?: string; preview?: string; message?: string }) => {
         setState((prev) => ({
           ...prev,
           unreadCount: prev.unreadCount + 1,
@@ -289,7 +290,8 @@ export function NotificationsProvider({ children }: NotificationsProviderProps) 
             messages: prev.counts.messages + 1,
           },
         }));
-        toast.info('New Message', data.message?.substring(0, 50) || 'You have a new message');
+        const text = data.body || data.preview || data.message || '';
+        toast.info('New Message', text.substring(0, 50) || 'You have a new message');
       });
 
       // Transaction events

--- a/react-frontend/src/pages/messages/ConversationPage.tsx
+++ b/react-frontend/src/pages/messages/ConversationPage.tsx
@@ -278,14 +278,18 @@ export function ConversationPage() {
       pollingIntervalRef.current = null;
     }
 
-    // Only poll if: document visible, not new conversation, have messages, and Pusher not connected
-    if (!isDocumentVisible || isNewConversation || !lastMessageIdRef.current || pusher?.isConnected) {
+    // Only poll if: document visible, not new conversation, and have messages loaded
+    if (!isDocumentVisible || isNewConversation || !lastMessageIdRef.current) {
       return;
     }
 
+    // When Pusher is connected, use a longer polling interval as a reliability fallback.
+    // When disconnected, poll more frequently as it's the primary update mechanism.
+    const interval = pusher?.isConnected ? 30000 : 5000;
+
     pollingIntervalRef.current = setInterval(() => {
       pollForNewMessages();
-    }, 5000);
+    }, interval);
 
     return () => {
       if (pollingIntervalRef.current) {

--- a/react-frontend/src/pages/messages/MessagesPage.tsx
+++ b/react-frontend/src/pages/messages/MessagesPage.tsx
@@ -77,48 +77,7 @@ export function MessagesPage() {
   const toUserId = searchParams.get('to');
   const listingId = searchParams.get('listing');
 
-  /**
-   * Handle incoming new message from Pusher
-   * Updates conversation list with new message preview and increments unread count
-   */
-  const handleNewMessage = useCallback((event: NewMessageEvent) => {
-    setConversations((prev) => {
-      // Find the conversation with this sender
-      const existingIndex = prev.findIndex((conv) => {
-        const otherUser = getOtherUser(conv);
-        return otherUser.id === event.sender_id;
-      });
-
-      if (existingIndex >= 0) {
-        // Update existing conversation
-        const updated = [...prev];
-        const conv = { ...updated[existingIndex] };
-
-        // Update last message
-        conv.last_message = {
-          id: event.id,
-          body: event.body,
-          sender_id: event.sender_id,
-          created_at: event.created_at,
-        };
-
-        // Increment unread count
-        conv.unread_count = (conv.unread_count || 0) + 1;
-
-        // Move to top of list
-        updated.splice(existingIndex, 1);
-        updated.unshift(conv);
-
-        return updated;
-      }
-
-      // New conversation - we'll reload to get the full conversation data
-      // This triggers a refresh which will include the new conversation
-      return prev;
-    });
-  }, []);
-
-  // Memoize loadConversations to use in effects
+  // Memoize loadConversations to use in effects and handlers
   const loadConversations = useCallback(async () => {
     try {
       setIsLoading(true);
@@ -136,6 +95,62 @@ export function MessagesPage() {
       setIsLoading(false);
     }
   }, []);
+
+  /**
+   * Handle incoming new message from Pusher
+   * Updates conversation list with new message preview and increments unread count
+   */
+  const handleNewMessage = useCallback((event: NewMessageEvent) => {
+    // Backend sends from_user_id on user channel; normalize to sender_id
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const raw = event as any;
+    const senderId: number | undefined = event.sender_id || raw.from_user_id;
+    if (!senderId) {
+      // Can't identify sender — full reload to be safe
+      loadConversations();
+      return;
+    }
+
+    setConversations((prev) => {
+      // Find the conversation with this sender
+      const existingIndex = prev.findIndex((conv) => {
+        const otherUser = getOtherUser(conv);
+        return otherUser.id === senderId;
+      });
+
+      if (existingIndex >= 0) {
+        // Update existing conversation optimistically
+        const updated = [...prev];
+        const conv = { ...updated[existingIndex] };
+
+        // Update last message (body may come as preview from legacy events)
+        conv.last_message = {
+          id: event.id,
+          body: event.body || raw.preview || '',
+          sender_id: senderId,
+          created_at: event.created_at || new Date().toISOString(),
+        };
+
+        // Increment unread count
+        conv.unread_count = (conv.unread_count || 0) + 1;
+
+        // Move to top of list
+        updated.splice(existingIndex, 1);
+        updated.unshift(conv);
+
+        return updated;
+      }
+
+      // New conversation from unknown sender — can't build full Conversation
+      // object client-side, so we return prev and let the reload below handle it
+      return prev;
+    });
+
+    // Always reload to catch new conversations and ensure data consistency.
+    // For existing conversations this is a no-op (optimistic update already applied),
+    // but for new conversations this is the only way to get the full conversation data.
+    loadConversations();
+  }, [loadConversations]);
 
   // Subscribe to Pusher for real-time updates
   useEffect(() => {

--- a/src/Services/MessageService.php
+++ b/src/Services/MessageService.php
@@ -68,6 +68,8 @@ class MessageService
         $hasLastActive = self::hasColumn('users', 'last_active_at');
         // Check if archived columns exist for soft delete filtering
         $hasArchived = self::hasColumn('messages', 'archived_by_sender');
+        // Check if is_deleted column exists for soft-delete filtering
+        $hasDeleted = self::hasColumn('messages', 'is_deleted');
 
         $lastActiveSelect = $hasLastActive
             ? "CASE WHEN m.sender_id = :uid_la THEN receiver.last_active_at ELSE sender.last_active_at END as other_user_last_active"
@@ -92,6 +94,9 @@ class MessageService
             $archiveFilter = "";
         }
 
+        // Build soft-delete filter (column may not exist in older schemas)
+        $deletedFilter = $hasDeleted ? "AND unread.is_deleted = 0" : "";
+
         // Build the query - get latest message per conversation partner
         $sql = "
             SELECT
@@ -111,6 +116,7 @@ class MessageService
                     WHERE unread.sender_id = CASE WHEN m.sender_id = :uid6 THEN m.receiver_id ELSE m.sender_id END
                     AND unread.receiver_id = :uid7
                     AND unread.is_read = 0
+                    {$deletedFilter}
                     AND unread.tenant_id = :tenant1
                 ) as unread_count
             FROM messages m
@@ -281,6 +287,8 @@ class MessageService
 
         // Check if archived columns exist for soft delete filtering
         $hasArchived = self::hasColumn('messages', 'archived_by_sender');
+        // Check if is_deleted column exists for soft-delete filtering
+        $hasDeleted = self::hasColumn('messages', 'is_deleted');
 
         // Decode cursor (message ID)
         $cursorId = null;
@@ -306,6 +314,9 @@ class MessageService
         $hasReactionsCol = self::hasColumn('messages', 'reactions');
         $reactionsSelect = $hasReactionsCol ? ", m.reactions" : ", NULL as reactions";
 
+        // Build soft-delete filter (column may not exist in older schemas)
+        $deleteFilter = $hasDeleted ? "AND m.is_deleted = 0" : "";
+
         // Build query
         $sql = "
             SELECT
@@ -325,6 +336,7 @@ class MessageService
             JOIN users sender ON m.sender_id = sender.id
             WHERE m.tenant_id = ?
             AND ((m.sender_id = ? AND m.receiver_id = ?) OR (m.sender_id = ? AND m.receiver_id = ?))
+            {$deleteFilter}
             {$archiveFilter}
         ";
         $params = [$tenantId, $userId, $otherUserId, $otherUserId, $userId];
@@ -682,9 +694,13 @@ class MessageService
         $tenantId = TenantContext::getId();
         $db = Database::getConnection();
 
+        // Exclude soft-deleted messages from unread count (column may not exist in older schemas)
+        $hasDeleted = self::hasColumn('messages', 'is_deleted');
+        $deleteFilter = $hasDeleted ? "AND is_deleted = 0" : "";
+
         $stmt = $db->prepare("
             SELECT COUNT(*) as cnt FROM messages
-            WHERE tenant_id = ? AND receiver_id = ? AND is_read = 0
+            WHERE tenant_id = ? AND receiver_id = ? AND is_read = 0 {$deleteFilter}
         ");
         $stmt->execute([$tenantId, $userId]);
 

--- a/src/Services/RealtimeService.php
+++ b/src/Services/RealtimeService.php
@@ -76,7 +76,14 @@ class RealtimeService
         $chatSent = PusherService::trigger($channel, 'message', $eventData);
 
         // Also send a notification event to receiver's personal channel
+        // Include full message data so the frontend can update conversation list
+        // without needing an extra API call (from_user_id kept for backward compat)
         $notifSent = PusherService::trigger($receiverChannel, 'new-message', [
+            'id' => $message['id'] ?? null,
+            'sender_id' => $senderId,
+            'receiver_id' => $receiverId,
+            'body' => $message['body'] ?? '',
+            'created_at' => $message['created_at'] ?? date('Y-m-d H:i:s'),
             'from_user_id' => $senderId,
             'preview' => mb_substr($message['body'] ?? '', 0, 100),
             'timestamp' => time() * 1000,


### PR DESCRIPTION
## Summary

- **P0 fix**: Messages were invisible in the React frontend despite email notifications working — 7 bugs found across the full Pusher → frontend → backend pipeline
- **Fixes**: Enriched Pusher payload, normalized field names in frontend handler, added `is_deleted=0` filters to 3 backend queries, added 30s polling fallback when Pusher connected, fixed toast preview text

### Changes by file

| File | What changed |
|------|-------------|
| `src/Services/RealtimeService.php` | Enriched `new-message` Pusher payload with `id`, `sender_id`, `receiver_id`, `body`, `created_at` (backward-compat fields kept) |
| `src/Services/MessageService.php` | Added conditional `is_deleted=0` filter to `getMessages()`, `getUnreadCount()`, and `getConversations()` unread subquery |
| `react-frontend/.../MessagesPage.tsx` | Normalized `sender_id`/`from_user_id`, reordered declarations, always calls `loadConversations()` after Pusher event to catch new conversations |
| `react-frontend/.../ConversationPage.tsx` | Polling now runs at 30s when Pusher connected (was fully disabled), 5s when disconnected |
| `react-frontend/.../NotificationsContext.tsx` | Toast reads `data.body || data.preview || data.message` instead of just `data.message` |

**Root Cause:** The Pusher `new-message` event on the user's personal channel sent `{from_user_id, preview, timestamp}` but the frontend `NewMessageEvent` type expected `{sender_id, body, id, created_at}`. Every field the frontend read was `undefined`, making the entire real-time message handler on MessagesPage dead code for all messages. This was compounded by: (1) the new-conversation branch returning stale state with no reload triggered, (2) soft-deleted messages leaking into `getMessages()`, `getUnreadCount()`, and the `getConversations()` unread subquery due to missing `is_deleted=0` filters, (3) ConversationPage polling completely disabled when Pusher reported connected, and (4) NotificationsContext toast reading `data.message` (undefined) instead of `data.body`/`data.preview`.

**Prevention:** (1) The backend Pusher payload now includes all fields the frontend expects, with backward-compat fields retained. (2) The frontend handler normalizes both field names and always triggers a full reload to catch new conversations. (3) All message queries now conditionally filter `is_deleted=0` (gated by `hasColumn` for schema safety). (4) Polling runs as a 30s fallback even when Pusher is connected. (5) Incident log added at `docs/incidents/messaging-missing-new-message-tenant2-2026-02-24.md`. Future prevention should add shared Pusher event type definitions between backend and frontend, and integration tests that assert Pusher event fields match frontend type expectations.

## Test plan

- [ ] Send message from User A → User B (first-time conversation) in Tenant 2 — verify conversation appears in B's inbox without page refresh
- [ ] Send message in existing conversation — verify unread badge increments and last message preview updates in real-time
- [ ] Verify toast notification shows message preview text (not "You have a new message")
- [ ] Delete a message — verify it disappears from thread view and unread count adjusts
- [ ] Open ConversationPage, simulate Pusher disconnect — verify polling resumes at 5s interval
- [ ] Verify `php -l` passes on all PHP files, `tsc --noEmit` and `vite build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)