### PR TITLE
fix(api): fatal error on match preferences update endpoint

### DIFF
--- a/src/Controllers/Api/MatchPreferencesApiController.php
+++ b/src/Controllers/Api/MatchPreferencesApiController.php
@@ -39,7 +39,7 @@ class MatchPreferencesApiController extends BaseApiController
     {
         $userId = $this->requireAuth();
 
-        $input = $this->getJsonInput();
+        $input = $this->getAllInput();
         $current = MatchingService::getPreferences($userId);
 
         // Only update fields that were provided


### PR DESCRIPTION
## Summary
- **Production fatal error** on `PUT /api/v2/users/me/match-preferences` — `getJsonInput()` was called but never defined on `MatchPreferencesApiController`
- Changed to `$this->getAllInput()` which is the actual `BaseApiController` method that reads the JSON request body

**Root Cause:** `MatchPreferencesApiController::update()` called `$this->getJsonInput()`, but this method doesn't exist on `BaseApiController`. It's a private convenience alias that some controllers (e.g. `AuthController`, `TotpApiController`) define individually. This controller was written without the alias and was never caught because the `update()` path wasn't exercised until now.

**Prevention:** The codebase should standardize on `$this->getAllInput()` (the actual base class method) rather than relying on per-controller private aliases. A future cleanup should remove or consolidate the `getJsonInput()` aliases across all controllers to prevent this class of error.

## Test plan
- [ ] `PUT /api/v2/users/me/match-preferences` no longer returns 500
- [ ] Match preference updates save correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)