### PR TITLE
fix(admin): correct notification links to match React admin routes

### DIFF
--- a/src/Controllers/Api/AuthController.php
+++ b/src/Controllers/Api/AuthController.php
@@ -382,7 +382,7 @@ class AuthController extends BaseApiController
             // Notify admins of new registration (including hardcoded master email)
             try {
                 $tenantName = \Nexus\Core\TenantContext::get()['name'] ?? 'Project NEXUS';
-                $adminLink = \Nexus\Core\TenantContext::getFrontendUrl() . \Nexus\Core\TenantContext::getBasePath() . '/admin/users/' . $userId;
+                $adminLink = \Nexus\Core\TenantContext::getFrontendUrl() . \Nexus\Core\TenantContext::getBasePath() . '/admin/users/' . $userId . '/edit';
 
                 // Get tenant admins
                 $adminStmt = $db->prepare("

--- a/src/Controllers/Api/RegistrationApiController.php
+++ b/src/Controllers/Api/RegistrationApiController.php
@@ -529,7 +529,7 @@ class RegistrationApiController extends BaseApiController
     {
         try {
             $tenantName = TenantContext::get()['name'] ?? 'Project NEXUS';
-            $adminLink = TenantContext::getFrontendUrl() . TenantContext::getBasePath() . '/admin/users/' . $userId;
+            $adminLink = TenantContext::getFrontendUrl() . TenantContext::getBasePath() . '/admin/users/' . $userId . '/edit';
 
             // Collect notification recipients: all active admins for this tenant
             // (includes all admin roles: admin, super_admin, tenant_admin, tenant_super_admin)

--- a/src/Services/GroupApprovalWorkflowService.php
+++ b/src/Services/GroupApprovalWorkflowService.php
@@ -464,7 +464,7 @@ class GroupApprovalWorkflowService
                     0,
                     'group_approval_request',
                     "A new group '{$group['name']}' is awaiting approval.",
-                    '/admin/groups',
+                    '/admin/groups/approvals',
                     null
                 );
             }


### PR DESCRIPTION
## Summary
- **New user registration notifications** pointed to `/admin/users/{id}` which doesn't match any React route — now points to `/admin/users/{id}/edit` (the actual UserEdit component)
- **Group approval notifications** pointed to `/admin/groups` which is a generic listing — now points to `/admin/groups/approvals` (the actual GroupApprovals component)

Affected files:
- `src/Controllers/Api/AuthController.php` — legacy PHP registration flow notification
- `src/Controllers/Api/RegistrationApiController.php` — V2 API registration notification
- `src/Services/GroupApprovalWorkflowService.php` — group approval request notification

**Root Cause:** When the admin panel was migrated from PHP to React, notification link URLs were not updated to match the new React Router route paths. The PHP code still generated URLs like `/admin/users/{id}` and `/admin/groups`, but the React admin routes are `/admin/users/:id/edit` and `/admin/groups/approvals` respectively.

**Prevention:** The audit recommended creating centralized helper functions (`AdminUrl::forReact()` / `AdminUrl::forLegacy()`) so all admin URL generation goes through one place, making future route changes a single-point update instead of a grep-and-fix exercise.

## Test plan
- [ ] Register a new user and verify the admin notification email links to `/admin/users/{id}/edit`
- [ ] Create a group requiring approval and verify the notification links to `/admin/groups/approvals`
- [ ] Confirm both React admin pages load correctly from the notification links

🤖 Generated with [Claude Code](https://claude.com/claude-code)