### PR TITLE
fix(federation): fix partner popup navigation buttons

### DIFF
--- a/react-frontend/src/pages/federation/FederationPartnersPage.tsx
+++ b/react-frontend/src/pages/federation/FederationPartnersPage.tsx
@@ -14,7 +14,7 @@
  */
 
 import { useState, useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import {
   Button,
@@ -98,6 +98,7 @@ const PERMISSION_META: Record<string, { label: string; icon: typeof Globe }> = {
 
 export function FederationPartnersPage() {
   usePageTitle('Partner Communities');
+  const navigate = useNavigate();
   const { isAuthenticated } = useAuth();
   const { tenantPath } = useTenant();
 
@@ -348,25 +349,29 @@ export function FederationPartnersPage() {
               <ModalFooter className="flex gap-2">
                 {isAuthenticated && (
                   <>
-                    <Link to={tenantPath(`/federation/members?partner_id=${selectedPartner.id}`)}>
-                      <Button
-                        variant="flat"
-                        className="bg-theme-elevated text-theme-primary"
-                        startContent={<Users className="w-4 h-4" aria-hidden="true" />}
-                        onPress={closeDetail}
-                      >
-                        Browse Members
-                      </Button>
-                    </Link>
-                    <Link to={tenantPath(`/federation/listings?partner_id=${selectedPartner.id}`)}>
-                      <Button
-                        className="bg-gradient-to-r from-indigo-500 to-purple-600 text-white"
-                        startContent={<ListTodo className="w-4 h-4" aria-hidden="true" />}
-                        onPress={closeDetail}
-                      >
-                        Browse Listings
-                      </Button>
-                    </Link>
+                    <Button
+                      variant="flat"
+                      className="bg-theme-elevated text-theme-primary"
+                      startContent={<Users className="w-4 h-4" aria-hidden="true" />}
+                      onPress={() => {
+                        const path = tenantPath(`/federation/members?partner_id=${selectedPartner.id}`);
+                        closeDetail();
+                        navigate(path);
+                      }}
+                    >
+                      Browse Members
+                    </Button>
+                    <Button
+                      className="bg-gradient-to-r from-indigo-500 to-purple-600 text-white"
+                      startContent={<ListTodo className="w-4 h-4" aria-hidden="true" />}
+                      onPress={() => {
+                        const path = tenantPath(`/federation/listings?partner_id=${selectedPartner.id}`);
+                        closeDetail();
+                        navigate(path);
+                      }}
+                    >
+                      Browse Listings
+                    </Button>
                   </>
                 )}
                 {!isAuthenticated && (


### PR DESCRIPTION
## Summary
- Fix "Browse Members" and "Browse Listings" buttons in the federation partners detail popup not navigating when clicked
- Replace `<Link>` wrappers with programmatic `navigate()` calls inside `onPress`

**Root Cause:** HeroUI's `<Button>` component uses React Aria internally. When `onPress` is provided, React Aria's press handling calls `event.preventDefault()` on the underlying click event. This prevented the ancestor `<Link>` (rendered as `<a>`) from performing its default navigation behavior. The modal closed (via `closeDetail`) but the user stayed on the same page.

**Prevention:** Use programmatic `navigate()` inside `onPress` handlers instead of wrapping HeroUI Buttons with `<Link>` when the button also needs an `onPress` callback. This is the standard pattern for HeroUI/React Aria components that need both click handlers and navigation.

## Test plan
- [ ] Go to https://hour-timebank.ie/federation/partners
- [ ] Click a partner card to open the detail popup
- [ ] Click "Browse Members" — should navigate to `/federation/members?partner_id=X`
- [ ] Repeat and click "Browse Listings" — should navigate to `/federation/listings?partner_id=X`
- [ ] Verify the modal closes on navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)