### PR TITLE
fix(safeguarding): critical audit — broker controls, notifications, enforcement

### DIFF
--- a/app/Http/Controllers/Api/AdminSafeguardingController.php
+++ b/app/Http/Controllers/Api/AdminSafeguardingController.php
@@ -6,6 +6,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Core\TenantContext;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -13,8 +14,10 @@ use Illuminate\Support\Facades\DB;
 /**
  * AdminSafeguardingController -- Admin safeguarding module endpoints.
  *
- * Provides dashboard stats, flagged message management, and safeguarding
- * assignment CRUD for the admin safeguarding module.
+ * Provides dashboard stats, flagged message management, guardian assignment
+ * CRUD, and member safeguarding preference review for the admin panel.
+ *
+ * Frontend contract: react-frontend/src/admin/modules/safeguarding/SafeguardingDashboard.tsx
  */
 class AdminSafeguardingController extends BaseApiController
 {
@@ -23,56 +26,108 @@ class AdminSafeguardingController extends BaseApiController
     /**
      * GET /v2/admin/safeguarding/dashboard
      *
-     * Returns aggregate stats for the safeguarding dashboard.
+     * Returns aggregate stats matching the SafeguardingDashboard frontend:
+     * { active_assignments, unreviewed_flags, consented_wards, total_flags_this_month, critical_flags }
      */
     public function dashboard(): JsonResponse
     {
         $this->requireAdmin();
         $tenantId = $this->getTenantId();
 
+        $activeAssignments = 0;
+        $unreviewedFlags = 0;
+        $consentedWards = 0;
+        $totalFlagsThisMonth = 0;
+        $criticalFlags = 0;
+
+        // Active safeguarding assignments (not revoked, consent given)
         try {
-            $totalFlagged = DB::table('flagged_messages')
+            $activeAssignments = (int) DB::table('safeguarding_assignments')
                 ->where('tenant_id', $tenantId)
-                ->count();
-
-            $pendingReview = DB::table('flagged_messages')
-                ->where('tenant_id', $tenantId)
-                ->where('status', 'pending')
-                ->count();
-
-            $activeAssignments = DB::table('safeguarding_assignments')
-                ->where('tenant_id', $tenantId)
-                ->where('status', 'active')
-                ->count();
-
-            $resolved = DB::table('flagged_messages')
-                ->where('tenant_id', $tenantId)
-                ->where('status', 'resolved')
+                ->whereNull('revoked_at')
                 ->count();
         } catch (\Illuminate\Database\QueryException $e) {
-            if ($this->isTableNotFound($e)) {
-                return $this->respondWithData([
-                    'total_flagged' => 0,
-                    'pending_review' => 0,
-                    'active_assignments' => 0,
-                    'resolved' => 0,
-                ]);
+            if (!$this->isTableNotFound($e)) {
+                throw $e;
             }
-            throw $e;
+        }
+
+        // Unreviewed broker message copies (pending review)
+        try {
+            $unreviewedFlags = (int) DB::table('broker_message_copies')
+                ->where('tenant_id', $tenantId)
+                ->whereNull('reviewed_at')
+                ->count();
+        } catch (\Illuminate\Database\QueryException $e) {
+            if (!$this->isTableNotFound($e)) {
+                throw $e;
+            }
+        }
+
+        // Consented wards (assignments where the ward has given consent)
+        try {
+            $consentedWards = (int) DB::table('safeguarding_assignments')
+                ->where('tenant_id', $tenantId)
+                ->whereNull('revoked_at')
+                ->whereNotNull('consent_given_at')
+                ->count();
+        } catch (\Illuminate\Database\QueryException $e) {
+            if (!$this->isTableNotFound($e)) {
+                throw $e;
+            }
+        }
+
+        // Total flags this month (broker message copies created this month)
+        try {
+            $totalFlagsThisMonth = (int) DB::table('broker_message_copies')
+                ->where('tenant_id', $tenantId)
+                ->where('created_at', '>=', now()->startOfMonth())
+                ->count();
+        } catch (\Illuminate\Database\QueryException $e) {
+            if (!$this->isTableNotFound($e)) {
+                throw $e;
+            }
+        }
+
+        // Critical: flagged copies + unreviewed safeguarding incidents
+        try {
+            $criticalFlags = (int) DB::table('broker_message_copies')
+                ->where('tenant_id', $tenantId)
+                ->where('flagged', true)
+                ->whereNull('reviewed_at')
+                ->count();
+        } catch (\Illuminate\Database\QueryException $e) {
+            if (!$this->isTableNotFound($e)) {
+                throw $e;
+            }
+        }
+
+        // Also count unreviewed safeguarding incidents as critical
+        try {
+            $criticalFlags += (int) DB::table('vol_safeguarding_incidents')
+                ->where('tenant_id', $tenantId)
+                ->whereIn('severity', ['high', 'critical'])
+                ->where('status', 'open')
+                ->count();
+        } catch (\Illuminate\Database\QueryException $e) {
+            // Table may not exist yet
         }
 
         return $this->respondWithData([
-            'total_flagged' => $totalFlagged,
-            'pending_review' => $pendingReview,
             'active_assignments' => $activeAssignments,
-            'resolved' => $resolved,
+            'unreviewed_flags' => $unreviewedFlags,
+            'consented_wards' => $consentedWards,
+            'total_flags_this_month' => $totalFlagsThisMonth,
+            'critical_flags' => $criticalFlags,
         ]);
     }
 
     /**
      * GET /v2/admin/safeguarding/flagged-messages
      *
-     * Returns list of flagged messages with user info.
+     * Returns broker message copies as flagged messages in the shape the frontend expects:
+     * { id, message_content, sender: { id, name, avatar_url }, recipient: { id, name, avatar_url },
+     *   severity, flag_reason, is_reviewed, reviewed_by, review_notes, reviewed_at, created_at }
      */
     public function flaggedMessages(): JsonResponse
     {
@@ -80,42 +135,80 @@ class AdminSafeguardingController extends BaseApiController
         $tenantId = $this->getTenantId();
 
         try {
-            $messages = DB::table('flagged_messages as fm')
-                ->join('users as u', 'fm.user_id', '=', 'u.id')
-                ->where('fm.tenant_id', $tenantId)
+            $copies = DB::table('broker_message_copies as bmc')
+                ->leftJoin('users as sender', 'bmc.sender_id', '=', 'sender.id')
+                ->leftJoin('users as receiver', 'bmc.receiver_id', '=', 'receiver.id')
+                ->leftJoin('users as reviewer', 'bmc.reviewed_by', '=', 'reviewer.id')
+                ->where('bmc.tenant_id', $tenantId)
                 ->select([
-                    'fm.id',
-                    'fm.user_id',
-                    'u.first_name',
-                    'u.last_name',
-                    'u.email',
-                    'fm.message_id',
-                    'fm.reason',
-                    'fm.status',
-                    'fm.review_notes',
-                    'fm.reviewed_by',
-                    'fm.reviewed_at',
-                    'fm.created_at',
-                    'fm.updated_at',
+                    'bmc.id',
+                    'bmc.original_message_id as message_id',
+                    'bmc.message_body as message_content',
+                    'bmc.sender_id',
+                    DB::raw("COALESCE(sender.name, CONCAT(COALESCE(sender.first_name, ''), ' ', COALESCE(sender.last_name, ''))) as sender_name"),
+                    'sender.avatar_url as sender_avatar',
+                    'bmc.receiver_id',
+                    DB::raw("COALESCE(receiver.name, CONCAT(COALESCE(receiver.first_name, ''), ' ', COALESCE(receiver.last_name, ''))) as receiver_name"),
+                    'receiver.avatar_url as receiver_avatar',
+                    'bmc.copy_reason',
+                    'bmc.flagged',
+                    'bmc.reviewed_by as reviewed_by_id',
+                    DB::raw("COALESCE(reviewer.name, CONCAT(COALESCE(reviewer.first_name, ''), ' ', COALESCE(reviewer.last_name, ''))) as reviewed_by_name"),
+                    'bmc.reviewed_at',
+                    'bmc.created_at',
                 ])
-                ->orderByDesc('fm.created_at')
+                ->orderByDesc('bmc.flagged')
+                ->orderByDesc('bmc.created_at')
+                ->limit(200)
                 ->get()
-                ->map(fn ($row) => (array) $row)
+                ->map(function ($row) {
+                    $severity = 'low';
+                    if ($row->flagged) {
+                        $severity = 'high';
+                    } elseif ($row->copy_reason === 'flagged_user') {
+                        $severity = 'medium';
+                    }
+
+                    return [
+                        'id' => (int) $row->id,
+                        'message_id' => (int) $row->message_id,
+                        'message_content' => $row->message_content ?? '',
+                        'sender' => [
+                            'id' => (int) $row->sender_id,
+                            'name' => trim($row->sender_name ?? ''),
+                            'avatar_url' => $row->sender_avatar,
+                        ],
+                        'recipient' => [
+                            'id' => (int) $row->receiver_id,
+                            'name' => trim($row->receiver_name ?? ''),
+                            'avatar_url' => $row->receiver_avatar,
+                        ],
+                        'severity' => $severity,
+                        'flag_reason' => $row->copy_reason ?? 'unknown',
+                        'is_reviewed' => $row->reviewed_at !== null,
+                        'reviewed_by' => $row->reviewed_by_name ? trim($row->reviewed_by_name) : null,
+                        'review_notes' => null,
+                        'reviewed_at' => $row->reviewed_at,
+                        'created_at' => $row->created_at,
+                    ];
+                })
                 ->toArray();
+
+            return $this->respondWithData($copies);
         } catch (\Illuminate\Database\QueryException $e) {
             if ($this->isTableNotFound($e)) {
-                return $this->respondWithCollection([]);
+                return $this->respondWithData([]);
             }
             throw $e;
         }
-
-        return $this->respondWithCollection($messages);
     }
 
     /**
      * GET /v2/admin/safeguarding/assignments
      *
-     * Returns list of safeguarding assignments with user info.
+     * Returns guardian assignments in the shape the frontend expects:
+     * { id, ward: { id, name, avatar_url }, guardian: { id, name, avatar_url },
+     *   status, consent_given, created_at, expires_at }
      */
     public function assignments(): JsonResponse
     {
@@ -124,77 +217,107 @@ class AdminSafeguardingController extends BaseApiController
 
         try {
             $assignments = DB::table('safeguarding_assignments as sa')
-                ->join('users as u', 'sa.ward_user_id', '=', 'u.id')
+                ->join('users as ward', 'sa.ward_user_id', '=', 'ward.id')
+                ->join('users as guardian', 'sa.guardian_user_id', '=', 'guardian.id')
                 ->where('sa.tenant_id', $tenantId)
                 ->select([
                     'sa.id',
-                    'sa.ward_user_id as user_id',
-                    'u.first_name',
-                    'u.last_name',
-                    'u.email',
-                    'sa.guardian_user_id as assignee_id',
-                    DB::raw("'safeguarding' as type"),
-                    DB::raw("CASE WHEN sa.revoked_at IS NOT NULL THEN 'revoked' WHEN sa.consent_given_at IS NOT NULL THEN 'active' ELSE 'pending' END as status"),
+                    'sa.ward_user_id',
+                    DB::raw("COALESCE(ward.name, CONCAT(COALESCE(ward.first_name, ''), ' ', COALESCE(ward.last_name, ''))) as ward_name"),
+                    'ward.avatar_url as ward_avatar',
+                    'sa.guardian_user_id',
+                    DB::raw("COALESCE(guardian.name, CONCAT(COALESCE(guardian.first_name, ''), ' ', COALESCE(guardian.last_name, ''))) as guardian_name"),
+                    'guardian.avatar_url as guardian_avatar',
+                    'sa.consent_given_at',
+                    'sa.revoked_at',
+                    'sa.assigned_at',
                     'sa.notes',
-                    'sa.assigned_at as created_at',
-                    'sa.assigned_at as updated_at',
                 ])
                 ->orderByDesc('sa.assigned_at')
                 ->get()
-                ->map(fn ($row) => (array) $row)
+                ->map(function ($row) {
+                    $status = 'pending';
+                    if ($row->revoked_at !== null) {
+                        $status = 'revoked';
+                    } elseif ($row->consent_given_at !== null) {
+                        $status = 'active';
+                    }
+
+                    return [
+                        'id' => (int) $row->id,
+                        'ward' => [
+                            'id' => (int) $row->ward_user_id,
+                            'name' => trim($row->ward_name ?? ''),
+                            'avatar_url' => $row->ward_avatar,
+                        ],
+                        'guardian' => [
+                            'id' => (int) $row->guardian_user_id,
+                            'name' => trim($row->guardian_name ?? ''),
+                            'avatar_url' => $row->guardian_avatar,
+                        ],
+                        'status' => $status,
+                        'consent_given' => $row->consent_given_at !== null,
+                        'created_at' => $row->assigned_at,
+                        'expires_at' => null,
+                    ];
+                })
                 ->toArray();
+
+            return $this->respondWithData($assignments);
         } catch (\Illuminate\Database\QueryException $e) {
             if ($this->isTableNotFound($e) || str_contains($e->getMessage(), 'Column not found')) {
-                return $this->respondWithCollection([]);
+                return $this->respondWithData([]);
             }
             throw $e;
         }
-
-        return $this->respondWithCollection($assignments);
     }
 
     /**
      * POST /v2/admin/safeguarding/flagged-messages/{id}/review
      *
-     * Reviews a flagged message by updating its status and adding review notes.
+     * Reviews a flagged message (broker_message_copies). Frontend sends { notes }.
+     * Marks the copy as reviewed by the current admin.
      */
     public function reviewMessage(Request $request, int $id): JsonResponse
     {
         $adminId = $this->requireAdmin();
         $tenantId = $this->getTenantId();
 
-        $validated = $request->validate([
-            'action' => 'required|in:pending,approved,rejected,resolved',
-            'notes' => 'nullable|string|max:2000',
-        ]);
+        $notes = $request->input('notes', '');
 
         try {
-            $affected = DB::table('flagged_messages')
+            $affected = DB::table('broker_message_copies')
                 ->where('id', $id)
                 ->where('tenant_id', $tenantId)
+                ->whereNull('reviewed_at')
                 ->update([
-                    'status' => $validated['action'],
                     'reviewed_by' => $adminId,
-                    'review_notes' => $validated['notes'] ?? null,
                     'reviewed_at' => now(),
-                    'updated_at' => now(),
                 ]);
 
             if ($affected === 0) {
                 return $this->respondWithError(
                     'NOT_FOUND',
-                    'Flagged message not found.',
+                    'Message not found or already reviewed.',
                     null,
                     404
                 );
             }
 
-            $message = DB::table('flagged_messages')
-                ->where('id', $id)
-                ->where('tenant_id', $tenantId)
-                ->first();
+            // Audit log the review
+            DB::table('activity_log')->insert([
+                'tenant_id' => $tenantId,
+                'user_id' => $adminId,
+                'action' => 'safeguarding_message_reviewed',
+                'action_type' => 'safeguarding',
+                'entity_type' => 'broker_message_copy',
+                'entity_id' => $id,
+                'details' => json_encode(['notes' => $notes]),
+                'ip_address' => request()?->ip(),
+                'created_at' => now(),
+            ]);
 
-            return $this->respondWithData((array) $message);
+            return $this->respondWithData(['reviewed' => true]);
         } catch (\Illuminate\Database\QueryException $e) {
             if ($this->isTableNotFound($e)) {
                 return $this->respondWithError(
@@ -211,50 +334,113 @@ class AdminSafeguardingController extends BaseApiController
     /**
      * POST /v2/admin/safeguarding/assignments
      *
-     * Creates a new safeguarding assignment.
+     * Creates a new safeguarding (guardian/ward) assignment.
+     * Accepts either user IDs or email addresses:
+     *   { user_id, assignee_id } OR { ward_email, guardian_email }
      */
     public function createAssignment(Request $request): JsonResponse
     {
-        $this->requireAdmin();
+        $adminId = $this->requireAdmin();
         $tenantId = $this->getTenantId();
 
-        $validated = $request->validate([
-            'user_id' => 'required|integer',
-            'assignee_id' => 'required|integer',
-            'type' => 'required|string|max:100',
-            'notes' => 'nullable|string|max:2000',
-        ]);
+        $wardId = null;
+        $guardianId = null;
 
-        // Validate both users belong to current tenant
-        $userExists = \App\Models\User::where('id', $validated['user_id'])
-            ->where('tenant_id', $tenantId)
-            ->exists();
-        $assigneeExists = \App\Models\User::where('id', $validated['assignee_id'])
-            ->where('tenant_id', $tenantId)
-            ->exists();
+        // Support both ID-based and email-based input from the frontend
+        if ($request->has('ward_email') || $request->has('guardian_email')) {
+            $wardEmail = trim($request->input('ward_email', ''));
+            $guardianEmail = trim($request->input('guardian_email', ''));
 
-        if (!$userExists) {
-            return $this->respondWithError('INVALID_USER', 'User not found in this tenant', 'user_id', 404);
+            if (empty($wardEmail) || empty($guardianEmail)) {
+                return $this->respondWithError('VALIDATION_ERROR', 'Both ward and guardian emails are required', null, 422);
+            }
+
+            $ward = \App\Models\User::where('email', $wardEmail)
+                ->where('tenant_id', $tenantId)
+                ->where('status', 'active')
+                ->first();
+            $guardian = \App\Models\User::where('email', $guardianEmail)
+                ->where('tenant_id', $tenantId)
+                ->where('status', 'active')
+                ->first();
+
+            if (!$ward) {
+                return $this->respondWithError('INVALID_USER', "No active member found with email: {$wardEmail}", 'ward_email', 404);
+            }
+            if (!$guardian) {
+                return $this->respondWithError('INVALID_USER', "No active member found with email: {$guardianEmail}", 'guardian_email', 404);
+            }
+
+            $wardId = $ward->id;
+            $guardianId = $guardian->id;
+        } else {
+            $validated = $request->validate([
+                'user_id' => 'required|integer',
+                'assignee_id' => 'required|integer',
+            ]);
+
+            $wardId = $validated['user_id'];
+            $guardianId = $validated['assignee_id'];
+
+            // Validate both users belong to current tenant
+            if (!\App\Models\User::where('id', $wardId)->where('tenant_id', $tenantId)->exists()) {
+                return $this->respondWithError('INVALID_USER', 'Ward user not found in this tenant', 'user_id', 404);
+            }
+            if (!\App\Models\User::where('id', $guardianId)->where('tenant_id', $tenantId)->exists()) {
+                return $this->respondWithError('INVALID_USER', 'Guardian user not found in this tenant', 'assignee_id', 404);
+            }
         }
-        if (!$assigneeExists) {
-            return $this->respondWithError('INVALID_USER', 'Assignee not found in this tenant', 'assignee_id', 404);
+
+        if ($wardId === $guardianId) {
+            return $this->respondWithError('VALIDATION_ERROR', 'Ward and guardian cannot be the same person', null, 422);
         }
+
+        $notes = $request->input('notes', '');
 
         try {
             $id = DB::table('safeguarding_assignments')->insertGetId([
                 'tenant_id' => $tenantId,
-                'ward_user_id' => $validated['user_id'],
-                'guardian_user_id' => $validated['assignee_id'],
-                'assigned_by' => $this->requireAdmin(),
+                'ward_user_id' => $wardId,
+                'guardian_user_id' => $guardianId,
+                'assigned_by' => $adminId,
                 'assigned_at' => now(),
-                'notes' => $validated['notes'] ?? null,
+                'notes' => $notes ?: null,
             ]);
 
-            $assignment = DB::table('safeguarding_assignments')
-                ->where('id', $id)
-                ->first();
+            // Audit log
+            DB::table('activity_log')->insert([
+                'tenant_id' => $tenantId,
+                'user_id' => $adminId,
+                'action' => 'safeguarding_assignment_created',
+                'action_type' => 'safeguarding',
+                'entity_type' => 'safeguarding_assignment',
+                'entity_id' => $id,
+                'details' => json_encode([
+                    'ward_user_id' => $wardId,
+                    'guardian_user_id' => $guardianId,
+                ]),
+                'ip_address' => request()?->ip(),
+                'created_at' => now(),
+            ]);
 
-            return $this->respondWithData((array) $assignment);
+            // Notify the ward and guardian
+            try {
+                $wardUser = \App\Models\User::find($wardId);
+                $guardianUser = \App\Models\User::find($guardianId);
+
+                \App\Models\Notification::create([
+                    'tenant_id' => $tenantId,
+                    'user_id' => $guardianId,
+                    'type' => 'safeguarding_assignment',
+                    'message' => 'You have been assigned as a safeguarding guardian for ' . ($wardUser->name ?? 'a member'),
+                    'link' => '/admin/safeguarding',
+                    'is_read' => false,
+                ]);
+            } catch (\Throwable $e) {
+                \Illuminate\Support\Facades\Log::warning('Failed to notify guardian of assignment', ['error' => $e->getMessage()]);
+            }
+
+            return $this->respondWithData(['id' => $id, 'created' => true]);
         } catch (\Illuminate\Database\QueryException $e) {
             if ($this->isTableNotFound($e)) {
                 return $this->respondWithError(
@@ -271,29 +457,45 @@ class AdminSafeguardingController extends BaseApiController
     /**
      * DELETE /v2/admin/safeguarding/assignments/{id}
      *
-     * Deletes a safeguarding assignment.
+     * Soft-deletes (revokes) a safeguarding assignment to preserve the audit trail.
      */
     public function deleteAssignment(int $id): JsonResponse
     {
-        $this->requireAdmin();
+        $adminId = $this->requireAdmin();
         $tenantId = $this->getTenantId();
 
         try {
             $affected = DB::table('safeguarding_assignments')
                 ->where('id', $id)
                 ->where('tenant_id', $tenantId)
-                ->delete();
+                ->whereNull('revoked_at')
+                ->update([
+                    'revoked_at' => now(),
+                ]);
 
             if ($affected === 0) {
                 return $this->respondWithError(
                     'NOT_FOUND',
-                    'Assignment not found.',
+                    'Assignment not found or already revoked.',
                     null,
                     404
                 );
             }
 
-            return $this->respondWithData(['deleted' => true]);
+            // Audit log the revocation
+            DB::table('activity_log')->insert([
+                'tenant_id' => $tenantId,
+                'user_id' => $adminId,
+                'action' => 'safeguarding_assignment_revoked',
+                'action_type' => 'safeguarding',
+                'entity_type' => 'safeguarding_assignment',
+                'entity_id' => $id,
+                'details' => json_encode(['revoked_by_admin' => $adminId]),
+                'ip_address' => request()?->ip(),
+                'created_at' => now(),
+            ]);
+
+            return $this->respondWithData(['revoked' => true]);
         } catch (\Illuminate\Database\QueryException $e) {
             if ($this->isTableNotFound($e)) {
                 return $this->respondWithError(
@@ -321,7 +523,7 @@ class AdminSafeguardingController extends BaseApiController
     public function memberPreferences(): JsonResponse
     {
         $adminId = $this->requireAdmin();
-        $tenantId = \App\Core\TenantContext::getId();
+        $tenantId = TenantContext::getId();
 
         try {
             $rows = DB::select(
@@ -368,6 +570,7 @@ class AdminSafeguardingController extends BaseApiController
 
             // Audit log this access
             DB::table('activity_log')->insert([
+                'tenant_id' => $tenantId,
                 'user_id' => $adminId,
                 'action' => 'safeguarding_preferences_list_viewed',
                 'action_type' => 'safeguarding',

--- a/app/Listeners/CopyMessageForBrokerReview.php
+++ b/app/Listeners/CopyMessageForBrokerReview.php
@@ -1,0 +1,64 @@
+<?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
+namespace App\Listeners;
+
+use App\Events\MessageSent;
+use App\Services\BrokerMessageVisibilityService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Checks every sent message against broker visibility rules and copies
+ * it to the broker review queue when criteria are met.
+ *
+ * Criteria (evaluated by BrokerMessageVisibilityService):
+ * - Sender is under safeguarding monitoring (flagged user)
+ * - First contact between two members
+ * - Sender is a new member (within monitoring window)
+ * - Message relates to a high-risk listing
+ * - Random compliance sampling
+ *
+ * Queued so it never delays message delivery to the recipient.
+ */
+class CopyMessageForBrokerReview implements ShouldQueue
+{
+    public function __construct()
+    {
+        //
+    }
+
+    public function handle(MessageSent $event): void
+    {
+        try {
+            $message = $event->message;
+            $senderId = (int) $message->sender_id;
+            $receiverId = (int) $message->receiver_id;
+            $listingId = $message->listing_id ? (int) $message->listing_id : null;
+
+            // Set tenant context for the queued job — required for HasTenantScope
+            // trait and any service that reads TenantContext::getId()
+            if ($event->tenantId) {
+                \App\Core\TenantContext::setById($event->tenantId);
+            }
+
+            /** @var BrokerMessageVisibilityService $visibilityService */
+            $visibilityService = app(BrokerMessageVisibilityService::class);
+
+            $copyReason = $visibilityService->shouldCopyMessage($senderId, $receiverId, $listingId);
+
+            if ($copyReason !== null) {
+                $visibilityService->copyMessageForBroker($message->id, $copyReason);
+            }
+        } catch (\Throwable $e) {
+            Log::error('CopyMessageForBrokerReview: failed', [
+                'message_id' => $event->message->id ?? null,
+                'tenant_id' => $event->tenantId ?? null,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/app/Listeners/NotifySafeguardingStaff.php
+++ b/app/Listeners/NotifySafeguardingStaff.php
@@ -34,6 +34,10 @@ class NotifySafeguardingStaff implements ShouldQueue
             $tenantId = $event->tenantId;
             $flaggedUserId = $event->userId;
 
+            // Set tenant context for queued job — required for HasTenantScope
+            // and any service that reads TenantContext::getId()
+            \App\Core\TenantContext::setById($tenantId);
+
             // Load the flagged member's name
             $flaggedUser = User::find($flaggedUserId);
             $memberName = $flaggedUser
@@ -52,10 +56,10 @@ class NotifySafeguardingStaff implements ShouldQueue
                 ? implode(', ', $optionLabels)
                 : 'safeguarding support options';
 
-            // Find all admin and broker users for this tenant
+            // Find all admin, tenant_admin, broker, and super_admin users for this tenant
             $staffUsers = DB::select(
                 "SELECT id, email, first_name, name, role FROM users
-                 WHERE tenant_id = ? AND role IN ('admin', 'broker', 'super_admin') AND status = 'active'",
+                 WHERE tenant_id = ? AND role IN ('admin', 'tenant_admin', 'broker', 'super_admin') AND status = 'active'",
                 [$tenantId]
             );
 

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -25,7 +25,7 @@ class Notification extends Model
     public $timestamps = false;
 
     protected $fillable = [
-        'user_id', 'type', 'message',
+        'tenant_id', 'user_id', 'type', 'message',
         'link', 'is_read', 'created_at',
     ];
 

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -13,6 +13,7 @@ use App\Events\MessageSent;
 use App\Events\SafeguardingFlaggedEvent;
 use App\Events\TransactionCompleted;
 use App\Events\UserRegistered;
+use App\Listeners\CopyMessageForBrokerReview;
 use App\Listeners\NotifyConnectionRequest;
 use App\Listeners\NotifyJobAlertSubscribers;
 use App\Listeners\NotifyMessageReceived;
@@ -55,6 +56,7 @@ class EventServiceProvider extends ServiceProvider
 
         MessageSent::class => [
             NotifyMessageReceived::class,
+            CopyMessageForBrokerReview::class,
         ],
 
         JobVacancyCreated::class => [

--- a/app/Services/BrokerMessageVisibilityService.php
+++ b/app/Services/BrokerMessageVisibilityService.php
@@ -51,7 +51,8 @@ class BrokerMessageVisibilityService
             return null;
         }
 
-        if ($this->isUserUnderMonitoring($senderId)) {
+        // Check BOTH sender and receiver — messages to/from vulnerable users must be monitored
+        if ($this->isUserUnderMonitoring($senderId) || $this->isUserUnderMonitoring($receiverId)) {
             return self::REASON_FLAGGED_USER;
         }
 

--- a/app/Services/ExchangeWorkflowService.php
+++ b/app/Services/ExchangeWorkflowService.php
@@ -141,7 +141,12 @@ class ExchangeWorkflowService
             return false;
         }
 
-        $needsBroker = self::needsBrokerApproval($exchange->listing_id, (float) $exchange->proposed_hours);
+        $needsBroker = self::needsBrokerApproval(
+            $exchange->listing_id,
+            (float) $exchange->proposed_hours,
+            (int) $exchange->requester_id,
+            (int) $exchange->provider_id
+        );
         $newStatus = $needsBroker ? self::STATUS_PENDING_BROKER : self::STATUS_ACCEPTED;
 
         return self::updateStatus($exchangeId, $newStatus, $providerId, 'provider', 'Provider accepted request');
@@ -778,9 +783,38 @@ class ExchangeWorkflowService
 
     /**
      * Check if an exchange needs broker approval (static).
+     *
+     * Checks TWO layers:
+     * 1. User-level safeguarding: either party has requires_broker_approval in user_messaging_restrictions
+     *    (set when a vulnerable person ticks safeguarding checkboxes during onboarding)
+     * 2. Listing-level risk: listing risk tags, hours threshold, or global broker approval config
      */
-    private static function needsBrokerApproval(int $listingId, float $proposedHours): bool
+    private static function needsBrokerApproval(int $listingId, float $proposedHours, ?int $requesterId = null, ?int $providerId = null): bool
     {
+        $tenantId = TenantContext::getId();
+
+        // LAYER 1: User-level safeguarding flags (always checked, even if exchange workflow is "off")
+        // A vulnerable person's exchanges MUST go through broker regardless of tenant config
+        try {
+            $userIds = array_filter([$requesterId, $providerId]);
+            if (!empty($userIds)) {
+                $placeholders = implode(',', array_fill(0, count($userIds), '?'));
+                $hasSafeguardingFlag = DB::selectOne(
+                    "SELECT COUNT(*) as cnt FROM user_messaging_restrictions
+                     WHERE tenant_id = ? AND user_id IN ({$placeholders})
+                     AND requires_broker_approval = 1
+                     AND (monitoring_expires_at IS NULL OR monitoring_expires_at > NOW())",
+                    array_merge([$tenantId], $userIds)
+                );
+                if ($hasSafeguardingFlag && (int) $hasSafeguardingFlag->cnt > 0) {
+                    return true;
+                }
+            }
+        } catch (\Exception $e) {
+            // Table may not exist — fail open for this check only
+        }
+
+        // LAYER 2: Listing-level and tenant-level config checks
         try {
             $configService = app(BrokerControlConfigService::class);
             if (!$configService->isExchangeWorkflowEnabled()) {
@@ -794,8 +828,6 @@ class ExchangeWorkflowService
             }
 
             if (!empty($config['auto_approve_low_risk'])) {
-                $tenantId = TenantContext::getId();
-
                 $isHighRisk = DB::table('listing_risk_tags')
                     ->where('listing_id', $listingId)
                     ->where('tenant_id', $tenantId)

--- a/app/Services/SafeguardingPreferenceService.php
+++ b/app/Services/SafeguardingPreferenceService.php
@@ -427,6 +427,7 @@ class SafeguardingPreferenceService
     ): void {
         try {
             DB::table('activity_log')->insert([
+                'tenant_id' => TenantContext::getId(),
                 'user_id' => $userId,
                 'action' => $action,
                 'action_type' => 'safeguarding',

--- a/react-frontend/src/contexts/NotificationsContext.tsx
+++ b/react-frontend/src/contexts/NotificationsContext.tsx
@@ -434,6 +434,8 @@ function getToastConfig(type: string): { title: string } {
     group: { title: t('group', 'Group Notification') },
     achievement: { title: t('achievement', 'Achievement Unlocked!') },
     broker_review: { title: t('broker_review', 'Message for Review') },
+    safeguarding_flag: { title: t('safeguarding_flag', 'Safeguarding Alert') },
+    safeguarding_assignment: { title: t('safeguarding_assignment', 'Safeguarding Assignment') },
     system: { title: t('system', 'System Notification') },
     vol_application_received: { title: t('vol_application_received', 'New Application') },
     vol_application_approved: { title: t('vol_application_approved', 'Application Approved') },

--- a/react-frontend/src/pages/notifications/NotificationsPage.tsx
+++ b/react-frontend/src/pages/notifications/NotificationsPage.tsx
@@ -24,6 +24,9 @@ import {
   CheckCheck,
   Trash2,
   Settings,
+  ShieldAlert,
+  Shield,
+  Eye,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { GlassCard } from '@/components/ui';
@@ -296,6 +299,9 @@ function NotificationCard({ notification, onMarkRead, onDelete }: NotificationCa
     event: { icon: <Calendar className="w-5 h-5" />, color: 'rose' },
     group: { icon: <Users className="w-5 h-5" />, color: 'teal' },
     achievement: { icon: <Award className="w-5 h-5" />, color: 'orange' },
+    safeguarding_flag: { icon: <ShieldAlert className="w-5 h-5" />, color: 'red' },
+    safeguarding_assignment: { icon: <Shield className="w-5 h-5" />, color: 'blue' },
+    broker_review: { icon: <Eye className="w-5 h-5" />, color: 'amber' },
   };
 
   const { icon, color } = iconMap[notification.type] || { icon: <Bell className="w-5 h-5" />, color: 'gray' };
@@ -308,6 +314,8 @@ function NotificationCard({ notification, onMarkRead, onDelete }: NotificationCa
     rose: 'bg-rose-500/20 text-rose-600 dark:text-rose-400',
     teal: 'bg-teal-500/20 text-teal-600 dark:text-teal-400',
     orange: 'bg-orange-500/20 text-orange-600 dark:text-orange-400',
+    red: 'bg-red-500/20 text-red-600 dark:text-red-400',
+    blue: 'bg-blue-500/20 text-blue-600 dark:text-blue-400',
     gray: 'bg-theme-elevated text-theme-muted',
   };
 


### PR DESCRIPTION
## Summary

Full security audit of the safeguarding module for vulnerable adult protection. **10 critical/high issues found and fixed** across the entire notification delivery chain, message monitoring, exchange enforcement, and admin dashboard.

- **Notification delivery was completely broken** — `tenant_id` silently dropped from all safeguarding notifications (missing from `$fillable`), queued listener had no tenant context, tenant admins excluded from alerts, React UI showed generic "Notification" instead of "Safeguarding Alert"
- **Message monitoring was not wired up** — `BrokerMessageVisibilityService.shouldCopyMessage()` was never called from the message sending flow; messages TO vulnerable users (not just FROM) were also not monitored
- **Exchange broker approval had a bypass** — vulnerable users' `requires_broker_approval` flag was ignored; only listing-level risk tags were checked
- **Admin dashboard returned wrong data** — all 5 endpoints had frontend-backend data contract mismatches

### Files changed (10)

| File | Change |
|------|--------|
| `app/Models/Notification.php` | Added `tenant_id` to `$fillable` — was silently dropped on every `create()` call |
| `app/Listeners/NotifySafeguardingStaff.php` | Added `TenantContext::setById()`, added `tenant_admin` role to staff query |
| `app/Listeners/CopyMessageForBrokerReview.php` | **NEW** — queued listener wiring `MessageSent` → broker message copy |
| `app/Providers/EventServiceProvider.php` | Registered `CopyMessageForBrokerReview` on `MessageSent` |
| `app/Services/BrokerMessageVisibilityService.php` | `shouldCopyMessage()` now checks both sender AND receiver monitoring |
| `app/Services/ExchangeWorkflowService.php` | `needsBrokerApproval()` now checks user-level safeguarding flags from `user_messaging_restrictions` |
| `app/Services/SafeguardingPreferenceService.php` | Added `tenant_id` to audit log inserts |
| `app/Http/Controllers/Api/AdminSafeguardingController.php` | Rewritten — all endpoints now return correct data shapes matching frontend types |
| `react-frontend/src/contexts/NotificationsContext.tsx` | Added `safeguarding_flag` and `safeguarding_assignment` to toast config |
| `react-frontend/src/pages/notifications/NotificationsPage.tsx` | Added red ShieldAlert icon for safeguarding notifications |

## Test plan

- [ ] Enable safeguarding step in admin Onboarding Settings
- [ ] As a new member, complete onboarding and tick "I consider myself a vulnerable adult"
- [ ] Verify admin receives in-app notification with "Safeguarding Alert" toast (not generic)
- [ ] Verify admin receives email with member name and selected options
- [ ] Verify notification appears in admin's notification list with red ShieldAlert icon
- [ ] Verify `user_messaging_restrictions` row created with `under_monitoring=1`, `requires_broker_approval=1`
- [ ] Send a message TO the vulnerable member — verify it appears in broker message review
- [ ] Send a message FROM the vulnerable member — verify it also appears in broker review
- [ ] Create an exchange involving the vulnerable member — verify it routes to `pending_broker` status
- [ ] Verify admin safeguarding dashboard loads with correct stats, flagged messages, and assignments
- [ ] Verify admin can create guardian assignment by email in the safeguarding dashboard
- [ ] Verify admin can revoke assignment (soft-delete, not hard-delete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)