### PR TITLE
chore: full system audit — security, SPDX, i18n, PHP quality, React fixes

### DIFF
--- a/app/Http/Controllers/Api/AdminCrmController.php
+++ b/app/Http/Controllers/Api/AdminCrmController.php
@@ -109,10 +109,10 @@ class AdminCrmController extends BaseApiController
         try {
             $openTasks = (int) DB::selectOne("SELECT COUNT(*) as cnt FROM coordinator_tasks WHERE tenant_id = ? AND status IN ('pending','in_progress')", [$tenantId])->cnt;
             $overdueTasks = (int) DB::selectOne("SELECT COUNT(*) as cnt FROM coordinator_tasks WHERE tenant_id = ? AND status IN ('pending','in_progress') AND due_date < CURDATE()", [$tenantId])->cnt;
-        } catch (\Throwable $e) {}
+        } catch (\Throwable $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
 
         $totalNotes = 0;
-        try { $totalNotes = (int) DB::selectOne("SELECT COUNT(*) as cnt FROM member_notes WHERE tenant_id = ?", [$tenantId])->cnt; } catch (\Throwable $e) {}
+        try { $totalNotes = (int) DB::selectOne("SELECT COUNT(*) as cnt FROM member_notes WHERE tenant_id = ?", [$tenantId])->cnt; } catch (\Throwable $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
 
         $neverLoggedIn = (int) DB::selectOne("SELECT COUNT(*) as cnt FROM users WHERE tenant_id = ? AND last_login_at IS NULL AND is_approved = 1", [$tenantId])->cnt;
         $approvedMembers = (int) DB::selectOne("SELECT COUNT(*) as cnt FROM users WHERE tenant_id = ? AND is_approved = 1", [$tenantId])->cnt;
@@ -141,7 +141,7 @@ class AdminCrmController extends BaseApiController
         $profileCompleted = (int) DB::selectOne("SELECT COUNT(*) as cnt FROM users WHERE tenant_id = ? AND (bio IS NOT NULL AND bio != '') AND (location IS NOT NULL AND location != '')", [$tenantId])->cnt;
 
         $firstListing = 0;
-        try { $firstListing = (int) DB::selectOne("SELECT COUNT(DISTINCT user_id) as cnt FROM listings WHERE tenant_id = ?", [$tenantId])->cnt; } catch (\Throwable $e) {}
+        try { $firstListing = (int) DB::selectOne("SELECT COUNT(DISTINCT user_id) as cnt FROM listings WHERE tenant_id = ?", [$tenantId])->cnt; } catch (\Throwable $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
 
         $firstExchange = 0;
         try {
@@ -149,7 +149,7 @@ class AdminCrmController extends BaseApiController
                 "SELECT COUNT(DISTINCT u) as cnt FROM (SELECT sender_id as u FROM transactions WHERE tenant_id = ? AND status = 'completed' UNION SELECT receiver_id as u FROM transactions WHERE tenant_id = ? AND status = 'completed') AS combined",
                 [$tenantId, $tenantId]
             )->cnt;
-        } catch (\Throwable $e) {}
+        } catch (\Throwable $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
 
         $repeatUser = 0;
         try {
@@ -157,7 +157,7 @@ class AdminCrmController extends BaseApiController
                 "SELECT COUNT(*) as cnt FROM (SELECT u, COUNT(*) as tx_count FROM (SELECT sender_id as u FROM transactions WHERE tenant_id = ? AND status = 'completed' UNION ALL SELECT receiver_id as u FROM transactions WHERE tenant_id = ? AND status = 'completed') AS all_tx GROUP BY u HAVING tx_count >= 2) AS repeat_users",
                 [$tenantId, $tenantId]
             )->cnt;
-        } catch (\Throwable $e) {}
+        } catch (\Throwable $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
 
         $monthlyRegistrations = DB::select(
             "SELECT DATE_FORMAT(created_at, '%Y-%m') as month, COUNT(*) as count FROM users WHERE tenant_id = ? AND created_at >= DATE_SUB(NOW(), INTERVAL 6 MONTH) GROUP BY DATE_FORMAT(created_at, '%Y-%m') ORDER BY month ASC",
@@ -764,7 +764,7 @@ class AdminCrmController extends BaseApiController
                 if ($userId) { $sql .= " AND l.user_id = ?"; $p[] = $userId; $cp[] = $userId; }
                 if ($useDayFilter) { $sql .= " AND l.created_at >= DATE_SUB(NOW(), INTERVAL ? DAY)"; $p[] = $safeDays; $cp[] = $safeDays; }
                 $unions[] = $sql; $params = array_merge($params, $p); $countParams = array_merge($countParams, $cp);
-            } catch (\Throwable $e) {}
+            } catch (\Throwable $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
         }
 
         // 4. Exchanges completed
@@ -779,7 +779,7 @@ class AdminCrmController extends BaseApiController
                 if ($userId) { $sql .= " AND t.sender_id = ?"; $p[] = $userId; $cp[] = $userId; }
                 if ($useDayFilter) { $sql .= " AND t.created_at >= DATE_SUB(NOW(), INTERVAL ? DAY)"; $p[] = $safeDays; $cp[] = $safeDays; }
                 $unions[] = $sql; $params = array_merge($params, $p); $countParams = array_merge($countParams, $cp);
-            } catch (\Throwable $e) {}
+            } catch (\Throwable $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
         }
 
         // 5. Notes added
@@ -794,7 +794,7 @@ class AdminCrmController extends BaseApiController
                 if ($userId) { $sql .= " AND mn.user_id = ?"; $p[] = $userId; $cp[] = $userId; }
                 if ($useDayFilter) { $sql .= " AND mn.created_at >= DATE_SUB(NOW(), INTERVAL ? DAY)"; $p[] = $safeDays; $cp[] = $safeDays; }
                 $unions[] = $sql; $params = array_merge($params, $p); $countParams = array_merge($countParams, $cp);
-            } catch (\Throwable $e) {}
+            } catch (\Throwable $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
         }
 
         // 6. Tasks created
@@ -808,7 +808,7 @@ class AdminCrmController extends BaseApiController
                 if ($userId) { $sql .= " AND ct.created_by = ?"; $p[] = $userId; $cp[] = $userId; }
                 if ($useDayFilter) { $sql .= " AND ct.created_at >= DATE_SUB(NOW(), INTERVAL ? DAY)"; $p[] = $safeDays; $cp[] = $safeDays; }
                 $unions[] = $sql; $params = array_merge($params, $p); $countParams = array_merge($countParams, $cp);
-            } catch (\Throwable $e) {}
+            } catch (\Throwable $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
         }
 
         // 7. Group joins
@@ -823,7 +823,7 @@ class AdminCrmController extends BaseApiController
                 if ($userId) { $sql .= " AND gm.user_id = ?"; $p[] = $userId; $cp[] = $userId; }
                 if ($useDayFilter) { $sql .= " AND gm.created_at >= DATE_SUB(NOW(), INTERVAL ? DAY)"; $p[] = $safeDays; $cp[] = $safeDays; }
                 $unions[] = $sql; $params = array_merge($params, $p); $countParams = array_merge($countParams, $cp);
-            } catch (\Throwable $e) {}
+            } catch (\Throwable $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
         }
 
         // 8. Profile updates

--- a/app/Http/Controllers/Api/AdminFederationController.php
+++ b/app/Http/Controllers/Api/AdminFederationController.php
@@ -179,7 +179,7 @@ class AdminFederationController extends BaseApiController
                     $data['settings'] = array_merge($data['settings'], array_diff_key($fc, ['federation_enabled' => '']));
                 }
             }
-        } catch (\Exception $e) {}
+        } catch (\Exception $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
 
         return $this->respondWithData($data);
     }
@@ -204,7 +204,7 @@ class AdminFederationController extends BaseApiController
             $config['federation'] = $federationSettings;
 
             DB::update("UPDATE tenants SET configuration = ? WHERE id = ?", [json_encode($config), $tenantId]);
-            try { app(\App\Services\RedisCache::class)->delete('tenant_bootstrap', $tenantId); } catch (\Exception $e) {}
+            try { app(\App\Services\RedisCache::class)->delete('tenant_bootstrap', $tenantId); } catch (\Exception $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
 
             return $this->respondWithData([
                 'federation_enabled' => $federationSettings['federation_enabled'] ?? false,
@@ -520,7 +520,7 @@ class AdminFederationController extends BaseApiController
                         [$t1, $t2, $t2, $t1]
                     );
                     $stats['messages_exchanged'] = (int) ($row->total ?? 0);
-                } catch (\Exception $e) {}
+                } catch (\Exception $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
             }
 
             if ($this->tableExists('federation_transactions')) {
@@ -530,7 +530,7 @@ class AdminFederationController extends BaseApiController
                         [$t1, $t2, $t2, $t1]
                     );
                     $stats['transactions_completed'] = (int) ($row->total ?? 0);
-                } catch (\Exception $e) {}
+                } catch (\Exception $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
             }
 
             return $this->respondWithData($stats);
@@ -602,7 +602,7 @@ class AdminFederationController extends BaseApiController
             $config = json_decode($row->configuration ?? '{}', true) ?: [];
             $config['federation_profile'] = array_merge($config['federation_profile'] ?? [], $input);
             DB::update("UPDATE tenants SET configuration = ? WHERE id = ?", [json_encode($config), $tenantId]);
-            try { app(\App\Services\RedisCache::class)->delete('tenant_bootstrap', $tenantId); } catch (\Exception $e) {}
+            try { app(\App\Services\RedisCache::class)->delete('tenant_bootstrap', $tenantId); } catch (\Exception $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
             return $this->respondWithData($config['federation_profile']);
         } catch (\Exception $e) {
             return $this->respondWithError('UPDATE_FAILED', __('api.update_failed', ['resource' => 'federation profile']), null, 500);
@@ -662,13 +662,13 @@ class AdminFederationController extends BaseApiController
         $data = ['total_partnerships' => 0, 'active_partnerships' => 0, 'pending_requests' => 0, 'cross_community_transactions' => 0, 'cross_community_messages' => 0];
 
         if ($this->tableExists('federation_partnerships')) {
-            try { $row = DB::selectOne("SELECT COUNT(*) as total, SUM(CASE WHEN status='active' THEN 1 ELSE 0 END) as active_count, SUM(CASE WHEN status='pending' THEN 1 ELSE 0 END) as pending FROM federation_partnerships WHERE tenant_id = ? OR partner_tenant_id = ?", [$tenantId, $tenantId]); $data['total_partnerships'] = (int)($row->total ?? 0); $data['active_partnerships'] = (int)($row->active_count ?? 0); $data['pending_requests'] = (int)($row->pending ?? 0); } catch (\Exception $e) {}
+            try { $row = DB::selectOne("SELECT COUNT(*) as total, SUM(CASE WHEN status='active' THEN 1 ELSE 0 END) as active_count, SUM(CASE WHEN status='pending' THEN 1 ELSE 0 END) as pending FROM federation_partnerships WHERE tenant_id = ? OR partner_tenant_id = ?", [$tenantId, $tenantId]); $data['total_partnerships'] = (int)($row->total ?? 0); $data['active_partnerships'] = (int)($row->active_count ?? 0); $data['pending_requests'] = (int)($row->pending ?? 0); } catch (\Exception $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
         }
         if ($this->tableExists('federation_transactions')) {
-            try { $row = DB::selectOne("SELECT COUNT(*) as total FROM federation_transactions WHERE sender_tenant_id = ? OR receiver_tenant_id = ?", [$tenantId, $tenantId]); $data['cross_community_transactions'] = (int)($row->total ?? 0); } catch (\Exception $e) {}
+            try { $row = DB::selectOne("SELECT COUNT(*) as total FROM federation_transactions WHERE sender_tenant_id = ? OR receiver_tenant_id = ?", [$tenantId, $tenantId]); $data['cross_community_transactions'] = (int)($row->total ?? 0); } catch (\Exception $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
         }
         if ($this->tableExists('federation_messages')) {
-            try { $row = DB::selectOne("SELECT COUNT(*) as total FROM federation_messages WHERE sender_tenant_id = ? OR receiver_tenant_id = ?", [$tenantId, $tenantId]); $data['cross_community_messages'] = (int)($row->total ?? 0); } catch (\Exception $e) {}
+            try { $row = DB::selectOne("SELECT COUNT(*) as total FROM federation_messages WHERE sender_tenant_id = ? OR receiver_tenant_id = ?", [$tenantId, $tenantId]); $data['cross_community_messages'] = (int)($row->total ?? 0); } catch (\Exception $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
         }
         return $this->respondWithData($data);
     }

--- a/app/Http/Controllers/Api/AdminGroupsController.php
+++ b/app/Http/Controllers/Api/AdminGroupsController.php
@@ -533,7 +533,7 @@ class AdminGroupsController extends BaseApiController
                 $policyCount = 0;
                 try {
                     $policyCount = (int) (DB::selectOne("SELECT COUNT(*) as cnt FROM group_policies WHERE tenant_id = ?", [$tenantId])->cnt ?? 0);
-                } catch (\Throwable $e) {}
+                } catch (\Throwable $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
 
                 return [
                     'id' => (int) $row->id,
@@ -1046,9 +1046,9 @@ class AdminGroupsController extends BaseApiController
 
             $memberCount = (int) (DB::selectOne("SELECT COUNT(*) as cnt FROM group_members WHERE group_id = ? AND tenant_id = ?", [$id, $tenantId])->cnt ?? 0);
             $postsCount = 0;
-            try { $postsCount = (int) (DB::selectOne("SELECT COUNT(*) as cnt FROM group_posts gp JOIN group_discussions gd ON gp.discussion_id = gd.id WHERE gd.group_id = ? AND gd.tenant_id = ?", [$id, $tenantId])->cnt ?? 0); } catch (\Throwable $e) {}
+            try { $postsCount = (int) (DB::selectOne("SELECT COUNT(*) as cnt FROM group_posts gp JOIN group_discussions gd ON gp.discussion_id = gd.id WHERE gd.group_id = ? AND gd.tenant_id = ?", [$id, $tenantId])->cnt ?? 0); } catch (\Throwable $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
             $eventsCount = 0;
-            try { $eventsCount = (int) (DB::selectOne("SELECT COUNT(*) as cnt FROM events WHERE group_id = ? AND tenant_id = ?", [$id, $tenantId])->cnt ?? 0); } catch (\Throwable $e) {}
+            try { $eventsCount = (int) (DB::selectOne("SELECT COUNT(*) as cnt FROM events WHERE group_id = ? AND tenant_id = ?", [$id, $tenantId])->cnt ?? 0); } catch (\Throwable $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
 
             return $this->respondWithData([
                 'group_id' => $id,

--- a/app/Http/Controllers/Api/AdminTimebankingController.php
+++ b/app/Http/Controllers/Api/AdminTimebankingController.php
@@ -8,6 +8,7 @@ namespace App\Http\Controllers\Api;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use App\Core\TenantContext;
 use App\Services\AbuseDetectionService;
 
@@ -57,7 +58,7 @@ class AdminTimebankingController extends BaseApiController
                 "SELECT COUNT(*) as cnt FROM abuse_alerts WHERE tenant_id = ? AND status IN ('new', 'reviewing')",
                 [$tenantId]
             )->cnt;
-        } catch (\Throwable $e) {}
+        } catch (\Throwable $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
 
         return $this->respondWithData([
             'total_transactions' => (int) ($txRow->total_transactions ?? 0),
@@ -105,7 +106,7 @@ class AdminTimebankingController extends BaseApiController
             $params[] = $offset;
 
             $items = DB::select($sql, $params);
-        } catch (\Throwable $e) {}
+        } catch (\Throwable $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
 
         $formatted = array_map(fn($r) => [
             'id' => (int) $r->id,
@@ -301,7 +302,7 @@ class AdminTimebankingController extends BaseApiController
                     'created_at' => $row->created_at ?? '',
                 ];
             }
-        } catch (\Throwable $e) {}
+        } catch (\Throwable $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
 
         return $this->respondWithData($wallets);
     }

--- a/app/Http/Controllers/Api/AdminToolsController.php
+++ b/app/Http/Controllers/Api/AdminToolsController.php
@@ -8,6 +8,7 @@ namespace App\Http\Controllers\Api;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use App\Core\TenantContext;
 use App\Services\RedisCache;
 use App\Services\TokenService;
@@ -260,7 +261,7 @@ class AdminToolsController extends BaseApiController
                 }
 
                 $pendingConversion = $nonWebpImages;
-            } catch (\Throwable $e) {}
+            } catch (\Throwable $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
         }
 
         return $this->respondWithData([
@@ -334,7 +335,7 @@ class AdminToolsController extends BaseApiController
                 }
 
                 usort($backups, fn($a, $b) => strcmp($b['created_at'], $a['created_at']));
-            } catch (\Throwable $e) {}
+            } catch (\Throwable $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
         }
 
         return $this->respondWithData($backups);

--- a/app/Http/Controllers/Api/AdminUsersController.php
+++ b/app/Http/Controllers/Api/AdminUsersController.php
@@ -221,7 +221,7 @@ class AdminUsersController extends BaseApiController
                 'icon' => $b->badge_icon ?? null,
                 'awarded_at' => $b->awarded_at ?? '',
             ], $badgeRows);
-        } catch (\Throwable $e) {}
+        } catch (\Throwable $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
 
         return $this->respondWithData([
             'id' => (int) $user->id,

--- a/app/Http/Controllers/Api/AdminVolunteerController.php
+++ b/app/Http/Controllers/Api/AdminVolunteerController.php
@@ -378,7 +378,7 @@ class AdminVolunteerController extends BaseApiController
             );
             $data['stats']['total_opportunities'] = (int) ($row->total ?? 0);
             $data['stats']['active_opportunities'] = (int) ($row->active_count ?? 0);
-        } catch (\Exception $e) {}
+        } catch (\Exception $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
 
         if ($this->tableExists('vol_applications')) {
             try {
@@ -389,7 +389,7 @@ class AdminVolunteerController extends BaseApiController
                 );
                 $data['stats']['total_applications'] = (int) ($row->total ?? 0);
                 $data['stats']['pending_applications'] = (int) ($row->pending ?? 0);
-            } catch (\Exception $e) {}
+            } catch (\Exception $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
         }
 
         if ($this->tableExists('vol_logs')) {
@@ -401,7 +401,7 @@ class AdminVolunteerController extends BaseApiController
                 );
                 $data['stats']['total_hours_logged'] = round((float) ($row->total_hours ?? 0), 1);
                 $data['stats']['active_volunteers'] = (int) ($row->volunteers ?? 0);
-            } catch (\Exception $e) {}
+            } catch (\Exception $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
         }
 
         try {
@@ -430,7 +430,7 @@ class AdminVolunteerController extends BaseApiController
                 unset($row['ui_status']);
                 return $row;
             }, $rows);
-        } catch (\Exception $e) {}
+        } catch (\Exception $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
 
         return $this->respondWithData($data);
     }
@@ -507,7 +507,7 @@ class AdminVolunteerController extends BaseApiController
                     [$tenantId, $tenantId, $tenantId, $tenantId]
                 );
                 return $this->respondWithData(array_map(fn($r) => (array)$r, $results));
-            } catch (\Throwable $e) {}
+            } catch (\Throwable $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
         }
 
         try {

--- a/app/Http/Controllers/Api/FeedSidebarController.php
+++ b/app/Http/Controllers/Api/FeedSidebarController.php
@@ -8,6 +8,7 @@ namespace App\Http\Controllers\Api;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\DB;
 use App\Core\TenantContext;
 
@@ -289,7 +290,7 @@ class FeedSidebarController extends BaseApiController
                         ->pluck('cid')
                         ->all();
                     $connectedIds = array_merge($connectedIds, array_map('intval', $cids));
-                } catch (\Exception $e) {}
+                } catch (\Exception $e) { Log::warning('Stats query failed in ' . __METHOD__, ['error' => $e->getMessage()]); }
 
                 $data['suggested_members'] = DB::table('users')
                     ->where('tenant_id', $tenantId)

--- a/app/Services/EndorsementService.php
+++ b/app/Services/EndorsementService.php
@@ -48,8 +48,10 @@ class EndorsementService
             return null;
         }
 
-        // Check endorsed user exists in same tenant
-        $endorsed = User::where('id', $endorsedId)->first(['id', 'first_name', 'last_name']);
+        // Check endorsed user exists in the same tenant
+        $endorsed = User::where('id', $endorsedId)
+            ->where('tenant_id', TenantContext::getId())
+            ->first(['id', 'first_name', 'last_name']);
         if (!$endorsed) {
             self::$errors[] = ['code' => 'NOT_FOUND', 'message' => __('api_controllers_2.endorsement.member_not_found')];
             return null;
@@ -175,10 +177,17 @@ class EndorsementService
      */
     public static function getEndorsementsForUser(int $userId): array
     {
+        $tenantId = TenantContext::getId();
+
+        // Verify the target user belongs to this tenant before exposing endorsement data
+        if (!User::where('id', $userId)->where('tenant_id', $tenantId)->exists()) {
+            return [];
+        }
+
         $rows = DB::table('skill_endorsements as se')
             ->join('users as u', 'se.endorser_id', '=', 'u.id')
             ->where('se.endorsed_id', $userId)
-            ->where('se.tenant_id', TenantContext::getId())
+            ->where('se.tenant_id', $tenantId)
             ->select(
                 'se.skill_name',
                 DB::raw('COUNT(*) as count'),

--- a/app/Services/EventReminderService.php
+++ b/app/Services/EventReminderService.php
@@ -144,9 +144,9 @@ class EventReminderService
                     $when = date('l, M j \\a\\t g:i A', strtotime($event->start_time));
 
                     if ($reminderType === '24h') {
-                        $message = "Reminder: \"{$title}\" is tomorrow — {$when}";
+                        $message = __('svc_notifications_2.event.reminder_tomorrow', ['title' => $title, 'when' => $when]);
                     } else {
-                        $message = "Starting soon: \"{$title}\" begins in 1 hour — {$when}";
+                        $message = __('svc_notifications_2.event.reminder_1h', ['title' => $title, 'when' => $when]);
                     }
 
                     $link = "/events/{$eventId}";

--- a/app/Services/EventService.php
+++ b/app/Services/EventService.php
@@ -465,7 +465,7 @@ class EventService
         }
 
         if (($event->status ?? 'active') === 'cancelled') {
-            self::$errors[] = ['code' => 'EVENT_CANCELLED', 'message' => 'This event has been cancelled'];
+            self::$errors[] = ['code' => 'EVENT_CANCELLED', 'message' => __('svc_notifications_2.event.rsvp_cancelled')];
             return false;
         }
 
@@ -473,7 +473,7 @@ class EventService
         if ($status === 'going' || $status === 'interested') {
             $eventEnd = $event->end_time ?? $event->start_time ?? null;
             if ($eventEnd && strtotime($eventEnd) < time()) {
-                self::$errors[] = ['code' => 'EVENT_ENDED', 'message' => 'This event has already ended'];
+                self::$errors[] = ['code' => 'EVENT_ENDED', 'message' => __('svc_notifications_2.event.rsvp_ended')];
                 return false;
             }
         }
@@ -871,9 +871,9 @@ class EventService
                 ->merge(collect($waitlistUserIds)->pluck('user_id'))
                 ->unique();
 
-            $message = "The event \"{$event->title}\" has been cancelled.";
+            $message = __('svc_notifications_2.event.cancelled_notification', ['title' => $event->title]);
             if (!empty($reason)) {
-                $message .= " Reason: {$reason}";
+                $message .= __('svc_notifications_2.event.cancelled_reason_suffix', ['reason' => $reason]);
             }
 
             foreach ($allUserIds as $uid) {

--- a/app/Services/GroupExchangeService.php
+++ b/app/Services/GroupExchangeService.php
@@ -400,7 +400,7 @@ class GroupExchangeService
         }
 
         if ($exchange->status === 'cancelled') {
-            return ['success' => false, 'error' => 'Exchange has been cancelled'];
+            return ['success' => false, 'error' => __('api_controllers_1.group_exchange.exchange_cancelled')];
         }
 
         // Check all participants have confirmed

--- a/config/admin-navigation.php
+++ b/config/admin-navigation.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Navigation Configuration
  * Single source of truth for admin sidebar navigation

--- a/config/css-bundles.php
+++ b/config/css-bundles.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * CSS Bundle Configuration
  * Optimizes CSS loading with code-splitting and minification

--- a/config/deployment-version.php
+++ b/config/deployment-version.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Deployment Version - Cache Busting
  *

--- a/config/heroes.php
+++ b/config/heroes.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * CivicOne Hero Configuration
  * Maps routes to hero settings following Section 9C of CIVICONE_WCAG21AA_SOURCE_OF_TRUTH.md

--- a/config/menu-manager.php
+++ b/config/menu-manager.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Menu Manager Configuration
  *

--- a/database/migrations/2026_03_30_100000_add_name_columns_to_newsletter_queue.php
+++ b/database/migrations/2026_03_30_100000_add_name_columns_to_newsletter_queue.php
@@ -13,9 +13,15 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('newsletter_queue', function (Blueprint $table) {
-            $table->string('name', 255)->default('')->after('email');
-            $table->string('first_name', 100)->default('')->after('name');
-            $table->string('last_name', 100)->default('')->after('first_name');
+            if (!Schema::hasColumn('newsletter_queue', 'name')) {
+                $table->string('name', 255)->default('')->after('email');
+            }
+            if (!Schema::hasColumn('newsletter_queue', 'first_name')) {
+                $table->string('first_name', 100)->default('')->after('name');
+            }
+            if (!Schema::hasColumn('newsletter_queue', 'last_name')) {
+                $table->string('last_name', 100)->default('')->after('first_name');
+            }
         });
     }
 

--- a/database/migrations/2026_04_03_300001_add_last_notified_at_to_saved_searches.php
+++ b/database/migrations/2026_04_03_300001_add_last_notified_at_to_saved_searches.php
@@ -13,7 +13,9 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('saved_searches', function (Blueprint $table) {
-            $table->timestamp('last_notified_at')->nullable()->after('last_run_at');
+            if (!Schema::hasColumn('saved_searches', 'last_notified_at')) {
+                $table->timestamp('last_notified_at')->nullable()->after('last_run_at');
+            }
         });
     }
 

--- a/e2e/global.setup.ts
+++ b/e2e/global.setup.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { chromium, FullConfig } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/e2e/global.teardown.ts
+++ b/e2e/global.teardown.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { FullConfig } from '@playwright/test';
 
 /**

--- a/e2e/helpers/test-utils.ts
+++ b/e2e/helpers/test-utils.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { Page, expect, Locator } from '@playwright/test';
 
 /**

--- a/e2e/page-objects/AdminPage.ts
+++ b/e2e/page-objects/AdminPage.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { Page, Locator, expect } from '@playwright/test';
 import { BasePage } from './BasePage';
 

--- a/e2e/page-objects/BasePage.ts
+++ b/e2e/page-objects/BasePage.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { Page, Locator, expect } from '@playwright/test';
 import { DEFAULT_TENANT, waitForPageLoad } from '../helpers/test-utils';
 

--- a/e2e/page-objects/BrokerControlsPage.ts
+++ b/e2e/page-objects/BrokerControlsPage.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { Page, Locator } from '@playwright/test';
 import { BasePage } from './BasePage';
 

--- a/e2e/page-objects/DashboardPage.ts
+++ b/e2e/page-objects/DashboardPage.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { Page, Locator, expect } from '@playwright/test';
 import { BasePage } from './BasePage';
 

--- a/e2e/page-objects/EventsPage.ts
+++ b/e2e/page-objects/EventsPage.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { Page, Locator, expect } from '@playwright/test';
 import { BasePage } from './BasePage';
 

--- a/e2e/page-objects/FeedPage.ts
+++ b/e2e/page-objects/FeedPage.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { Page, Locator } from '@playwright/test';
 import { BasePage } from './BasePage';
 

--- a/e2e/page-objects/GroupsPage.ts
+++ b/e2e/page-objects/GroupsPage.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { Page, Locator, expect } from '@playwright/test';
 import { BasePage } from './BasePage';
 

--- a/e2e/page-objects/ListingsPage.ts
+++ b/e2e/page-objects/ListingsPage.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { Page, Locator, expect } from '@playwright/test';
 import { BasePage } from './BasePage';
 

--- a/e2e/page-objects/LoginPage.ts
+++ b/e2e/page-objects/LoginPage.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { Page, Locator, expect } from '@playwright/test';
 import { BasePage } from './BasePage';
 

--- a/e2e/page-objects/MembersPage.ts
+++ b/e2e/page-objects/MembersPage.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { Page, Locator, expect } from '@playwright/test';
 import { BasePage } from './BasePage';
 

--- a/e2e/page-objects/MessagesPage.ts
+++ b/e2e/page-objects/MessagesPage.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { Page, Locator, expect } from '@playwright/test';
 import { BasePage } from './BasePage';
 

--- a/e2e/page-objects/SuperAdminPage.ts
+++ b/e2e/page-objects/SuperAdminPage.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { Page, Locator, expect } from '@playwright/test';
 import { BasePage } from './BasePage';
 

--- a/e2e/page-objects/WalletPage.ts
+++ b/e2e/page-objects/WalletPage.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { Page, Locator, expect } from '@playwright/test';
 import { BasePage } from './BasePage';
 

--- a/e2e/page-objects/index.ts
+++ b/e2e/page-objects/index.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Page Objects Index
  * Export all page objects for easy importing in tests

--- a/e2e/tests/admin/admin.spec.ts
+++ b/e2e/tests/admin/admin.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import {
   AdminDashboardPage,

--- a/e2e/tests/admin/broker-controls.spec.ts
+++ b/e2e/tests/admin/broker-controls.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { BrokerControlsPage } from '../../page-objects';
 

--- a/e2e/tests/admin/super-admin.spec.ts
+++ b/e2e/tests/admin/super-admin.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { SuperAdminPage } from '../../page-objects';
 

--- a/e2e/tests/auth/login.spec.ts
+++ b/e2e/tests/auth/login.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { LoginPage } from '../../page-objects';
 import { tenantUrl, dismissDevNoticeModal } from '../../helpers/test-utils';

--- a/e2e/tests/auth/register.spec.ts
+++ b/e2e/tests/auth/register.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { generateTestData, tenantUrl, dismissDevNoticeModal } from '../../helpers/test-utils';
 

--- a/e2e/tests/broker/broker-message-visibility.spec.ts
+++ b/e2e/tests/broker/broker-message-visibility.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import type { APIRequestContext } from '@playwright/test';
 import * as dotenv from 'dotenv';

--- a/e2e/tests/broker/broker-visibility.spec.ts
+++ b/e2e/tests/broker/broker-visibility.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect, APIRequestContext } from '@playwright/test';
 import * as dotenv from 'dotenv';
 import * as path from 'path';

--- a/e2e/tests/compose/compose.spec.ts
+++ b/e2e/tests/compose/compose.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { tenantUrl, generateTestData } from '../../helpers/test-utils';
 

--- a/e2e/tests/connections/connections.spec.ts
+++ b/e2e/tests/connections/connections.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { tenantUrl, dismissDevNoticeModal } from '../../helpers/test-utils';
 

--- a/e2e/tests/dashboard/dashboard.spec.ts
+++ b/e2e/tests/dashboard/dashboard.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { DashboardPage } from '../../page-objects';
 

--- a/e2e/tests/events/events.spec.ts
+++ b/e2e/tests/events/events.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { EventsPage, CreateEventPage, EventDetailPage } from '../../page-objects';
 import { generateTestData } from '../../helpers/test-utils';

--- a/e2e/tests/federation/federation.spec.ts
+++ b/e2e/tests/federation/federation.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { tenantUrl, dismissDevNoticeModal } from '../../helpers/test-utils';
 

--- a/e2e/tests/feed/feed.spec.ts
+++ b/e2e/tests/feed/feed.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { FeedPage } from '../../page-objects';
 import { generateTestData } from '../../helpers/test-utils';

--- a/e2e/tests/gamification/gamification.spec.ts
+++ b/e2e/tests/gamification/gamification.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { tenantUrl, dismissDevNoticeModal } from '../../helpers/test-utils';
 

--- a/e2e/tests/groups/groups.spec.ts
+++ b/e2e/tests/groups/groups.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { GroupsPage, GroupDetailPage, CreateGroupPage } from '../../page-objects';
 import { generateTestData, tenantUrl } from '../../helpers/test-utils';

--- a/e2e/tests/listings/listings-mobile-scroll.spec.ts
+++ b/e2e/tests/listings/listings-mobile-scroll.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { tenantUrl } from '../../helpers/test-utils';
 

--- a/e2e/tests/listings/listings.spec.ts
+++ b/e2e/tests/listings/listings.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { ListingsPage, CreateListingPage, ListingDetailPage } from '../../page-objects';
 import { generateTestData } from '../../helpers/test-utils';

--- a/e2e/tests/location/location-autocomplete.spec.ts
+++ b/e2e/tests/location/location-autocomplete.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect, Page } from '@playwright/test';
 import { tenantUrl, dismissDevNoticeModal } from '../../helpers/test-utils';
 

--- a/e2e/tests/members/members.spec.ts
+++ b/e2e/tests/members/members.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { MembersPage, ProfilePage, SettingsPage } from '../../page-objects';
 import { generateTestData, tenantUrl } from '../../helpers/test-utils';

--- a/e2e/tests/messages/messages.spec.ts
+++ b/e2e/tests/messages/messages.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { MessagesPage, MessageThreadPage, NewMessagePage } from '../../page-objects';
 import { generateTestData } from '../../helpers/test-utils';

--- a/e2e/tests/notifications/notifications.spec.ts
+++ b/e2e/tests/notifications/notifications.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { tenantUrl, dismissDevNoticeModal } from '../../helpers/test-utils';
 

--- a/e2e/tests/public/legal-pages.spec.ts
+++ b/e2e/tests/public/legal-pages.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { tenantUrl } from '../../helpers/test-utils';
 

--- a/e2e/tests/pwa/pwa.spec.ts
+++ b/e2e/tests/pwa/pwa.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { tenantUrl, dismissDevNoticeModal } from '../../helpers/test-utils';
 

--- a/e2e/tests/reviews/reviews.spec.ts
+++ b/e2e/tests/reviews/reviews.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { tenantUrl, dismissDevNoticeModal } from '../../helpers/test-utils';
 

--- a/e2e/tests/search/search.spec.ts
+++ b/e2e/tests/search/search.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { tenantUrl, dismissDevNoticeModal } from '../../helpers/test-utils';
 

--- a/e2e/tests/volunteering/volunteering.spec.ts
+++ b/e2e/tests/volunteering/volunteering.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { tenantUrl, dismissDevNoticeModal } from '../../helpers/test-utils';
 

--- a/e2e/tests/wallet/wallet.spec.ts
+++ b/e2e/tests/wallet/wallet.spec.ts
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import { test, expect } from '@playwright/test';
 import { WalletPage, TransferPage, InsightsPage } from '../../page-objects';
 import { generateTestData } from '../../helpers/test-utils';

--- a/lang/en/svc_notifications_2.json
+++ b/lang/en/svc_notifications_2.json
@@ -93,6 +93,12 @@
     "review.submitted_successfully": "Review submitted successfully",
 
     "event.added_to_waitlist": "This event is full. You have been added to the waitlist.",
+    "event.reminder_tomorrow": "Reminder: \"{{title}}\" is tomorrow — {{when}}",
+    "event.reminder_1h": "Starting soon: \"{{title}}\" begins in 1 hour — {{when}}",
+    "event.cancelled_notification": "The event \"{{title}}\" has been cancelled.",
+    "event.cancelled_reason_suffix": " Reason: {{reason}}",
+    "event.rsvp_cancelled": "This event has been cancelled",
+    "event.rsvp_ended": "This event has already ended",
 
     "comment.deleted": "Comment deleted",
 

--- a/migrations/2026_01_25_seed_legal_documents_content.php
+++ b/migrations/2026_01_25_seed_legal_documents_content.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Seed Legal Documents Content
  *

--- a/migrations/fix_null_member_names.php
+++ b/migrations/fix_null_member_names.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Migration: Fix NULL Member Names
  *

--- a/mobile/components/ui/Button.test.tsx
+++ b/mobile/components/ui/Button.test.tsx
@@ -1,3 +1,8 @@
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import Button from './Button';

--- a/react-frontend/tsconfig.json
+++ b/react-frontend/tsconfig.json
@@ -16,6 +16,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]

--- a/scripts/add-spdx-headers.mjs
+++ b/scripts/add-spdx-headers.mjs
@@ -29,7 +29,15 @@ const DIRS = [
   { path: 'src', extensions: ['.php'] },
   { path: 'httpdocs', extensions: ['.php'] },
   { path: 'tests', extensions: ['.php'] },
+  { path: 'app', extensions: ['.php'] },
+  { path: 'config', extensions: ['.php'] },
+  { path: 'routes', extensions: ['.php'] },
+  { path: 'views', extensions: ['.php'] },
+  { path: 'migrations', extensions: ['.php'] },
+  { path: join('database', 'migrations'), extensions: ['.php'] },
   { path: join('react-frontend', 'src'), extensions: ['.ts', '.tsx'] },
+  { path: 'e2e', extensions: ['.ts', '.tsx'] },
+  { path: 'mobile', extensions: ['.ts', '.tsx'] },
 ];
 
 // Directories to skip
@@ -61,15 +69,18 @@ function addHeaderToPhp(content) {
   // Already has SPDX header
   if (content.includes(SPDX_MARKER)) return null;
 
-  // Find the <?php tag
-  const phpTagMatch = content.match(/^<\?php\s*/);
-  if (!phpTagMatch) return null; // Not a PHP file with opening tag
-
-  const afterTag = content.slice(phpTagMatch[0].length);
   const header = makePhpHeader();
 
-  // Insert header right after <?php with a blank line before and after
-  return `<?php\n${header}\n${afterTag}`;
+  // PHP file with opening <?php tag — insert header right after it
+  const phpTagMatch = content.match(/^<\?php\s*/);
+  if (phpTagMatch) {
+    const afterTag = content.slice(phpTagMatch[0].length);
+    return `<?php\n${header}\n${afterTag}`;
+  }
+
+  // HTML-first template (no <?php opener, e.g. error pages, partials)
+  // Wrap header in a silent PHP block prepended before the HTML
+  return `<?php\n${header}?>\n${content}`;
 }
 
 function addHeaderToTs(content) {

--- a/scripts/check-spdx.mjs
+++ b/scripts/check-spdx.mjs
@@ -17,7 +17,15 @@ const dirs = [
   { path: 'src', ext: ['.php'] },
   { path: 'httpdocs', ext: ['.php'] },
   { path: 'tests', ext: ['.php'] },
+  { path: 'app', ext: ['.php'] },
+  { path: 'config', ext: ['.php'] },
+  { path: 'routes', ext: ['.php'] },
+  { path: 'views', ext: ['.php'] },
+  { path: 'migrations', ext: ['.php'] },
+  { path: join('database', 'migrations'), ext: ['.php'] },
   { path: join('react-frontend', 'src'), ext: ['.ts', '.tsx'] },
+  { path: 'e2e', ext: ['.ts', '.tsx'] },
+  { path: 'mobile', ext: ['.ts', '.tsx'] },
 ];
 
 let totalFiles = 0;

--- a/views/404.php
+++ b/views/404.php
@@ -1,3 +1,9 @@
+<?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+?>
 <!DOCTYPE html>
 <html lang="en">
 

--- a/views/500.php
+++ b/views/500.php
@@ -1,3 +1,9 @@
+<?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+?>
 <!DOCTYPE html>
 <html lang="en">
 

--- a/views/admin/404-errors/index.php
+++ b/views/admin/404-errors/index.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/404-errors/index.php';

--- a/views/admin/activity_log.php
+++ b/views/admin/activity_log.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Activity Log Dispatcher
 // Path: views/admin-legacy/activity_log.php
 

--- a/views/admin/attributes/create.php
+++ b/views/admin/attributes/create.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Layout Switcher for Admin Attributes Create
 // FIXED: Use consistent session variable order (active_layout first)
 $layout = layout(); // Fixed: centralized detection

--- a/views/admin/attributes/edit.php
+++ b/views/admin/attributes/edit.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Layout Switcher for Admin Attributes Edit
 // FIXED: Use consistent session variable order (active_layout first)
 $layout = layout(); // Fixed: centralized detection

--- a/views/admin/attributes/index.php
+++ b/views/admin/attributes/index.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/attributes/index.php';

--- a/views/admin/blog/builder.php
+++ b/views/admin/blog/builder.php
@@ -1,3 +1,9 @@
+<?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+?>
 <!DOCTYPE html>
 <html lang="en">
 

--- a/views/admin/blog/form.php
+++ b/views/admin/blog/form.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Layout: Default (Admin)
 $layout = 'default';
 $isEdit = isset($post);

--- a/views/admin/blog/index.php
+++ b/views/admin/blog/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Layout: Default (Admin)
 $layout = 'default';
 ?>

--- a/views/admin/categories/create.php
+++ b/views/admin/categories/create.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Layout Switcher for Admin Categories Create
 // FIXED: Use consistent session variable order (active_layout first)
 $layout = layout(); // Fixed: centralized detection

--- a/views/admin/categories/edit.php
+++ b/views/admin/categories/edit.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Layout Switcher for Admin Categories Edit
 // FIXED: Use consistent session variable order (active_layout first)
 $layout = layout(); // Fixed: centralized detection

--- a/views/admin/categories/index.php
+++ b/views/admin/categories/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Layout Switcher for Admin Categories
 // FIXED: Use consistent session variable order (active_layout first)
 $layout = layout(); // Fixed: centralized detection

--- a/views/admin/dashboard.php
+++ b/views/admin/dashboard.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Master Admin Dashboard Dispatcher
 // Path: views/admin-legacy/dashboard.php
 

--- a/views/admin/enterprise/gdpr/audit.php
+++ b/views/admin/enterprise/gdpr/audit.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * GDPR Audit Log
  * Complete audit trail for GDPR compliance activities

--- a/views/admin/enterprise/gdpr/consents.php
+++ b/views/admin/enterprise/gdpr/consents.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * GDPR Consent Management
  * View and manage user consents across the platform

--- a/views/admin/enterprise/gdpr/request-view.php
+++ b/views/admin/enterprise/gdpr/request-view.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * GDPR Request Detail View
  * View and process individual GDPR requests

--- a/views/admin/federation/api-keys-create.php
+++ b/views/admin/federation/api-keys-create.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Federation API Keys Create - View Dispatcher
 $layout = layout();
 $modernView = __DIR__ . '/../../modern/admin-legacy/federation/api-keys-create.php';

--- a/views/admin/federation/api-keys-show.php
+++ b/views/admin/federation/api-keys-show.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Federation API Key Details - View Dispatcher
 $layout = layout();
 $modernView = __DIR__ . '/../../modern/admin-legacy/federation/api-keys-show.php';

--- a/views/admin/federation/api-keys.php
+++ b/views/admin/federation/api-keys.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Federation API Keys - View Dispatcher
 $layout = layout();
 $modernView = __DIR__ . '/../../modern/admin-legacy/federation/api-keys.php';

--- a/views/admin/federation/dashboard.php
+++ b/views/admin/federation/dashboard.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Federation Admin Dashboard - View Dispatcher
 $layout = layout();
 $modernView = __DIR__ . '/../../modern/admin-legacy/federation/dashboard.php';

--- a/views/admin/federation/data.php
+++ b/views/admin/federation/data.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Federation Data Management - View Dispatcher
 $layout = layout();
 $modernView = __DIR__ . '/../../modern/admin-legacy/federation/data.php';

--- a/views/admin/federation/external-partners-create.php
+++ b/views/admin/federation/external-partners-create.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // External Partners Create - View Dispatcher
 $layout = layout();
 $modernView = __DIR__ . '/../../modern/admin-legacy/federation/external-partners-create.php';

--- a/views/admin/federation/external-partners-show.php
+++ b/views/admin/federation/external-partners-show.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // External Partners Show - View Dispatcher
 $layout = layout();
 $modernView = __DIR__ . '/../../modern/admin-legacy/federation/external-partners-show.php';

--- a/views/admin/federation/external-partners.php
+++ b/views/admin/federation/external-partners.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // External Partners - View Dispatcher
 $layout = layout();
 $modernView = __DIR__ . '/../../modern/admin-legacy/federation/external-partners.php';

--- a/views/admin/federation/index.php
+++ b/views/admin/federation/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Federation Settings - View Dispatcher
 $layout = layout();
 $modernView = __DIR__ . '/../../modern/admin-legacy/federation/index.php';

--- a/views/admin/federation/partnerships.php
+++ b/views/admin/federation/partnerships.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Federation Partnerships - View Dispatcher
 $layout = layout();
 $modernView = __DIR__ . '/../../modern/admin-legacy/federation/partnerships.php';

--- a/views/admin/gamification/analytics.php
+++ b/views/admin/gamification/analytics.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/gamification/analytics.php';

--- a/views/admin/gamification/campaigns.php
+++ b/views/admin/gamification/campaigns.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/gamification/campaigns.php';

--- a/views/admin/gamification/custom-badge-form.php
+++ b/views/admin/gamification/custom-badge-form.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/gamification/custom-badge-form.php';

--- a/views/admin/gamification/custom-badges.php
+++ b/views/admin/gamification/custom-badges.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/gamification/custom-badges.php';

--- a/views/admin/image-settings.php
+++ b/views/admin/image-settings.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Image Optimization Settings
  * Configure WebP conversion, quality settings, and auto-optimization

--- a/views/admin/legal-documents/acceptances.php
+++ b/views/admin/legal-documents/acceptances.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/legal-documents/acceptances.php';

--- a/views/admin/legal-documents/compliance.php
+++ b/views/admin/legal-documents/compliance.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/legal-documents/compliance.php';

--- a/views/admin/legal-documents/create.php
+++ b/views/admin/legal-documents/create.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/legal-documents/create.php';

--- a/views/admin/legal-documents/edit.php
+++ b/views/admin/legal-documents/edit.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/legal-documents/edit.php';

--- a/views/admin/legal-documents/index.php
+++ b/views/admin/legal-documents/index.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/legal-documents/index.php';

--- a/views/admin/legal-documents/show.php
+++ b/views/admin/legal-documents/show.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/legal-documents/show.php';

--- a/views/admin/legal-documents/versions/compare-select.php
+++ b/views/admin/legal-documents/versions/compare-select.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../../modern/admin/legal-documents/versions/compare-select.php';

--- a/views/admin/legal-documents/versions/compare.php
+++ b/views/admin/legal-documents/versions/compare.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../../modern/admin/legal-documents/versions/compare.php';

--- a/views/admin/legal-documents/versions/create.php
+++ b/views/admin/legal-documents/versions/create.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../../modern/admin/legal-documents/versions/create.php';

--- a/views/admin/legal-documents/versions/edit.php
+++ b/views/admin/legal-documents/versions/edit.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../../modern/admin/legal-documents/versions/edit.php';

--- a/views/admin/legal-documents/versions/show.php
+++ b/views/admin/legal-documents/versions/show.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../../modern/admin/legal-documents/versions/show.php';

--- a/views/admin/listings/index.php
+++ b/views/admin/listings/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Admin Listings Index View
 $isPending = ($currentStatus ?? '') === 'pending';
 ?>

--- a/views/admin/native-app.php
+++ b/views/admin/native-app.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../modern/admin/native-app.php';

--- a/views/admin/news/index.php
+++ b/views/admin/news/index.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin blog
 require __DIR__ . '/../../modern/admin/blog/index.php';

--- a/views/admin/newsletters/analytics.php
+++ b/views/admin/newsletters/analytics.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/newsletters/analytics.php';

--- a/views/admin/newsletters/bounces.php
+++ b/views/admin/newsletters/bounces.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/newsletters/bounces.php';

--- a/views/admin/newsletters/diagnostics.php
+++ b/views/admin/newsletters/diagnostics.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/newsletters/diagnostics.php';

--- a/views/admin/newsletters/form.php
+++ b/views/admin/newsletters/form.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/newsletters/form.php';

--- a/views/admin/newsletters/index.php
+++ b/views/admin/newsletters/index.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/newsletters/index.php';

--- a/views/admin/newsletters/resend.php
+++ b/views/admin/newsletters/resend.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/newsletters/resend.php';

--- a/views/admin/newsletters/segment-form.php
+++ b/views/admin/newsletters/segment-form.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/newsletters/segment-form.php';

--- a/views/admin/newsletters/segments.php
+++ b/views/admin/newsletters/segments.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/newsletters/segments.php';

--- a/views/admin/newsletters/send-time.php
+++ b/views/admin/newsletters/send-time.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/newsletters/send-time.php';

--- a/views/admin/newsletters/stats.php
+++ b/views/admin/newsletters/stats.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/newsletters/stats.php';

--- a/views/admin/newsletters/subscribers.php
+++ b/views/admin/newsletters/subscribers.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/newsletters/subscribers.php';

--- a/views/admin/newsletters/template-form.php
+++ b/views/admin/newsletters/template-form.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/newsletters/template-form.php';

--- a/views/admin/newsletters/templates.php
+++ b/views/admin/newsletters/templates.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/newsletters/templates.php';

--- a/views/admin/pages/builder.php
+++ b/views/admin/pages/builder.php
@@ -1,3 +1,9 @@
+<?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+?>
 <!DOCTYPE html>
 <html lang="en">
 

--- a/views/admin/pages/index.php
+++ b/views/admin/pages/index.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/pages/index.php';

--- a/views/admin/pages/list.php
+++ b/views/admin/pages/list.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // $pageTitle is set in Controller/View logic, but usually we dynamic it
 $tenantName = App\Core\TenantContext::get()['name'] ?? 'Nexus TimeBank';
 $pageTitle = "Page Builder - $tenantName";

--- a/views/admin/partials/analytics_chart.php
+++ b/views/admin/partials/analytics_chart.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // views/admin-legacy/partials/analytics_chart.php
 
 // Data expected: $monthly_stats (array of ['month' => '2023-10', 'volume' => 120])

--- a/views/admin/seed-generator/index.php
+++ b/views/admin/seed-generator/index.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/seed-generator/index.php';

--- a/views/admin/seed-generator/preview.php
+++ b/views/admin/seed-generator/preview.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Seed Generator - Preview & Validation
  * Shows exactly what will be generated before you download it

--- a/views/admin/seed-generator/verification.php
+++ b/views/admin/seed-generator/verification.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Seed Generator - Verification Dashboard
  * Proves generator can see database and is 100% safe

--- a/views/admin/seo/index.php
+++ b/views/admin/seo/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Admin SEO Dispatcher
 // Modern layout (default)
 $modernPath = dirname(__DIR__, 2) . '/modern/admin-legacy/seo/index.php';

--- a/views/admin/settings.php
+++ b/views/admin/settings.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../modern/admin/settings.php';

--- a/views/admin/test-runner/dashboard.php
+++ b/views/admin/test-runner/dashboard.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Test Runner Dashboard - FDS Gold Standard
  *

--- a/views/admin/test-runner/view.php
+++ b/views/admin/test-runner/view.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Test Run Details View - FDS Gold Standard
  *

--- a/views/admin/users/edit.php
+++ b/views/admin/users/edit.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/users/edit.php';

--- a/views/admin/users/index.php
+++ b/views/admin/users/index.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/users/index.php';

--- a/views/admin/volunteering/approvals.php
+++ b/views/admin/volunteering/approvals.php
@@ -1,3 +1,8 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim — dispatches to modern admin with correct header
 require __DIR__ . '/../../modern/admin/volunteering/approvals.php';

--- a/views/admin/volunteering/index.php
+++ b/views/admin/volunteering/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 // Legacy admin view shim
 require __DIR__ . '/../../modern/admin/volunteering/index.php';
 

--- a/views/admin/volunteering/organizations.php
+++ b/views/admin/volunteering/organizations.php
@@ -1,3 +1,7 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
 
 require __DIR__ . '/../../modern/admin/volunteering/organizations.php';

--- a/views/admin/webp-converter.php
+++ b/views/admin/webp-converter.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * WebP Image Converter - Gold Standard v2.1
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/auth/login.php
+++ b/views/auth/login.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Minimal Login Page
  *

--- a/views/emails/match_digest.php
+++ b/views/emails/match_digest.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Match Digest Email Template - Modern Theme Polish
  *

--- a/views/emails/match_hot.php
+++ b/views/emails/match_hot.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Hot Match Email Template - Modern Theme Polish
  *

--- a/views/emails/match_mutual.php
+++ b/views/emails/match_mutual.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Mutual Match Email Template - Modern Theme Polish
  *

--- a/views/emails/weekly_digest.php
+++ b/views/emails/weekly_digest.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Weekly Digest Email Template
  *

--- a/views/error/404.php
+++ b/views/error/404.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * 404 Error Page
  * This is the fallback 404 view for the modern layout

--- a/views/errors/403.php
+++ b/views/errors/403.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * 403 Forbidden Error Page
  */

--- a/views/errors/404.php
+++ b/views/errors/404.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * 404 Not Found Error Page
  */

--- a/views/errors/private_profile.php
+++ b/views/errors/private_profile.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Private Profile Error Page
  * Styles in: /httpdocs/assets/css/error-pages.css

--- a/views/layouts/admin-footer.php
+++ b/views/layouts/admin-footer.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Gold Standard Footer Component
  * STANDALONE - closes HTML document started by admin-header.php

--- a/views/layouts/admin-header.php
+++ b/views/layouts/admin-header.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Gold Standard Header Component
  * STANDALONE admin interface - does NOT use main site header/footer

--- a/views/modern/admin/404-errors/index.php
+++ b/views/modern/admin/404-errors/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Modern Admin 404 Error Tracking Dashboard
  * Gold theme with polished interface

--- a/views/modern/admin/activity_log.php
+++ b/views/modern/admin/activity_log.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Activity Log - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/ai-settings.php
+++ b/views/modern/admin/ai-settings.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * AI Settings - Gold Standard Mission Control
  * STANDALONE admin interface - does NOT use main site header/footer

--- a/views/modern/admin/algorithm-settings.php
+++ b/views/modern/admin/algorithm-settings.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Algorithm Settings - Gold Standard
  * Unified MatchRank (Listings) & CommunityRank (Members) Configuration

--- a/views/modern/admin/attributes/create.php
+++ b/views/modern/admin/attributes/create.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Create Attribute - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/attributes/edit.php
+++ b/views/modern/admin/attributes/edit.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Edit Attribute - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/attributes/index.php
+++ b/views/modern/admin/attributes/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Attributes Manager - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/blog-restore/index.php
+++ b/views/modern/admin/blog-restore/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 $pageTitle = $pageTitle ?? 'Restore Blog Posts';
 require __DIR__ . '/../partials/admin-header.php';
 ?>

--- a/views/modern/admin/blog/builder.php
+++ b/views/modern/admin/blog/builder.php
@@ -1,3 +1,9 @@
+<?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+?>
 <!DOCTYPE html>
 <html lang="en">
 

--- a/views/modern/admin/blog/form.php
+++ b/views/modern/admin/blog/form.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Blog/Article Form - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/blog/index.php
+++ b/views/modern/admin/blog/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Blog/News - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/broker-controls/configuration.php
+++ b/views/modern/admin/broker-controls/configuration.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Broker Controls Configuration
  * Unified settings for all broker control features

--- a/views/modern/admin/broker-controls/exchanges/index.php
+++ b/views/modern/admin/broker-controls/exchanges/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Exchange Requests List
  * View and manage exchange requests pending broker action

--- a/views/modern/admin/broker-controls/exchanges/show.php
+++ b/views/modern/admin/broker-controls/exchanges/show.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Exchange Request Detail View
  * View detailed information about a single exchange request

--- a/views/modern/admin/broker-controls/index.php
+++ b/views/modern/admin/broker-controls/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Broker Controls Dashboard
  * Overview of all broker control features and pending actions

--- a/views/modern/admin/broker-controls/messages/index.php
+++ b/views/modern/admin/broker-controls/messages/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Message Review Queue
  * Review messages copied for broker visibility

--- a/views/modern/admin/broker-controls/monitoring/index.php
+++ b/views/modern/admin/broker-controls/monitoring/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * User Monitoring Dashboard
  * Manage user messaging restrictions and monitoring flags

--- a/views/modern/admin/broker-controls/risk-tags/form.php
+++ b/views/modern/admin/broker-controls/risk-tags/form.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Risk Tag Form
  * Add or edit risk tag for a listing

--- a/views/modern/admin/broker-controls/risk-tags/index.php
+++ b/views/modern/admin/broker-controls/risk-tags/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Risk Tags List
  * View and manage risk-tagged listings

--- a/views/modern/admin/broker-controls/stats.php
+++ b/views/modern/admin/broker-controls/stats.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Broker Controls Statistics
  * Analytics and metrics for broker control features

--- a/views/modern/admin/categories/create.php
+++ b/views/modern/admin/categories/create.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Create Category - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/categories/edit.php
+++ b/views/modern/admin/categories/edit.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Edit Category - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/categories/index.php
+++ b/views/modern/admin/categories/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Category Manager - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/cron-jobs/index.php
+++ b/views/modern/admin/cron-jobs/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Cron Jobs - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/cron-jobs/logs.php
+++ b/views/modern/admin/cron-jobs/logs.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Cron Logs - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/cron-jobs/settings.php
+++ b/views/modern/admin/cron-jobs/settings.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Cron Settings - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/cron-jobs/setup.php
+++ b/views/modern/admin/cron-jobs/setup.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Cron Job Setup Guide - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/dashboard.php
+++ b/views/modern/admin/dashboard.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Dashboard - Gold Standard Mission Control
  * STANDALONE admin interface - does NOT use main site header/footer

--- a/views/modern/admin/deliverability/analytics.php
+++ b/views/modern/admin/deliverability/analytics.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 use App\Core\TenantContext;
 use App\Core\Csrf;
 

--- a/views/modern/admin/deliverability/create.php
+++ b/views/modern/admin/deliverability/create.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 use App\Core\TenantContext;
 use App\Core\Csrf;
 

--- a/views/modern/admin/deliverability/dashboard.php
+++ b/views/modern/admin/deliverability/dashboard.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 use App\Core\TenantContext;
 use App\Core\Csrf;
 

--- a/views/modern/admin/deliverability/edit.php
+++ b/views/modern/admin/deliverability/edit.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 use App\Core\TenantContext;
 use App\Core\Csrf;
 

--- a/views/modern/admin/deliverability/list.php
+++ b/views/modern/admin/deliverability/list.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 use App\Core\TenantContext;
 use App\Core\Csrf;
 

--- a/views/modern/admin/deliverability/view.php
+++ b/views/modern/admin/deliverability/view.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Deliverability View - Admin Panel
  *

--- a/views/modern/admin/enterprise/audit/permissions.php
+++ b/views/modern/admin/enterprise/audit/permissions.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Permission Audit Log Viewer
  * Gold Standard v2.0 Admin Interface

--- a/views/modern/admin/enterprise/config/dashboard.php
+++ b/views/modern/admin/enterprise/config/dashboard.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Configuration Dashboard - Gold Standard v2.0
  * STANDALONE Admin Interface with Holographic Glassmorphism

--- a/views/modern/admin/enterprise/config/secrets.php
+++ b/views/modern/admin/enterprise/config/secrets.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Modern Secrets Management - Gold Standard v2.0
  * Dark Mode Optimized Vault & Secrets Interface

--- a/views/modern/admin/enterprise/dashboard.php
+++ b/views/modern/admin/enterprise/dashboard.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Enterprise Dashboard - Gold Standard v2.0
  * STANDALONE Admin Interface with Holographic Glassmorphism

--- a/views/modern/admin/enterprise/gdpr/audit.php
+++ b/views/modern/admin/enterprise/gdpr/audit.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * GDPR Audit Log - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/enterprise/gdpr/breach-report.php
+++ b/views/modern/admin/enterprise/gdpr/breach-report.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * GDPR Breach Report Form - Gold Standard v2.0
  * STANDALONE Admin Interface with Holographic Glassmorphism

--- a/views/modern/admin/enterprise/gdpr/breach-view.php
+++ b/views/modern/admin/enterprise/gdpr/breach-view.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Modern GDPR Breach Detail View - Gold Standard v2.0
  * Dark Mode Optimized Security Incident Detail

--- a/views/modern/admin/enterprise/gdpr/breaches.php
+++ b/views/modern/admin/enterprise/gdpr/breaches.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin GDPR Data Breach Management - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/enterprise/gdpr/consent-detail.php
+++ b/views/modern/admin/enterprise/gdpr/consent-detail.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Modern Consent Detail View - Gold Standard v2.0
  * View consent type details and user consent records

--- a/views/modern/admin/enterprise/gdpr/consents.php
+++ b/views/modern/admin/enterprise/gdpr/consents.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin GDPR Consent Management - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/enterprise/gdpr/dashboard.php
+++ b/views/modern/admin/enterprise/gdpr/dashboard.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * GDPR Dashboard - Gold Standard v2.0
  * STANDALONE Admin Interface with Holographic Glassmorphism

--- a/views/modern/admin/enterprise/gdpr/request-create.php
+++ b/views/modern/admin/enterprise/gdpr/request-create.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * GDPR Request Create View - Gold Standard v2.0
  * Admin-initiated GDPR request form

--- a/views/modern/admin/enterprise/gdpr/request-view.php
+++ b/views/modern/admin/enterprise/gdpr/request-view.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Modern GDPR Request Detail View - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/enterprise/gdpr/requests.php
+++ b/views/modern/admin/enterprise/gdpr/requests.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * GDPR Requests Management - Gold Standard v2.0
  * STANDALONE Admin Interface with Holographic Glassmorphism

--- a/views/modern/admin/enterprise/monitoring/dashboard.php
+++ b/views/modern/admin/enterprise/monitoring/dashboard.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * System Monitoring Dashboard - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/enterprise/monitoring/health.php
+++ b/views/modern/admin/enterprise/monitoring/health.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * System Health Check - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/enterprise/monitoring/log-view.php
+++ b/views/modern/admin/enterprise/monitoring/log-view.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Log Viewer - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/enterprise/monitoring/logs.php
+++ b/views/modern/admin/enterprise/monitoring/logs.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * System Logs Dashboard - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/enterprise/monitoring/requirements.php
+++ b/views/modern/admin/enterprise/monitoring/requirements.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Platform Requirements Checker - Gold Standard v2.0
  * Comprehensive dependency and environment validation

--- a/views/modern/admin/enterprise/partials/enterprise-footer.php
+++ b/views/modern/admin/enterprise/partials/enterprise-footer.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Enterprise Module Footer - Gold Standard
  * STANDALONE footer with toast notifications

--- a/views/modern/admin/enterprise/partials/enterprise-header.php
+++ b/views/modern/admin/enterprise/partials/enterprise-header.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Enterprise Module Header - Gold Standard
  * STANDALONE admin interface with role-based access control

--- a/views/modern/admin/enterprise/partials/nav.php
+++ b/views/modern/admin/enterprise/partials/nav.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Enterprise Navigation Component - Gold Standard v2.0
  * Smart Tab Navigation for Enterprise Admin Interface

--- a/views/modern/admin/enterprise/permissions/index.php
+++ b/views/modern/admin/enterprise/permissions/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Permissions Browser - Gold Standard v2.0 Admin Interface
  * STANDALONE admin interface for browsing all system permissions

--- a/views/modern/admin/enterprise/roles/create.php
+++ b/views/modern/admin/enterprise/roles/create.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Create Role - Gold Standard v2.0 Admin Interface
  * STANDALONE admin interface for creating new roles

--- a/views/modern/admin/enterprise/roles/dashboard.php
+++ b/views/modern/admin/enterprise/roles/dashboard.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Role & Permission Management Dashboard - Gold Standard v2.0
  * STANDALONE admin interface for enterprise RBAC system

--- a/views/modern/admin/enterprise/roles/edit.php
+++ b/views/modern/admin/enterprise/roles/edit.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Edit Role - Gold Standard v2.0 Admin Interface
  * STANDALONE admin interface for editing existing roles

--- a/views/modern/admin/enterprise/roles/show.php
+++ b/views/modern/admin/enterprise/roles/show.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Role Detail View
  * Gold Standard v2.0 Admin Interface

--- a/views/modern/admin/federation/analytics-unavailable.php
+++ b/views/modern/admin/federation/analytics-unavailable.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Federation Analytics Unavailable
  * Shown when federation is not enabled or tenant is not whitelisted

--- a/views/modern/admin/federation/analytics.php
+++ b/views/modern/admin/federation/analytics.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Federation Analytics Dashboard
  * Gold Standard admin page for viewing federation activity metrics

--- a/views/modern/admin/federation/api-keys-create.php
+++ b/views/modern/admin/federation/api-keys-create.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Create Federation API Key
  * Form for creating new external partner API keys

--- a/views/modern/admin/federation/api-keys-show.php
+++ b/views/modern/admin/federation/api-keys-show.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * API Key Details View
  * Detailed view of a specific API key with usage stats and logs

--- a/views/modern/admin/federation/api-keys.php
+++ b/views/modern/admin/federation/api-keys.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Federation API Keys Management
  * Admin interface for managing external partner API keys

--- a/views/modern/admin/federation/dashboard.php
+++ b/views/modern/admin/federation/dashboard.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Federation Admin Dashboard
  * Overview of federation activity, partnerships, and user adoption

--- a/views/modern/admin/federation/data.php
+++ b/views/modern/admin/federation/data.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Federation Data Management
  * Import/Export interface for federation data

--- a/views/modern/admin/federation/directory-my-profile.php
+++ b/views/modern/admin/federation/directory-my-profile.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Federation Directory - My Profile
  * Gold Standard admin page for editing own timebank's directory listing

--- a/views/modern/admin/federation/directory-profile.php
+++ b/views/modern/admin/federation/directory-profile.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Federation Directory - View Timebank Profile
  * View details of another timebank before requesting partnership

--- a/views/modern/admin/federation/directory.php
+++ b/views/modern/admin/federation/directory.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Federation Directory - Discover Partner Timebanks
  * Gold Standard admin page for finding and connecting with other timebanks

--- a/views/modern/admin/federation/external-partners-create.php
+++ b/views/modern/admin/federation/external-partners-create.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * External Federation Partners - Create Form
  * Add a new external federation server connection

--- a/views/modern/admin/federation/external-partners-show.php
+++ b/views/modern/admin/federation/external-partners-show.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * External Federation Partners - Show/Edit View
  * View and manage a single external federation partner

--- a/views/modern/admin/federation/external-partners.php
+++ b/views/modern/admin/federation/external-partners.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * External Federation Partners - List View
  * Admin interface for managing external federation server connections

--- a/views/modern/admin/federation/index.php
+++ b/views/modern/admin/federation/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Tenant Admin Federation Settings Dashboard
  * Allows tenant admins to manage their own federation settings

--- a/views/modern/admin/federation/partnerships.php
+++ b/views/modern/admin/federation/partnerships.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Tenant Admin Federation Partnerships
  * Manage partnerships with other timebanks

--- a/views/modern/admin/feed-algorithm.php
+++ b/views/modern/admin/feed-algorithm.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Feed Algorithm - Gold Standard Mission Control
  * STANDALONE admin interface - does NOT use main site header/footer

--- a/views/modern/admin/gamification/analytics.php
+++ b/views/modern/admin/gamification/analytics.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Gamification Analytics - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/gamification/campaign-form.php
+++ b/views/modern/admin/gamification/campaign-form.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Campaign Form - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/gamification/campaigns.php
+++ b/views/modern/admin/gamification/campaigns.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Achievement Campaigns - Gold Standard Mission Control
  * STANDALONE admin interface - does NOT use main site header/footer

--- a/views/modern/admin/gamification/custom-badge-form.php
+++ b/views/modern/admin/gamification/custom-badge-form.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Custom Badge Form - Gold Standard
  * STANDALONE admin interface - Complete redesign

--- a/views/modern/admin/gamification/custom-badges.php
+++ b/views/modern/admin/gamification/custom-badges.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Custom Badges - Gold Standard
  * STANDALONE admin interface - Complete redesign

--- a/views/modern/admin/gamification/index.php
+++ b/views/modern/admin/gamification/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Gamification - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/geocode-groups.php
+++ b/views/modern/admin/geocode-groups.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Geocode Groups - Admin Interface
  */

--- a/views/modern/admin/group-locations.php
+++ b/views/modern/admin/group-locations.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Group Location Manager - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/group-ranking.php
+++ b/views/modern/admin/group-ranking.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Smart Group Ranking Dashboard - Admin FDS Gold Standard
  * Intelligent featured groups management with geographic diversity

--- a/views/modern/admin/group-types/form.php
+++ b/views/modern/admin/group-types/form.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Group Type Create/Edit Form - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/group-types/index.php
+++ b/views/modern/admin/group-types/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Group Types Management - Gold Standard v2.0
  * STANDALONE Admin Interface with Holographic Glassmorphism

--- a/views/modern/admin/groups/analytics.php
+++ b/views/modern/admin/groups/analytics.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Groups Analytics Dashboard
  * Path: views/modern/admin-legacy/groups/analytics.php

--- a/views/modern/admin/groups/approvals.php
+++ b/views/modern/admin/groups/approvals.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Groups Approval Workflow
  * Path: views/modern/admin-legacy/groups/approvals.php

--- a/views/modern/admin/groups/index.php
+++ b/views/modern/admin/groups/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Groups Management - Gold Standard
  */

--- a/views/modern/admin/groups/moderation.php
+++ b/views/modern/admin/groups/moderation.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Groups Moderation Dashboard
  * Path: views/modern/admin-legacy/groups/moderation.php

--- a/views/modern/admin/groups/owner-analytics.php
+++ b/views/modern/admin/groups/owner-analytics.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Groups - Owner Analytics (Gold Standard)
  * Accessed via /admin-legacy/groups/view?id=X → Analytics Tab

--- a/views/modern/admin/groups/policies.php
+++ b/views/modern/admin/groups/policies.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Groups Policies Management
  * Path: views/modern/admin-legacy/groups/policies.php

--- a/views/modern/admin/groups/recommendations.php
+++ b/views/modern/admin/groups/recommendations.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin: Group Recommendations Performance Dashboard - FDS Gold Standard
  * Shows metrics on ML recommendation engine performance

--- a/views/modern/admin/groups/settings.php
+++ b/views/modern/admin/groups/settings.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Groups Settings
  * Path: views/modern/admin-legacy/groups/settings.php

--- a/views/modern/admin/groups/view.php
+++ b/views/modern/admin/groups/view.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Group Detail View
  * Path: views/modern/admin-legacy/groups/view.php

--- a/views/modern/admin/layouts/gold-standard.php
+++ b/views/modern/admin/layouts/gold-standard.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Gold Standard Layout - Mission Control Design
  * Dark Mode Holographic Glassmorphism Theme

--- a/views/modern/admin/legal-documents/acceptances.php
+++ b/views/modern/admin/legal-documents/acceptances.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin View Acceptance Records for a Version
  */

--- a/views/modern/admin/legal-documents/compliance.php
+++ b/views/modern/admin/legal-documents/compliance.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Legal Compliance Dashboard
  * Overview of document acceptance rates and compliance statistics

--- a/views/modern/admin/legal-documents/create.php
+++ b/views/modern/admin/legal-documents/create.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Create Legal Document Form
  */

--- a/views/modern/admin/legal-documents/edit.php
+++ b/views/modern/admin/legal-documents/edit.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Edit Legal Document Settings
  */

--- a/views/modern/admin/legal-documents/index.php
+++ b/views/modern/admin/legal-documents/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Legal Documents Manager
  * List all legal documents with compliance statistics

--- a/views/modern/admin/legal-documents/show.php
+++ b/views/modern/admin/legal-documents/show.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Legal Document Detail View
  * Show document with version history and stats

--- a/views/modern/admin/legal-documents/versions/compare-select.php
+++ b/views/modern/admin/legal-documents/versions/compare-select.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Select Versions to Compare
  */

--- a/views/modern/admin/legal-documents/versions/compare.php
+++ b/views/modern/admin/legal-documents/versions/compare.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Version Comparison View
  * Side-by-side diff of two document versions

--- a/views/modern/admin/legal-documents/versions/create.php
+++ b/views/modern/admin/legal-documents/versions/create.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Create New Version Form
  */

--- a/views/modern/admin/legal-documents/versions/edit.php
+++ b/views/modern/admin/legal-documents/versions/edit.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Edit Draft Version Form
  */

--- a/views/modern/admin/legal-documents/versions/show.php
+++ b/views/modern/admin/legal-documents/versions/show.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin View Version Details
  */

--- a/views/modern/admin/listings/index.php
+++ b/views/modern/admin/listings/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Listings Manager - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/match-approvals/history.php
+++ b/views/modern/admin/match-approvals/history.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Match Approval History
  * Shows approved/rejected matches

--- a/views/modern/admin/match-approvals/index.php
+++ b/views/modern/admin/match-approvals/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Match Approvals Dashboard
  * Broker workflow for approving/rejecting matches

--- a/views/modern/admin/match-approvals/show.php
+++ b/views/modern/admin/match-approvals/show.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Match Approval Detail View
  * Shows full details for a single match approval request

--- a/views/modern/admin/menus/builder.php
+++ b/views/modern/admin/menus/builder.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Menu Builder
  * Visual menu item management with drag-and-drop

--- a/views/modern/admin/menus/create.php
+++ b/views/modern/admin/menus/create.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Menu Creation Form
  */

--- a/views/modern/admin/menus/index.php
+++ b/views/modern/admin/menus/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Menu Manager - Gold Standard v2.0
  * STANDALONE Admin Interface with Holographic Glassmorphism

--- a/views/modern/admin/native-app.php
+++ b/views/modern/admin/native-app.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Native App Management - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/newsletters/activity.php
+++ b/views/modern/admin/newsletters/activity.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Newsletter Activity View - All Opens & Clicks
  * Holographic Glassmorphism Dark Theme

--- a/views/modern/admin/newsletters/analytics.php
+++ b/views/modern/admin/newsletters/analytics.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Newsletter Analytics - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/newsletters/bounces.php
+++ b/views/modern/admin/newsletters/bounces.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Newsletter Bounces - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/newsletters/diagnostics.php
+++ b/views/modern/admin/newsletters/diagnostics.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Newsletter Diagnostics & Repair Tool - Gold Standard Admin UI
  * Holographic Glassmorphism Dark Theme

--- a/views/modern/admin/newsletters/form.php
+++ b/views/modern/admin/newsletters/form.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Newsletter Create/Edit Form - Gold Standard Admin UI
  * Holographic Glassmorphism Dark Theme

--- a/views/modern/admin/newsletters/index.php
+++ b/views/modern/admin/newsletters/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Newsletter Hub - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/newsletters/resend.php
+++ b/views/modern/admin/newsletters/resend.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Resend to Non-Openers View - Gold Standard Admin UI
  * Holographic Glassmorphism Dark Theme

--- a/views/modern/admin/newsletters/segment-form.php
+++ b/views/modern/admin/newsletters/segment-form.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Newsletter Segment Create/Edit Form - Gold Standard Admin UI
  * Holographic Glassmorphism Design

--- a/views/modern/admin/newsletters/segments.php
+++ b/views/modern/admin/newsletters/segments.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Newsletter Segments - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/newsletters/send-time.php
+++ b/views/modern/admin/newsletters/send-time.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Send Time Optimization View - Gold Standard Admin UI
  * Holographic Glassmorphism Dark Theme

--- a/views/modern/admin/newsletters/stats.php
+++ b/views/modern/admin/newsletters/stats.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Newsletter Stats/Analytics View - Gold Standard Admin UI
  * Holographic Glassmorphism Dark Theme

--- a/views/modern/admin/newsletters/subscribers.php
+++ b/views/modern/admin/newsletters/subscribers.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Newsletter Subscribers - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/newsletters/template-form.php
+++ b/views/modern/admin/newsletters/template-form.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Newsletter Template Create/Edit Form - Gold Standard Admin UI
  * Holographic Glassmorphism Design

--- a/views/modern/admin/newsletters/templates.php
+++ b/views/modern/admin/newsletters/templates.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Newsletter Templates - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/nexus-score-analytics.php
+++ b/views/modern/admin/nexus-score-analytics.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Nexus Score Analytics Dashboard
  * Community-wide scoring analytics and insights for administrators

--- a/views/modern/admin/pages/builder-v2.php
+++ b/views/modern/admin/pages/builder-v2.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Page Builder V2 - Modern Builder Interface
  * Clean, functional page builder with Gold Standard design

--- a/views/modern/admin/pages/builder.php
+++ b/views/modern/admin/pages/builder.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Page Builder - Gold Standard Edition
  * STANDALONE admin interface using admin-header.php and admin-footer.php

--- a/views/modern/admin/pages/create.php
+++ b/views/modern/admin/pages/create.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Create Page - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/pages/index.php
+++ b/views/modern/admin/pages/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Page Manager - Gold Standard
  * STANDALONE admin interface with drag-to-reorder

--- a/views/modern/admin/pages/preview.php
+++ b/views/modern/admin/pages/preview.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Page Preview Template
  * Shows a page preview with header banner indicating preview mode

--- a/views/modern/admin/pages/versions.php
+++ b/views/modern/admin/pages/versions.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Page Version History - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/partials/admin-breadcrumbs.php
+++ b/views/modern/admin/partials/admin-breadcrumbs.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Breadcrumbs Component
  * Automatically generates breadcrumbs from current URL and navigation config

--- a/views/modern/admin/partials/admin-footer.php
+++ b/views/modern/admin/partials/admin-footer.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Footer - Redirects to shared admin footer
  * This file exists for backwards compatibility with existing admin views

--- a/views/modern/admin/partials/admin-header.php
+++ b/views/modern/admin/partials/admin-header.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Gold Standard Header Component - Modern Theme
  * STANDALONE admin interface - does NOT use main site header/footer

--- a/views/modern/admin/partials/super-admin-footer.php
+++ b/views/modern/admin/partials/super-admin-footer.php
@@ -1,3 +1,9 @@
+<?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+?>
     </div><!-- /.super-admin-content -->
 </div><!-- /.super-admin-wrapper -->
 

--- a/views/modern/admin/partials/super-admin-header.php
+++ b/views/modern/admin/partials/super-admin-header.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin Gold Standard Header Component
  * STANDALONE Platform Master interface - does NOT use main site header/footer

--- a/views/modern/admin/plans/comparison.php
+++ b/views/modern/admin/plans/comparison.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Plan Comparison
  * Visual comparison matrix

--- a/views/modern/admin/plans/form.php
+++ b/views/modern/admin/plans/form.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Plan Form - Create/Edit
  */

--- a/views/modern/admin/plans/index.php
+++ b/views/modern/admin/plans/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Plan Manager - Index
  * Super Admin interface for managing subscription plans

--- a/views/modern/admin/plans/subscriptions.php
+++ b/views/modern/admin/plans/subscriptions.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Subscription Manager
  * Assign plans to tenants

--- a/views/modern/admin/seo/audit.php
+++ b/views/modern/admin/seo/audit.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin SEO Health Audit - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/seo/bulk-edit.php
+++ b/views/modern/admin/seo/bulk-edit.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Bulk SEO Editor - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/seo/index.php
+++ b/views/modern/admin/seo/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin SEO Settings - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/seo/organization.php
+++ b/views/modern/admin/seo/organization.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Organization Schema Settings - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/seo/redirects.php
+++ b/views/modern/admin/seo/redirects.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin 301 Redirect Manager - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/settings.php
+++ b/views/modern/admin/settings.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Settings - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/smart-match-monitoring.php
+++ b/views/modern/admin/smart-match-monitoring.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Smart Match Monitoring Dashboard - Admin Interface
  */

--- a/views/modern/admin/smart-match-users.php
+++ b/views/modern/admin/smart-match-users.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Smart Match Users to Groups - Admin Interface
  */

--- a/views/modern/admin/smart-matching/analytics.php
+++ b/views/modern/admin/smart-matching/analytics.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Smart Matching Analytics - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/smart-matching/configuration.php
+++ b/views/modern/admin/smart-matching/configuration.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Smart Matching Configuration - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/smart-matching/index.php
+++ b/views/modern/admin/smart-matching/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Smart Matching - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/super-admin/dashboard.php
+++ b/views/modern/admin/super-admin/dashboard.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin Dashboard - Gold Standard
  * Platform Master Control Center

--- a/views/modern/admin/super-admin/tenant-edit.php
+++ b/views/modern/admin/super-admin/tenant-edit.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin Tenant Edit - Gold Standard
  * Configure individual community settings

--- a/views/modern/admin/super-admin/users.php
+++ b/views/modern/admin/super-admin/users.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin Users - Gold Standard
  * Global User Directory across all tenants

--- a/views/modern/admin/timebanking/alert-detail.php
+++ b/views/modern/admin/timebanking/alert-detail.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Alert Detail - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/timebanking/alerts.php
+++ b/views/modern/admin/timebanking/alerts.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Abuse Alerts - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/timebanking/create-org.php
+++ b/views/modern/admin/timebanking/create-org.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Create Organization - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/timebanking/dashboard.php
+++ b/views/modern/admin/timebanking/dashboard.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Timebanking Dashboard - Gold Standard
  * STANDALONE admin interface with analytics

--- a/views/modern/admin/timebanking/org-members.php
+++ b/views/modern/admin/timebanking/org-members.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Organization Members - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/timebanking/org-wallets.php
+++ b/views/modern/admin/timebanking/org-wallets.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Organization Wallets - Gold Standard v2.0
  * STANDALONE admin interface with Holographic Glassmorphism

--- a/views/modern/admin/timebanking/user-report.php
+++ b/views/modern/admin/timebanking/user-report.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Timebanking User Report - Gold Standard Admin UI
  * Holographic Glassmorphism Design

--- a/views/modern/admin/timebanking/user-search.php
+++ b/views/modern/admin/timebanking/user-search.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Timebanking User Search - Gold Standard Admin UI
  * Holographic Glassmorphism Design

--- a/views/modern/admin/users/create.php
+++ b/views/modern/admin/users/create.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Create User - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/users/edit.php
+++ b/views/modern/admin/users/edit.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Edit User - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/users/index.php
+++ b/views/modern/admin/users/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin User Management - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/users/permissions.php
+++ b/views/modern/admin/users/permissions.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * User Permission Editor
  * Gold Standard v2.0 Admin Interface

--- a/views/modern/admin/volunteering/approvals.php
+++ b/views/modern/admin/volunteering/approvals.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Volunteering Approvals - Gold Standard
  * STANDALONE admin interface

--- a/views/modern/admin/volunteering/index.php
+++ b/views/modern/admin/volunteering/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Volunteering Admin Dashboard - Gold Standard Mission Control
  * STANDALONE admin interface - does NOT use main site header/footer

--- a/views/modern/admin/volunteering/organizations.php
+++ b/views/modern/admin/volunteering/organizations.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Volunteering Organizations - Gold Standard
  * STANDALONE admin interface

--- a/views/newsletter/message.php
+++ b/views/newsletter/message.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Newsletter Message Page
  *

--- a/views/partials/admin/admin-bulk-actions.php
+++ b/views/partials/admin/admin-bulk-actions.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Bulk Actions System - Gold Standard v2.0
  * Reusable bulk operations for list pages with checkboxes

--- a/views/partials/admin/admin-export.php
+++ b/views/partials/admin/admin-export.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Export System - Gold Standard v2.0
  * CSV/PDF/Excel export functionality for data tables

--- a/views/partials/admin/admin-footer.php
+++ b/views/partials/admin/admin-footer.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Gold Standard Footer Component
  * STANDALONE - closes HTML document started by admin-header.php

--- a/views/partials/admin/admin-modals.php
+++ b/views/partials/admin/admin-modals.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Modal System - Gold Standard v2.0
  * Reusable modal components for quick actions

--- a/views/partials/admin/admin-navigation-config.php
+++ b/views/partials/admin/admin-navigation-config.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Navigation Configuration
  * Shared navigation structure used by both Modern and CivicOne themes

--- a/views/partials/admin/admin-realtime.php
+++ b/views/partials/admin/admin-realtime.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Real-Time Updates System - Gold Standard v2.0
  * Polling-based live dashboard updates

--- a/views/partials/admin/admin-sidebar.php
+++ b/views/partials/admin/admin-sidebar.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Sidebar Navigation Component
  * Renders collapsible vertical sidebar from centralized config

--- a/views/partials/admin/admin-validation.php
+++ b/views/partials/admin/admin-validation.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Admin Form Validation - Gold Standard v2.0
  * Live client-side validation with visual feedback

--- a/views/partials/admin/super-admin-footer.php
+++ b/views/partials/admin/super-admin-footer.php
@@ -1,3 +1,9 @@
+<?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+?>
     </div><!-- /.super-admin-content -->
 </div><!-- /.super-admin-wrapper -->
 

--- a/views/partials/admin/super-admin-header.php
+++ b/views/partials/admin/super-admin-header.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin Gold Standard Header Component
  * STANDALONE Platform Master interface - does NOT use main site header/footer

--- a/views/super-admin/audit/index.php
+++ b/views/super-admin/audit/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin - Audit Log
  *

--- a/views/super-admin/bulk/index.php
+++ b/views/super-admin/bulk/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin - Bulk Operations
  *

--- a/views/super-admin/dashboard.php
+++ b/views/super-admin/dashboard.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin Dashboard
  * Infrastructure Overview - Tenant Hierarchy Management

--- a/views/super-admin/federation/audit-log.php
+++ b/views/super-admin/federation/audit-log.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin Federation Audit Log
  * Complete audit trail of all federation activity

--- a/views/super-admin/federation/index.php
+++ b/views/super-admin/federation/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin Federation Control Center
  * Overview of all federation activity and controls

--- a/views/super-admin/federation/partnerships.php
+++ b/views/super-admin/federation/partnerships.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin Federation Partnerships Overview
  * View and manage all partnerships across the platform

--- a/views/super-admin/federation/system-controls.php
+++ b/views/super-admin/federation/system-controls.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin Federation System Controls
  * Master kill switch and global feature toggles

--- a/views/super-admin/federation/tenant-features.php
+++ b/views/super-admin/federation/tenant-features.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin - Tenant Federation Features
  * View and manage federation features for a specific tenant

--- a/views/super-admin/federation/whitelist.php
+++ b/views/super-admin/federation/whitelist.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin Federation Whitelist Management
  * Manage which tenants can participate in federation

--- a/views/super-admin/partials/footer.php
+++ b/views/super-admin/partials/footer.php
@@ -1,3 +1,9 @@
+<?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+?>
     </main>
 
     <script>

--- a/views/super-admin/partials/header.php
+++ b/views/super-admin/partials/header.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin Panel Header
  * Distinct from Platform Admin - Infrastructure Management

--- a/views/super-admin/tenants/create.php
+++ b/views/super-admin/tenants/create.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin - Create Tenant Form
  */

--- a/views/super-admin/tenants/edit.php
+++ b/views/super-admin/tenants/edit.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin - Edit Tenant Form
  */

--- a/views/super-admin/tenants/hierarchy.php
+++ b/views/super-admin/tenants/hierarchy.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin - Visual Hierarchy Tree
  *

--- a/views/super-admin/tenants/index.php
+++ b/views/super-admin/tenants/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin - Tenant List
  */

--- a/views/super-admin/tenants/show.php
+++ b/views/super-admin/tenants/show.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin - View Tenant Details
  */

--- a/views/super-admin/users/create.php
+++ b/views/super-admin/users/create.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin - Create User Form
  */

--- a/views/super-admin/users/edit.php
+++ b/views/super-admin/users/edit.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin - Edit User (Full Control)
  *

--- a/views/super-admin/users/index.php
+++ b/views/super-admin/users/index.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin - User List
  */

--- a/views/super-admin/users/show.php
+++ b/views/super-admin/users/show.php
@@ -1,4 +1,9 @@
 <?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
 /**
  * Super Admin - View User Details
  */


### PR DESCRIPTION
## Summary

Full system audit across 5 domains, run in parallel by agent teams. All findings triaged and fixed where actionable.

- **Security**: Enforce tenant scope on endorsement user lookups (cross-tenant user enumeration/endorsement was possible)
- **PHP Backend**: Add `Log::warning()` to 21 silent empty catch blocks in stats controllers; add `Schema::hasColumn()` idempotency guards to 2 migrations
- **SPDX Headers**: Add AGPL-3.0 headers to 338 files (config, views, migrations, e2e, mobile); expand compliance scripts to cover full codebase
- **i18n**: Replace 7 hardcoded English strings in EventReminderService, EventService, GroupExchangeService with translation keys; add 6 new keys to svc_notifications_2.json
- **React**: Suppress TS5101 `baseUrl` deprecation warning in tsconfig.json

## Commits

| Commit | Fix |
|--------|-----|
| `274ce75` | fix(security): enforce tenant scope on endorsement user lookups |
| `b69ed68` | fix(backend): Log::warning on empty catch blocks; migration idempotency guards |
| `01e92bf` | chore(spdx): add AGPL-3.0 headers to 338 files; expand compliance scripts |
| `e7b87d0` | fix(i18n): replace hardcoded English strings in event/exchange services |
| `cdfdc8e` | fix(react): suppress tsconfig baseUrl deprecation warning (TS5101) |

## Backlog (not fixed in this PR)

- **i18n — super-admin PHP views**: 76+ hardcoded strings across `views/super-admin/` — large refactor, tracked separately
- **React large pages**: `JobDetailPage.tsx` (2,760 lines), `GroupDetailPage.tsx` (2,014 lines) — refactoring candidates, no functional bugs
- **`$where` SQL pattern**: Flagged by audit agent; confirmed safe on review (all conditions are hardcoded literals or `?` params; sort column from whitelist; `$order` binary-validated)

## Test plan

- [ ] Verify endorsements cannot be made across tenants (test with two different tenant users)
- [ ] Confirm stats dashboards (volunteer, CRM, timebanking) still render correctly — catch blocks now log but don't break
- [ ] Run `node scripts/check-spdx.mjs` — should report 0 missing
- [ ] Confirm event reminder notifications still deliver with correct text
- [ ] Run `cd react-frontend && npm run lint` — no TS5101 deprecation warning

https://claude.ai/code/session_01CgJfzqNuwz7Xd4XtV3TaUq