### PR TITLE
Internationalize UI strings across frontend and improve table existence check

### DIFF
--- a/app/Http/Controllers/Api/AdminNewsletterController.php
+++ b/app/Http/Controllers/Api/AdminNewsletterController.php
@@ -9,6 +9,7 @@ namespace App\Http\Controllers\Api;
 use App\Services\NewsletterService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use App\Core\TenantContext;
 use Illuminate\Support\Facades\Log;
 
@@ -45,12 +46,7 @@ class AdminNewsletterController extends BaseApiController
         if (!in_array($table, self::ALLOWED_TABLES, true)) {
             return false;
         }
-        try {
-            DB::select("SELECT 1 FROM `{$table}` LIMIT 1");
-            return true;
-        } catch (\Exception $e) {
-            return false;
-        }
+        return Schema::hasTable($table);
     }
 
     public function index(): JsonResponse

--- a/react-frontend/public/locales/en/about.json
+++ b/react-frontend/public/locales/en/about.json
@@ -409,5 +409,6 @@
     "cta_subtitle": "Whether you want to partner, fund, volunteer, or join as a member \u2014 there\u0027s a role for you in building a more connected Ireland.",
     "cta_download": "Download Full Plan",
     "cta_contact": "Get in Touch"
-  }
+  },
+  "age_band": "Age {{band}}"
 }

--- a/react-frontend/public/locales/en/admin.json
+++ b/react-frontend/public/locales/en/admin.json
@@ -788,6 +788,7 @@
     "low": "Low",
     "medium": "Medium",
     "planned": "Planned",
+    "clear": "Clear",
     "refresh": "Refresh",
     "unexpected_error": "Unexpected error",
     "unfeature": "Unfeature"
@@ -1382,6 +1383,8 @@
     "back_to_roles": "Back to Roles",
     "basic_information": "Basic Information",
     "breach_reported_successfully": "Breach Reported Successfully",
+    "secret_rotation_title": "Secret Rotation",
+    "connection_test_title": "Connection Test Results",
     "col_action": "Action",
     "col_actions": "Actions",
     "col_consented": "Consented",
@@ -4513,6 +4516,7 @@
     "withdrawn_on": "Withdrawn on"
   },
   "users": {
+    "page_title": "Admin - Users",
     "action_approve": "Approve",
     "action_ban": "Ban",
     "action_delete": "Delete",

--- a/react-frontend/public/locales/en/admin.json
+++ b/react-frontend/public/locales/en/admin.json
@@ -789,6 +789,7 @@
     "medium": "Medium",
     "planned": "Planned",
     "clear": "Clear",
+    "no": "No",
     "refresh": "Refresh",
     "unexpected_error": "Unexpected error",
     "unfeature": "Unfeature"
@@ -901,6 +902,7 @@
     "module_desc_identity_verification": "Stripe Identity verification with ID Verified badge, document + selfie matching, and configurable fee"
   },
   "content": {
+    "about": "About",
     "about_section": "About Section",
     "advanced_options": "Advanced Options",
     "allowed_layouts": "Allowed Layouts",
@@ -4808,5 +4810,44 @@
     "total_actions_30d": "Total Actions (Last 30 Days)",
     "export_csv": "Export CSV",
     "clear": "Clear Filters"
+  },
+  "bulk": {
+    "result_failed": "Bulk action failed",
+    "result_partial": "Partial success: {{success}} succeeded, {{failed}} failed",
+    "result_success": "{{count}} item(s) updated successfully",
+    "confirm_title": "{{action}} selected items?",
+    "confirm_message": "This will {{action}} {{count}} item(s).",
+    "destructive_warning": "This action cannot be undone.",
+    "reason_label": "Reason",
+    "reason_placeholder": "Enter a reason...",
+    "clear_selection": "Clear selection",
+    "blog": {
+      "publish": "Publish",
+      "publish_confirm_title": "Publish selected posts?",
+      "publish_confirm_message": "This will publish {{count}} post(s).",
+      "archive": "Archive (Unpublish)",
+      "archive_confirm_title": "Archive selected posts?",
+      "archive_confirm_message": "This will unpublish {{count}} post(s). They can be republished later.",
+      "delete": "Delete",
+      "delete_confirm_title": "Delete selected posts?",
+      "delete_confirm_message": "This will permanently delete {{count}} post(s). This cannot be undone."
+    },
+    "marketplace": {
+      "reject": "Reject",
+      "reject_confirm_title": "Reject selected items?",
+      "reject_confirm_message": "This will reject {{count}} item(s).",
+      "reason_label": "Rejection reason",
+      "reason_placeholder": "Enter rejection reason..."
+    },
+    "users": {
+      "approve": "Approve",
+      "approve_confirm_title": "Approve selected users?",
+      "approve_confirm_message": "This will approve {{count}} user(s).",
+      "suspend": "Suspend",
+      "suspend_confirm_title": "Suspend selected users?",
+      "suspend_confirm_message": "This will suspend {{count}} user(s).",
+      "reason_label": "Suspension reason",
+      "reason_placeholder": "Enter suspension reason..."
+    }
   }
 }

--- a/react-frontend/public/locales/en/auth.json
+++ b/react-frontend/public/locales/en/auth.json
@@ -186,6 +186,9 @@
   "login_meta_description": "Sign in to your account",
   "passkey_not_found": "No passkey found for this account. Log in with your password, then go to Settings to register a passkey.",
   "page_meta": {
+    "login": {
+      "title": "Sign In"
+    },
     "register": {
       "title": "Create Account"
     },

--- a/react-frontend/public/locales/en/common.json
+++ b/react-frontend/public/locales/en/common.json
@@ -401,6 +401,11 @@
   "verification": {
     "not_id_verified": "Not ID Verified"
   },
+  "radius_5": "5 km",
+  "radius_10": "10 km",
+  "radius_25": "25 km",
+  "radius_50": "50 km",
+  "radius_100": "100 km",
   "page_meta": {
     "skills_browse": {
       "title": "Browse Skills"

--- a/react-frontend/public/locales/en/community.json
+++ b/react-frontend/public/locales/en/community.json
@@ -277,6 +277,8 @@
     "load_failed": "Failed to load certificates. Please try again.",
     "load_error": "Unable to load certificates. Please try again."
   },
+  "remote": "Remote",
+  "closes_date": "Closes {{date}}",
   "page_meta": {
     "register_organisation": {
       "title": "Register Organisation"

--- a/react-frontend/public/locales/en/errors.json
+++ b/react-frontend/public/locales/en/errors.json
@@ -13,6 +13,11 @@
   "whats_new": "What's new:",
   "later": "Later",
   "download_update": "Download Update",
+  "community_not_found": "Community Not Found",
+  "community_not_found_message": "We couldn't find a community called \"{{slug}}\".",
+  "community_not_found_detail": "The community may have been renamed, deactivated, or the URL may be incorrect.",
+  "go_home": "Go Home",
+  "find_community": "Find Community",
   "validation": {
     "required": "This field is required",
     "email": "Please enter a valid email address",

--- a/react-frontend/public/locales/en/events.json
+++ b/react-frontend/public/locales/en/events.json
@@ -241,6 +241,11 @@
     "vote_failed": "Failed to record vote",
     "view_full": "View full poll"
   },
+  "radius_5": "5 km",
+  "radius_10": "10 km",
+  "radius_25": "25 km",
+  "radius_50": "50 km",
+  "radius_100": "100 km",
   "page_meta": {
     "create": {
       "title": "Create Event"

--- a/react-frontend/public/locales/en/listings.json
+++ b/react-frontend/public/locales/en/listings.json
@@ -181,6 +181,11 @@
   "filter_this_month": "This month",
   "clear_filters": "Clear filters",
   "results_count": "{{count}} listings found",
+  "radius_5": "5 km",
+  "radius_10": "10 km",
+  "radius_25": "25 km",
+  "radius_50": "50 km",
+  "radius_100": "100 km",
   "page_meta": {
     "create": {
       "title": "Create Listing"

--- a/react-frontend/public/locales/en/polls.json
+++ b/react-frontend/public/locales/en/polls.json
@@ -74,6 +74,10 @@
   "category_placeholder": "e.g. Community, Events, Feedback",
   "anonymous_voting": "Anonymous Voting",
   "anonymous_voting_desc": "Hide voter identities in results",
+  "ranked_results_title": "Round-by-Round Results",
+  "round_number": "Round {{number}}",
+  "eliminated_candidate": "Eliminated: {{name}}",
+  "total_ballots": "Total ballots: {{count}}",
   "aria": {
     "export_csv": "Export results as CSV"
   },

--- a/react-frontend/src/admin/modules/content/PagesAdmin.tsx
+++ b/react-frontend/src/admin/modules/content/PagesAdmin.tsx
@@ -120,10 +120,10 @@ export function PagesAdmin() {
       sortable: true,
       render: (item) => item.show_in_menu ? (
         <Chip size="sm" variant="flat" color="primary">
-          {item.menu_location === 'footer' ? 'Footer' : 'About'}
+          {item.menu_location === 'footer' ? t('content.footer') : t('content.about')}
         </Chip>
       ) : (
-        <span className="text-sm text-default-400">No</span>
+        <span className="text-sm text-default-400">{t('common.no')}</span>
       ),
     },
     {

--- a/react-frontend/src/admin/modules/enterprise/SecretsVault.tsx
+++ b/react-frontend/src/admin/modules/enterprise/SecretsVault.tsx
@@ -278,7 +278,7 @@ export function SecretsVault() {
       {/* Rotate Result Modal */}
       <Modal isOpen={rotateModalOpen} onClose={() => setRotateModalOpen(false)}>
         <ModalContent>
-          <ModalHeader>Secret Rotation</ModalHeader>
+          <ModalHeader>{t('enterprise.secret_rotation_title')}</ModalHeader>
           <ModalBody>
             <p className="text-default-600">{rotateMessage}</p>
           </ModalBody>
@@ -293,7 +293,7 @@ export function SecretsVault() {
       {/* Test Connection Results Modal */}
       <Modal isOpen={testModalOpen} onClose={() => setTestModalOpen(false)}>
         <ModalContent>
-          <ModalHeader>Connection Test Results</ModalHeader>
+          <ModalHeader>{t('enterprise.connection_test_title')}</ModalHeader>
           <ModalBody>
             {testResults && (
               <div className="space-y-3">

--- a/react-frontend/src/admin/modules/groups/GroupList.tsx
+++ b/react-frontend/src/admin/modules/groups/GroupList.tsx
@@ -376,7 +376,7 @@ export function GroupList() {
           <span className="text-sm font-medium">{selectedIds.size} selected</span>
           <Button size="sm" variant="flat" onPress={handleBulkArchive}>{t('groups.archive')}</Button>
           <Button size="sm" variant="flat" color="danger" onPress={handleBulkDelete}>{t('common.delete')}</Button>
-          <Button size="sm" variant="flat" onPress={() => setSelectedIds(new Set())}>Clear</Button>
+          <Button size="sm" variant="flat" onPress={() => setSelectedIds(new Set())}>{t('common.clear')}</Button>
         </div>
       )}
 

--- a/react-frontend/src/admin/modules/users/UserList.tsx
+++ b/react-frontend/src/admin/modules/users/UserList.tsx
@@ -59,7 +59,7 @@ import type { AdminUser, UserListParams } from '../../api/types';
 
 export function UserList() {
   const { t } = useTranslation('admin');
-  usePageTitle('Admin - Users');
+  usePageTitle(t('users.page_title'));
   const { tenantPath, tenant } = useTenant();
   const toast = useToast();
   const { user: currentUser } = useAuth();

--- a/react-frontend/src/broker/pages/ExchangesPage.tsx
+++ b/react-frontend/src/broker/pages/ExchangesPage.tsx
@@ -45,7 +45,7 @@ const statusColorMap: Record<string, 'warning' | 'success' | 'danger' | 'default
 
 export default function ExchangesPage() {
   const { t } = useTranslation('broker');
-  usePageTitle('Exchanges - Broker');
+  usePageTitle(t('exchanges.title'));
   const toast = useToast();
 
   // Data state

--- a/react-frontend/src/broker/pages/MessageReviewPage.tsx
+++ b/react-frontend/src/broker/pages/MessageReviewPage.tsx
@@ -54,7 +54,7 @@ function filterParam(tab: string): string | undefined {
 
 export default function MessageReviewPage() {
   const { t } = useTranslation('broker');
-  usePageTitle('Messages - Broker');
+  usePageTitle(t('messages.title'));
   const toast = useToast();
 
   // Data state

--- a/react-frontend/src/broker/pages/SafeguardingPage.tsx
+++ b/react-frontend/src/broker/pages/SafeguardingPage.tsx
@@ -112,7 +112,7 @@ function SeverityChip({ severity }: { severity: string }) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 export default function SafeguardingPage() {
-  usePageTitle('Safeguarding - Broker');
+  usePageTitle(t('safeguarding.title'));
   const { t } = useTranslation('broker');
   const toast = useToast();
 

--- a/react-frontend/src/broker/pages/VettingPage.tsx
+++ b/react-frontend/src/broker/pages/VettingPage.tsx
@@ -85,7 +85,7 @@ function tabToParams(tab: TabKey): { status?: string; expiring_soon?: boolean } 
 // ─────────────────────────────────────────────────────────────────────────────
 
 export default function VettingPage() {
-  usePageTitle('Vetting & DBS - Broker');
+  usePageTitle(t('vetting.title'));
   const { t } = useTranslation('broker');
   const toast = useToast();
 

--- a/react-frontend/src/components/routing/TenantShell.tsx
+++ b/react-frontend/src/components/routing/TenantShell.tsx
@@ -253,10 +253,11 @@ import { PageMeta } from '@/components/seo';
 import { usePageTitle } from '@/hooks';
 
 function CommunityNotFound({ slug }: { slug: string }) {
-  usePageTitle('Community Not Found');
+  const { t } = useTranslation('errors');
+  usePageTitle(t('community_not_found'));
   return (
     <div className="min-h-[80vh] flex items-center justify-center px-4">
-      <PageMeta title="Community Not Found" noIndex />
+      <PageMeta title={t('community_not_found')} noIndex />
       <Helmet>
         <meta name="prerender-status-code" content="404" />
       </Helmet>
@@ -270,12 +271,12 @@ function CommunityNotFound({ slug }: { slug: string }) {
             <Globe className="w-10 h-10 text-amber-500" aria-hidden="true" />
           </div>
 
-          <h1 className="text-2xl font-bold text-theme-primary mb-2">Community Not Found</h1>
+          <h1 className="text-2xl font-bold text-theme-primary mb-2">{t('community_not_found')}</h1>
           <p className="text-theme-muted mb-2">
-            We couldn&apos;t find a community called &ldquo;<strong>{slug}</strong>&rdquo;.
+            {t('community_not_found_message', { slug })}
           </p>
           <p className="text-sm text-theme-subtle mb-8">
-            The community may have been renamed, deactivated, or the URL may be incorrect.
+            {t('community_not_found_detail')}
           </p>
 
           <div className="flex flex-col sm:flex-row gap-3">
@@ -284,7 +285,7 @@ function CommunityNotFound({ slug }: { slug: string }) {
                 className="w-full bg-gradient-to-r from-indigo-500 to-purple-600 text-white"
                 startContent={<Home className="w-4 h-4" aria-hidden="true" />}
               >
-                Go Home
+                {t('go_home')}
               </Button>
             </Link>
             <Link to="/login" className="flex-1">
@@ -293,7 +294,7 @@ function CommunityNotFound({ slug }: { slug: string }) {
                 className="w-full bg-theme-elevated text-theme-muted"
                 startContent={<Search className="w-4 h-4" aria-hidden="true" />}
               >
-                Find Community
+                {t('find_community')}
               </Button>
             </Link>
           </div>

--- a/react-frontend/src/pages/about/ImpactReportPage.tsx
+++ b/react-frontend/src/pages/about/ImpactReportPage.tsx
@@ -392,7 +392,7 @@ export function ImpactReportPage() {
                     { band: '65+', pct: '28%', color: 'from-amber-500/20 to-orange-500/20' },
                   ].map((age) => (
                     <div key={age.band} className={`p-3 rounded-xl bg-gradient-to-br ${age.color} text-center`}>
-                      <p className="text-xs text-theme-subtle mb-1">Age {age.band}</p>
+                      <p className="text-xs text-theme-subtle mb-1">{t('age_band', { band: age.band })}</p>
                       <p className="text-lg font-bold text-theme-primary">{age.pct}</p>
                     </div>
                   ))}

--- a/react-frontend/src/pages/auth/ForgotPasswordPage.tsx
+++ b/react-frontend/src/pages/auth/ForgotPasswordPage.tsx
@@ -21,7 +21,7 @@ import { api } from '@/lib/api';
 
 export function ForgotPasswordPage() {
   const { t } = useTranslation('auth');
-  usePageTitle('Reset Password');
+  usePageTitle(t('page_meta.forgot_password.title'));
   const { branding, tenantPath } = useTenant();
   const [email, setEmail] = useState('');
   const [isLoading, setIsLoading] = useState(false);

--- a/react-frontend/src/pages/auth/LoginPage.tsx
+++ b/react-frontend/src/pages/auth/LoginPage.tsx
@@ -42,7 +42,7 @@ interface Tenant {
 
 export function LoginPage() {
   const { t } = useTranslation('auth');
-  usePageTitle('Sign In');
+  usePageTitle(t('page_meta.login.title'));
   const navigate = useNavigate();
   const location = useLocation();
   const {

--- a/react-frontend/src/pages/auth/RegisterPage.tsx
+++ b/react-frontend/src/pages/auth/RegisterPage.tsx
@@ -70,7 +70,7 @@ const STEPS = [
 
 export function RegisterPage() {
   const { t } = useTranslation('auth');
-  usePageTitle('Create Account');
+  usePageTitle(t('page_meta.register.title'));
   const navigate = useNavigate();
   const { register, isAuthenticated, isLoading, error, clearError } = useAuth();
   const { tenant, tenantSlug, tenantPath } = useTenant();

--- a/react-frontend/src/pages/auth/ResetPasswordPage.tsx
+++ b/react-frontend/src/pages/auth/ResetPasswordPage.tsx
@@ -22,7 +22,7 @@ import { validatePassword, PASSWORD_REQUIREMENTS } from '@/lib/validation';
 
 export function ResetPasswordPage() {
   const { t } = useTranslation('auth');
-  usePageTitle('Set New Password');
+  usePageTitle(t('reset_password.page_title'));
   const { branding, tenantPath } = useTenant();
   const [searchParams] = useSearchParams();
   const token = searchParams.get('token');

--- a/react-frontend/src/pages/auth/VerifyEmailPage.tsx
+++ b/react-frontend/src/pages/auth/VerifyEmailPage.tsx
@@ -27,7 +27,7 @@ type VerifyState = 'loading' | 'success' | 'error';
 
 export function VerifyEmailPage() {
   const { t } = useTranslation('auth');
-  usePageTitle('Verify Email');
+  usePageTitle(t('page_meta.verify_email.title'));
   const { branding, tenantPath, tenant } = useTenant();
   const { isAuthenticated } = useAuth();
 

--- a/react-frontend/src/pages/auth/VerifyIdentityPage.tsx
+++ b/react-frontend/src/pages/auth/VerifyIdentityPage.tsx
@@ -66,7 +66,7 @@ type PageState = 'loading' | 'start' | 'in_progress' | 'passed' | 'failed' | 'ac
 
 export function VerifyIdentityPage() {
   const { t } = useTranslation('auth');
-  usePageTitle('Verify Identity');
+  usePageTitle(t('page_meta.verify_identity.title'));
   const navigate = useNavigate();
   const { branding, tenantPath } = useTenant();
   const { isAuthenticated } = useAuth();

--- a/react-frontend/src/pages/events/EventsPage.tsx
+++ b/react-frontend/src/pages/events/EventsPage.tsx
@@ -321,11 +321,11 @@ export function EventsPage() {
                 value: 'text-theme-primary',
               }}
             >
-              <SelectItem key="5">5 km</SelectItem>
-              <SelectItem key="10">10 km</SelectItem>
-              <SelectItem key="25">25 km</SelectItem>
-              <SelectItem key="50">50 km</SelectItem>
-              <SelectItem key="100">100 km</SelectItem>
+              <SelectItem key="5">{t('radius_5')}</SelectItem>
+              <SelectItem key="10">{t('radius_10')}</SelectItem>
+              <SelectItem key="25">{t('radius_25')}</SelectItem>
+              <SelectItem key="50">{t('radius_50')}</SelectItem>
+              <SelectItem key="100">{t('radius_100')}</SelectItem>
             </Select>
           )}
 

--- a/react-frontend/src/pages/listings/ListingsPage.tsx
+++ b/react-frontend/src/pages/listings/ListingsPage.tsx
@@ -554,11 +554,11 @@ export function ListingsPage() {
                   value: 'text-theme-primary',
                 }}
               >
-                <SelectItem key="5">5 km</SelectItem>
-                <SelectItem key="10">10 km</SelectItem>
-                <SelectItem key="25">25 km</SelectItem>
-                <SelectItem key="50">50 km</SelectItem>
-                <SelectItem key="100">100 km</SelectItem>
+                <SelectItem key="5">{t('radius_5')}</SelectItem>
+                <SelectItem key="10">{t('radius_10')}</SelectItem>
+                <SelectItem key="25">{t('radius_25')}</SelectItem>
+                <SelectItem key="50">{t('radius_50')}</SelectItem>
+                <SelectItem key="100">{t('radius_100')}</SelectItem>
               </Select>
             )}
 

--- a/react-frontend/src/pages/members/MembersPage.tsx
+++ b/react-frontend/src/pages/members/MembersPage.tsx
@@ -395,11 +395,11 @@ export function MembersPage() {
                   value: 'text-theme-primary',
                 }}
               >
-                <SelectItem key="5">5 km</SelectItem>
-                <SelectItem key="10">10 km</SelectItem>
-                <SelectItem key="25">25 km</SelectItem>
-                <SelectItem key="50">50 km</SelectItem>
-                <SelectItem key="100">100 km</SelectItem>
+                <SelectItem key="5">{t('radius_5')}</SelectItem>
+                <SelectItem key="10">{t('radius_10')}</SelectItem>
+                <SelectItem key="25">{t('radius_25')}</SelectItem>
+                <SelectItem key="50">{t('radius_50')}</SelectItem>
+                <SelectItem key="100">{t('radius_100')}</SelectItem>
               </Select>
             )}
 

--- a/react-frontend/src/pages/organisations/OrganisationDetailPage.tsx
+++ b/react-frontend/src/pages/organisations/OrganisationDetailPage.tsx
@@ -472,12 +472,12 @@ export function OrganisationDetailPage() {
                           {job.type}
                         </Chip>
                         {job.is_remote ? (
-                          <span>Remote</span>
+                          <span>{t('remote')}</span>
                         ) : job.location ? (
                           <span>{job.location}</span>
                         ) : null}
                         {job.deadline && (
-                          <span>Closes {new Date(job.deadline).toLocaleDateString()}</span>
+                          <span>{t('closes_date', { date: new Date(job.deadline).toLocaleDateString() })}</span>
                         )}
                       </div>
                     </div>

--- a/react-frontend/src/pages/polls/PollsPage.tsx
+++ b/react-frontend/src/pages/polls/PollsPage.tsx
@@ -1219,7 +1219,7 @@ export function PollsPage() {
                     </Button>
                     {rankedResults && (
                       <div className="mt-3 p-3 rounded-xl bg-theme-elevated space-y-3">
-                        <h4 className="text-sm font-semibold text-theme-primary">Round-by-Round Results</h4>
+                        <h4 className="text-sm font-semibold text-theme-primary">{t('ranked_results_title')}</h4>
                         {/* Winner */}
                         {rankedResults.winner ? (
                           <div className="flex items-center gap-2 p-2 rounded-lg bg-emerald-500/10 border border-emerald-500/20">
@@ -1235,7 +1235,7 @@ export function PollsPage() {
                           const eliminated = round.eliminated as string | undefined;
                           return (
                             <div key={idx} className="p-2 rounded-lg border border-[var(--border-default)]">
-                              <p className="text-xs font-semibold text-theme-muted mb-1.5">Round {idx + 1}</p>
+                              <p className="text-xs font-semibold text-theme-muted mb-1.5">{t('round_number', { number: idx + 1 })}</p>
                               {votes && Object.entries(votes)
                                 .sort(([, a], [, b]) => b - a)
                                 .map(([option, count]) => {
@@ -1257,14 +1257,14 @@ export function PollsPage() {
                                   );
                                 })}
                               {eliminated && (
-                                <p className="text-[10px] text-red-400 mt-1">Eliminated: {eliminated}</p>
+                                <p className="text-[10px] text-red-400 mt-1">{t('eliminated_candidate', { name: eliminated })}</p>
                               )}
                             </div>
                           );
                         })}
                         {/* Total ballots */}
                         {rankedResults.total_ballots ? (
-                          <p className="text-xs text-theme-subtle">Total ballots: {String(rankedResults.total_ballots)}</p>
+                          <p className="text-xs text-theme-subtle">{t('total_ballots', { count: String(rankedResults.total_ballots) })}</p>
                         ) : null}
                       </div>
                     )}

--- a/react-frontend/src/pages/settings/SettingsPage.tsx
+++ b/react-frontend/src/pages/settings/SettingsPage.tsx
@@ -69,7 +69,7 @@ import { LinkedAccountsTab } from './tabs/LinkedAccountsTab';
 // ─────────────────────────────────────────────────────────────────────────────
 
 export function SettingsPage() {
-  usePageTitle('Settings');
+  usePageTitle(t('page_meta.title'));
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { user, logout, refreshUser } = useAuth();


### PR DESCRIPTION
## Summary
- Extracted hardcoded UI strings to i18n translation files across multiple pages and components (auth, community, polls, admin, broker, about)
- Replaced manual database table existence check with Laravel's `Schema::hasTable()` method
- Added missing translation keys for page titles, buttons, and user-facing messages

## Type of Change
- [x] Refactoring (no functional changes)
- [x] New feature (i18n support for previously hardcoded strings)

## Changes Made

### Frontend Internationalization
- **TenantShell.tsx**: Moved "Community Not Found" error page strings to `errors.json` translation file
- **PollsPage.tsx**: Internationalized ranked voting results UI (round numbers, eliminated candidates, ballot counts)
- **SecretsVault.tsx**: Moved modal headers to enterprise translation namespace
- **OrganisationDetailPage.tsx**: Added translations for job listing metadata (remote, closing date)
- **ImpactReportPage.tsx**: Internationalized age band labels
- **Auth pages**: Moved page titles to `page_meta` translation structure (Login, Register, Reset Password, Verify Email, Verify Identity)
- **UserList.tsx**: Moved admin page title to translations
- **Broker pages**: Internationalized page titles (Exchanges, Messages, Safeguarding, Vetting)
- **SettingsPage.tsx**: Moved settings page title to translations

### Backend Improvements
- **AdminNewsletterController.php**: Replaced try-catch database query with `Schema::hasTable()` for cleaner, more reliable table existence checking

### Translation Files Updated
- `errors.json`: Added community not found messages and button labels
- `admin.json`: Added "Clear" button, secret rotation, and connection test titles; added users page title
- `polls.json`: Added ranked voting result labels
- `about.json`: Added age band template
- `auth.json`: Added login page title to page_meta structure
- `community.json`: Added remote job and closing date translations

## Pre-Deployment Checklist
- [x] No `as any` type assertions introduced
- [x] All translation keys follow existing naming conventions
- [x] Backend change uses Laravel's built-in Schema facade

## Test Plan
- Verify all previously hardcoded strings now display correctly in UI
- Test with different language locales to ensure translation keys are properly referenced
- Confirm `Schema::hasTable()` behaves identically to previous implementation for allowed tables
- Run `npm run build` to ensure no TypeScript errors from translation key references

https://claude.ai/code/session_012aR7Mnc6HEkwze4dPiVU1M