### PR TITLE
fix(audit): tenant validation, missing DB indexes, and i18n violations

### DIFF
--- a/app/Services/GoalProgressService.php
+++ b/app/Services/GoalProgressService.php
@@ -6,6 +6,7 @@
 
 namespace App\Services;
 
+use App\Models\Goal;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -20,6 +21,9 @@ class GoalProgressService
      */
     public function getProgressHistory(int $goalId, array $filters = []): array
     {
+        // Validates tenant ownership via HasTenantScope global scope
+        Goal::findOrFail($goalId);
+
         $limit = min((int) ($filters['limit'] ?? 50), 100);
         $cursor = $filters['cursor'] ?? null;
 
@@ -55,6 +59,9 @@ class GoalProgressService
      */
     public function getSummary(int $goalId): array
     {
+        // Validates tenant ownership via HasTenantScope global scope
+        Goal::findOrFail($goalId);
+
         $total = DB::table('goal_progress_history')
             ->where('goal_id', $goalId)
             ->count();

--- a/app/Services/PollRankingService.php
+++ b/app/Services/PollRankingService.php
@@ -6,6 +6,7 @@
 
 namespace App\Services;
 
+use App\Models\Poll;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -20,6 +21,9 @@ class PollRankingService
      */
     public function submitRanking(int $pollId, int $userId, array $rankings): bool
     {
+        // Validates tenant ownership via HasTenantScope global scope
+        Poll::findOrFail($pollId);
+
         $exists = DB::table('poll_rankings')
             ->where('poll_id', $pollId)
             ->where('user_id', $userId)
@@ -49,6 +53,9 @@ class PollRankingService
      */
     public function calculateResults(int $pollId): array
     {
+        // Validates tenant ownership via HasTenantScope global scope
+        Poll::findOrFail($pollId);
+
         $rankings = DB::table('poll_rankings')
             ->where('poll_id', $pollId)
             ->orderBy('user_id')
@@ -87,6 +94,9 @@ class PollRankingService
      */
     public function getUserRankings(int $pollId, int $userId): ?array
     {
+        // Validates tenant ownership via HasTenantScope global scope
+        Poll::findOrFail($pollId);
+
         $rankings = DB::table('poll_rankings')
             ->where('poll_id', $pollId)
             ->where('user_id', $userId)

--- a/database/migrations/2026_04_14_000001_add_missing_tenant_id_indexes.php
+++ b/database/migrations/2026_04_14_000001_add_missing_tenant_id_indexes.php
@@ -1,0 +1,80 @@
+<?php
+// Copyright © 2024–2026 Jasper Ford
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Author: Jasper Ford
+// See NOTICE file for attribution and acknowledgements.
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add missing tenant_id indexes on 16 tenant-scoped tables.
+ *
+ * An audit identified these tables with tenant_id columns but no index.
+ * Without an index, every tenant-filtered query on these tables causes a
+ * full table scan, degrading performance as row counts grow.
+ *
+ * Tables covered:
+ *   cron_logs, federation_rate_limits, group_answers,
+ *   group_chatroom_pinned_messages, group_notification_preferences,
+ *   group_qa_votes, group_user_bans, group_user_warnings,
+ *   listing_images, org_wallet_limits, progress_notifications,
+ *   push_subscriptions, role_permissions, salary_benchmarks,
+ *   user_permissions, user_roles
+ *
+ * listing_reports is intentionally excluded — it already has a composite
+ * index on (tenant_id, status) from 2026_04_03_100001_create_listing_reports_table.
+ */
+return new class extends Migration
+{
+    /**
+     * The 16 tables that need a plain tenant_id index.
+     * Each entry is [table_name, index_name].
+     */
+    private array $tables = [
+        ['cron_logs',                       'cron_logs_tenant_id_index'],
+        ['federation_rate_limits',           'federation_rate_limits_tenant_id_index'],
+        ['group_answers',                    'group_answers_tenant_id_index'],
+        ['group_chatroom_pinned_messages',   'group_chatroom_pinned_messages_tenant_id_index'],
+        ['group_notification_preferences',   'group_notification_preferences_tenant_id_index'],
+        ['group_qa_votes',                   'group_qa_votes_tenant_id_index'],
+        ['group_user_bans',                  'group_user_bans_tenant_id_index'],
+        ['group_user_warnings',              'group_user_warnings_tenant_id_index'],
+        ['listing_images',                   'listing_images_tenant_id_index'],
+        ['org_wallet_limits',               'org_wallet_limits_tenant_id_index'],
+        ['progress_notifications',          'progress_notifications_tenant_id_index'],
+        ['push_subscriptions',              'push_subscriptions_tenant_id_index'],
+        ['role_permissions',                'role_permissions_tenant_id_index'],
+        ['salary_benchmarks',               'salary_benchmarks_tenant_id_index'],
+        ['user_permissions',                'user_permissions_tenant_id_index'],
+        ['user_roles',                      'user_roles_tenant_id_index'],
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->tables as [$table, $indexName]) {
+            if (Schema::hasTable($table) && ! $this->indexExists($table, $indexName)) {
+                DB::statement("ALTER TABLE `{$table}` ADD INDEX `{$indexName}` (`tenant_id`)");
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ($this->tables as [$table, $indexName]) {
+            if (Schema::hasTable($table) && $this->indexExists($table, $indexName)) {
+                DB::statement("ALTER TABLE `{$table}` DROP INDEX `{$indexName}`");
+            }
+        }
+    }
+
+    private function indexExists(string $table, string $indexName): bool
+    {
+        $result = DB::select(
+            "SHOW INDEX FROM `{$table}` WHERE Key_name = ?",
+            [$indexName]
+        );
+        return ! empty($result);
+    }
+};

--- a/react-frontend/public/locales/en/broker.json
+++ b/react-frontend/public/locales/en/broker.json
@@ -123,6 +123,15 @@
     "col_consent": "Consent",
     "col_member": "Member",
     "col_options": "Preferences",
+    "col_has_triggers": "Has Triggers",
+    "yes": "Yes",
+    "no": "No",
+    "stat_flags_month": "Flags This Month",
+    "stat_critical": "Critical Flags",
+    "stat_unreviewed": "Unreviewed",
+    "tabs_aria": "Safeguarding tabs",
+    "severity_label": "Severity:",
+    "review_notes_label": "Review Notes",
     "mark_reviewed": "Mark Reviewed",
     "review_notes_placeholder": "Add review notes...",
     "reviewed_success": "Message reviewed successfully.",
@@ -147,6 +156,12 @@
     "verify": "Verify",
     "reject": "Reject",
     "reject_reason_placeholder": "Reason for rejection...",
+    "reject_reason_label": "Reason",
+    "stat_total": "Total",
+    "stat_pending": "Pending",
+    "stat_verified": "Verified",
+    "stat_expiring": "Expiring Soon",
+    "tabs_aria": "Vetting status tabs",
     "verified_success": "Vetting record verified.",
     "rejected_success": "Vetting record rejected.",
     "no_records": "No vetting records found."
@@ -172,7 +187,10 @@
     "reason_placeholder": "Reason for rejection...",
     "approved_success": "Exchange approved.",
     "rejected_success": "Exchange rejected.",
-    "no_exchanges": "No exchanges found."
+    "no_exchanges": "No exchanges found.",
+    "actions_aria": "Actions",
+    "exchange_actions_aria": "Exchange actions",
+    "status_filter_aria": "Exchange status filter"
   },
 
   "messages": {
@@ -181,6 +199,7 @@
     "filter_unreviewed": "Unreviewed",
     "filter_all": "All",
     "filter_flagged": "Flagged",
+    "filter_aria": "Message filter",
     "col_sender": "Sender",
     "col_receiver": "Receiver",
     "col_preview": "Preview",

--- a/react-frontend/src/broker/pages/ExchangesPage.tsx
+++ b/react-frontend/src/broker/pages/ExchangesPage.tsx
@@ -219,11 +219,11 @@ export default function ExchangesPage() {
         render: (item) => (
           <Dropdown>
             <DropdownTrigger>
-              <Button isIconOnly size="sm" variant="light" aria-label="Actions">
+              <Button isIconOnly size="sm" variant="light" aria-label={t('exchanges.actions_aria')}>
                 <MoreVertical size={16} />
               </Button>
             </DropdownTrigger>
-            <DropdownMenu aria-label="Exchange actions">
+            <DropdownMenu aria-label={t('exchanges.exchange_actions_aria')}>
               <DropdownItem
                 key="approve"
                 onPress={() => setApproveTarget(item)}
@@ -267,7 +267,7 @@ export default function ExchangesPage() {
 
       {/* Status tabs */}
       <Tabs
-        aria-label="Exchange status filter"
+        aria-label={t('exchanges.status_filter_aria')}
         selectedKey={status || 'all'}
         onSelectionChange={handleTabChange}
         className="mb-4"

--- a/react-frontend/src/broker/pages/MessageReviewPage.tsx
+++ b/react-frontend/src/broker/pages/MessageReviewPage.tsx
@@ -246,7 +246,7 @@ export default function MessageReviewPage() {
 
       {/* Filter tabs */}
       <Tabs
-        aria-label="Message filter"
+        aria-label={t('messages.filter_aria')}
         selectedKey={filter}
         onSelectionChange={handleTabChange}
         className="mb-4"

--- a/react-frontend/src/broker/pages/SafeguardingPage.tsx
+++ b/react-frontend/src/broker/pages/SafeguardingPage.tsx
@@ -358,12 +358,12 @@ export default function SafeguardingPage() {
     },
     {
       key: 'has_triggers',
-      label: 'Has Triggers',
+      label: t('safeguarding.col_has_triggers'),
       render: (item) =>
         item.has_triggers ? (
-          <Chip size="sm" color="danger" variant="flat">Yes</Chip>
+          <Chip size="sm" color="danger" variant="flat">{t('safeguarding.yes')}</Chip>
         ) : (
-          <Chip size="sm" color="success" variant="flat">No</Chip>
+          <Chip size="sm" color="success" variant="flat">{t('safeguarding.no')}</Chip>
         ),
     },
     {
@@ -385,21 +385,21 @@ export default function SafeguardingPage() {
       {/* Stat cards */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <StatCard
-          label="Flags This Month"
+          label={t('safeguarding.stat_flags_month')}
           value={stats?.total_flags_this_month ?? 0}
           icon={Flag}
           color="warning"
           loading={statsLoading}
         />
         <StatCard
-          label="Critical Flags"
+          label={t('safeguarding.stat_critical')}
           value={stats?.critical_flags ?? 0}
           icon={AlertTriangle}
           color="danger"
           loading={statsLoading}
         />
         <StatCard
-          label="Unreviewed"
+          label={t('safeguarding.stat_unreviewed')}
           value={stats?.unreviewed_flags ?? 0}
           icon={Eye}
           color="primary"
@@ -411,7 +411,7 @@ export default function SafeguardingPage() {
       <Tabs
         selectedKey={activeTab}
         onSelectionChange={(key) => setActiveTab(String(key))}
-        aria-label="Safeguarding tabs"
+        aria-label={t('safeguarding.tabs_aria')}
         color="primary"
         variant="underlined"
       >
@@ -521,11 +521,11 @@ export default function SafeguardingPage() {
                   <p className="text-default-500">{reviewTarget.message_content || reviewTarget.message_body || ''}</p>
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className="text-sm text-default-500">Severity:</span>
+                  <span className="text-sm text-default-500">{t('safeguarding.severity_label')}</span>
                   <SeverityChip severity={reviewTarget.severity || reviewTarget.flag_severity || 'low'} />
                 </div>
                 <Textarea
-                  label="Review Notes"
+                  label={t('safeguarding.review_notes_label')}
                   placeholder={t('safeguarding.review_notes_placeholder')}
                   value={reviewNotes}
                   onValueChange={setReviewNotes}

--- a/react-frontend/src/broker/pages/VettingPage.tsx
+++ b/react-frontend/src/broker/pages/VettingPage.tsx
@@ -269,28 +269,28 @@ export default function VettingPage() {
       {/* Stat cards */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <StatCard
-          label="Total"
+          label={t('vetting.stat_total')}
           value={stats?.total ?? 0}
           icon={FileCheck}
           color="default"
           loading={statsLoading}
         />
         <StatCard
-          label="Pending"
+          label={t('vetting.stat_pending')}
           value={stats?.pending ?? 0}
           icon={Clock}
           color="warning"
           loading={statsLoading}
         />
         <StatCard
-          label="Verified"
+          label={t('vetting.stat_verified')}
           value={stats?.verified ?? 0}
           icon={ShieldCheck}
           color="success"
           loading={statsLoading}
         />
         <StatCard
-          label="Expiring Soon"
+          label={t('vetting.stat_expiring')}
           value={stats?.expiring_soon ?? 0}
           icon={AlertTriangle}
           color="danger"
@@ -302,7 +302,7 @@ export default function VettingPage() {
       <Tabs
         selectedKey={activeTab}
         onSelectionChange={(key) => setActiveTab(String(key) as TabKey)}
-        aria-label="Vetting status tabs"
+        aria-label={t('vetting.tabs_aria')}
         color="primary"
         variant="underlined"
       >
@@ -369,7 +369,7 @@ export default function VettingPage() {
         isLoading={rejectLoading}
       >
         <Textarea
-          label="Reason"
+          label={t('vetting.reject_reason_label')}
           placeholder={t('vetting.reject_reason_placeholder')}
           value={rejectReason}
           onValueChange={setRejectReason}

--- a/react-frontend/src/pages/auth/RegisterPage.tsx
+++ b/react-frontend/src/pages/auth/RegisterPage.tsx
@@ -874,7 +874,7 @@ export function RegisterPage() {
       <form onSubmit={handleSubmit} className="space-y-4">
         {/* Honeypot - hidden from users, visible to bots */}
         <div className="hidden" aria-hidden="true">
-          <label htmlFor="website">Website</label>
+          <label htmlFor="website">{t('register.honeypot_label')}</label>
           <input
             ref={honeypotRef}
             type="text"


### PR DESCRIPTION
## Summary

Full platform code audit with fixes for the top findings:

- **Security:** `GoalProgressService` and `PollRankingService` queried child tables by `goal_id`/`poll_id` without first confirming the parent record belongs to the current tenant. Fixed with `findOrFail()` via tenant-scoped Eloquent models — cross-tenant access now throws a 404 before any query runs.
- **Performance:** 16 tenant-scoped tables had `tenant_id` columns with no index, causing full table scans on every tenant-filtered query. New migration adds the missing indexes with full idempotency guards.
- **i18n:** 20 hardcoded English strings found in 5 broker pages (SafeguardingPage, VettingPage, ExchangesPage, MessageReviewPage, RegisterPage). All replaced with `t()` calls; keys added to `broker.json`.

## Commits

- `bd669c3` — `perf(db): add missing tenant_id indexes on 16 tables`
- `f0af0de` — `fix(security): add tenant validation in GoalProgressService and PollRankingService`
- `2105d2a` — `fix(i18n): replace hardcoded strings in broker pages with translation keys`

## Test plan

- [ ] Run `php artisan migrate` locally — new index migration should apply cleanly with no errors
- [ ] Verify `GoalProgressService::getProgressHistory()` with an invalid/cross-tenant goal ID returns 404
- [ ] Verify `PollRankingService` methods similarly return 404 for cross-tenant poll IDs
- [ ] Check broker pages (Safeguarding, Vetting, Exchanges, MessageReview) render labels correctly with active locale

https://claude.ai/code/session_01RqUyNNBA8mMUr8rHQsvJ4v