### PR TITLE
fix(listings): Fix renewListing runtime error on success path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Documentation now covers every module and follows the Diátaxis framework.** Added maintained, code-verified guides for all remaining modules (marketplace, courses, podcasts, blog & resources, social feed, AI chat, ideation & challenges, organisations, monetization, connections & reviews, identity verification) — 24 module guides in total — plus explanation docs for internationalisation ([docs/I18N.md](docs/I18N.md)), the database and migrations ([docs/DATABASE.md](docs/DATABASE.md)), and the CI pipeline ([docs/CI.md](docs/CI.md)), a [RELEASES.md](RELEASES.md) versioning policy, a "How the documentation is organised" Diátaxis index, and a markdownlint configuration.
 - **A hosted documentation site and documentation CI gates.** The docs now build into a searchable MkDocs Material site with an interactive Redoc API reference (deployed to GitHub Pages), and CI gained documentation quality gates: markdownlint (Markdown structure), Redocly (OpenAPI contract validity), and a MkDocs build check.
 
+### Fixed
+
+- **Renewing a listing that was about to expire no longer errors.** One-click renewal of an active listing with a future expiry date was failing with a runtime error instead of extending it; renewal now correctly extends the expiry by 30 days and increments the renewal counter.
+
 ## [1.5.3] - 2026-06-23
 
 ### Added

--- a/app/Models/Listing.php
+++ b/app/Models/Listing.php
@@ -66,6 +66,7 @@ class Listing extends Model
         'direct_messaging_disabled' => 'boolean',
         'exchange_workflow_required' => 'boolean',
         'is_featured' => 'boolean',
+        'expires_at' => 'datetime',
         'renewed_at' => 'datetime',
         'featured_until' => 'datetime',
         'reviewed_at' => 'datetime',

--- a/app/Services/ListingExpiryService.php
+++ b/app/Services/ListingExpiryService.php
@@ -210,12 +210,13 @@ class ListingExpiryService
 
         $newExpiresAt = $baseDate->copy()->addDays(self::RENEWAL_DAYS)->format('Y-m-d H:i:s');
 
-        $listing->update([
-            'status' => 'active',
-            'expires_at' => $newExpiresAt,
-            'renewed_at' => now(),
-            'renewal_count' => DB::raw('renewal_count + 1'),
-        ]);
+        // Set + save instead of DB::raw('renewal_count + 1'): the raw expression
+        // conflicts with the 'renewal_count' => 'integer' cast in Listing::$casts.
+        $listing->status = 'active';
+        $listing->expires_at = $newExpiresAt;
+        $listing->renewed_at = now();
+        $listing->renewal_count = $currentCount + 1;
+        $listing->save();
 
         // Log activity
         try {

--- a/react-frontend/package-lock.json
+++ b/react-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexus-react-frontend",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexus-react-frontend",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -5627,6 +5627,72 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
@@ -9866,6 +9932,18 @@
         "rxjs": {
           "optional": true
         }
+      }
+    },
+    "node_modules/heroui-cli/node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/heroui-cli/node_modules/yocto-queue": {

--- a/tests/Laravel/Unit/Services/ListingExpiryServiceTest.php
+++ b/tests/Laravel/Unit/Services/ListingExpiryServiceTest.php
@@ -194,32 +194,73 @@ class ListingExpiryServiceTest extends TestCase
         $this->assertSame(0, $result['errors']);
     }
 
-    // ── renewListing: successful path (service has two known bugs — documented) ─
+    // ── renewListing: successful path — extends expiry, increments renewal_count ─
 
     /**
-     * @see ListingExpiryService::renewListing() line 206: $listing->expires_at is a
-     *      raw string (not in Listing::$casts as datetime), so ->copy() on line 211
-     *      throws "Call to a member function copy() on string" for active listings
-     *      with a future expires_at.
+     * Active listing with a future expires_at: renewal extends expiry by RENEWAL_DAYS
+     * from the existing expires_at and bumps renewal_count by one.
      *
-     *      Additionally, DB::raw('renewal_count + 1') on line 217 conflicts with the
-     *      'renewal_count' => 'integer' cast in Listing::$casts, throwing
-     *      "Object of class Query\Expression could not be converted to int" on every
-     *      renewal path that reaches the update() call.
-     *
-     *      Both bugs exist in app/ source which cannot be modified by this test suite.
-     *      The two successful-renewal tests are skipped until the service is fixed:
-     *      (a) add 'expires_at' => 'datetime' to Listing::$casts, and
-     *      (b) use $listing->increment('renewal_count') instead of DB::raw().
+     * This is the path that previously threw at runtime:
+     *  (a) expires_at was not cast to datetime, so $baseDate->copy() hit a string;
+     *  (b) DB::raw('renewal_count + 1') conflicted with the 'renewal_count' => 'integer'
+     *      cast. Both are now fixed (see Listing::$casts + ListingExpiryService).
      */
-    public function test_renew_listing_success_path_skipped_pending_service_bug_fix(): void
+    public function test_renew_listing_success_extends_expiry_and_increments_count(): void
     {
-        $this->markTestSkipped(
-            'renewListing() has two service-layer bugs: ' .
-            '(1) expires_at is not cast to datetime so ->copy() throws on string; ' .
-            '(2) DB::raw(renewal_count+1) conflicts with integer cast in Listing::$casts. ' .
-            'Fix app/Services/ListingExpiryService.php and app/Models/Listing.php before enabling.'
+        $baseExpiry = Carbon::now()->addDays(5)->startOfSecond();
+        $listingId  = $this->insertListing([
+            'status'        => 'active',
+            'expires_at'    => $baseExpiry->toDateTimeString(),
+            'renewal_count' => 2,
+        ]);
+
+        $result = $this->service->renewListing($listingId, $this->userId);
+
+        $this->assertTrue($result['success'], 'Renewal of an active future-expiry listing should succeed');
+        $this->assertNull($result['error']);
+        $this->assertNotNull($result['new_expires_at']);
+
+        // New expiry must be exactly RENEWAL_DAYS (30) past the original future expiry.
+        $expectedExpiry = $baseExpiry->copy()->addDays(30);
+        $this->assertSame($expectedExpiry->format('Y-m-d H:i:s'), $result['new_expires_at']);
+
+        $row = DB::table('listings')->where('id', $listingId)->first();
+        $this->assertSame('active', $row->status);
+        $this->assertTrue(
+            Carbon::parse($row->expires_at)->isSameMinute($expectedExpiry),
+            'Stored expires_at should be extended by 30 days from the original future expiry'
         );
+        $this->assertSame(3, (int) $row->renewal_count, 'renewal_count must increment from 2 to 3');
+    }
+
+    // ── renewListing: expired listing renews from now() ──────────────────────────
+
+    /**
+     * A listing that is past its expiry (or not 'active') renews from now(), not from
+     * the stale past expires_at — confirms the now() base-date branch also works.
+     */
+    public function test_renew_listing_expired_listing_renews_from_now(): void
+    {
+        $listingId = $this->insertListing([
+            'status'        => 'expired',
+            'expires_at'    => Carbon::now()->subDays(3)->toDateTimeString(),
+            'renewal_count' => 0,
+        ]);
+
+        $before = Carbon::now();
+        $result = $this->service->renewListing($listingId, $this->userId);
+        $after  = Carbon::now();
+
+        $this->assertTrue($result['success']);
+
+        // New expiry should be ~30 days from now (between before+30d and after+30d).
+        $newExpiry = Carbon::parse($result['new_expires_at']);
+        $this->assertTrue($newExpiry->greaterThanOrEqualTo($before->copy()->addDays(30)->subSecond()));
+        $this->assertTrue($newExpiry->lessThanOrEqualTo($after->copy()->addDays(30)->addSecond()));
+
+        $row = DB::table('listings')->where('id', $listingId)->first();
+        $this->assertSame('active', $row->status, 'Renewing reactivates an expired listing');
+        $this->assertSame(1, (int) $row->renewal_count);
     }
 
     // ── renewListing: non-owner gets forbidden ────────────────────────────────


### PR DESCRIPTION
## Summary
- Fix `ListingExpiryService::renewListing()` throwing at runtime on the success path, so renewing an expiring listing now actually extends it.
- Add `'expires_at' => 'datetime'` to `Listing::$casts` (consistent with the existing `renewed_at`/`featured_until`/`reviewed_at` casts) and replace `DB::raw('renewal_count + 1')` with an explicit set + save that respects the `'renewal_count' => 'integer'` cast.
- Un-skip the previously-skipped success-path test and add coverage for both the active future-expiry path and the expired-listing path.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## Contributor Terms
- [x] I have read and agree to `CONTRIBUTOR_TERMS.md`, including the licence grant, patent grant, ownership/employer-permission confirmation, third-party-code restrictions, and AI-disclosure requirements.
- [x] I confirm I own this contribution or am authorised to submit it on behalf of the person or organisation that owns it.
- [x] I have disclosed meaningful AI-generated or AI-assisted contributions in this PR, or this PR contains no meaningful AI-generated or AI-assisted contribution.

**Third-Party Material Disclosure:** None

**AI Contribution Disclosure:** Implemented with Claude Code (Claude) — diagnosed the two service-layer bugs, applied the model cast + service fix, and wrote the regression tests.

## Root Cause Analysis (required for bug fixes)
**What was the bug?**
Renewing an active listing with a future `expires_at` (the normal "renew before it expires" flow) errored at runtime instead of extending the expiry, so users could not renew expiring listings.

**Root Cause:**
Two independent service-layer faults on the renewal path:
1. `expires_at` was not declared as a `datetime` cast on `App\Models\Listing`, so the value loaded off the model was a plain string. `renewListing()` called `$baseDate->copy()` on it (`copy()` is a Carbon method), which throws `Call to a member function copy() on string` whenever the active/future-expiry branch was taken.
2. The renewal `update()` set `renewal_count` to `DB::raw('renewal_count + 1')` while the model declares `'renewal_count' => 'integer'`. The integer cast tries to convert the `Query\Expression` object to an int and throws `Object of class Illuminate\Database\Query\Expression could not be converted to int`.

**Why wasn't it caught earlier?**
There was no test exercising the successful renewal path — the existing test only covered the `not_found`/`forbidden`/`limit_reached` guard branches, all of which return before reaching the buggy `->copy()` + `update()` lines. The success-path test had been written but left `markTestSkipped()` precisely because of these two bugs.

**Prevention:**
- Added `'expires_at' => 'datetime'` to `Listing::$casts` so the attribute is always a Carbon instance.
- Replaced the raw SQL increment with an explicit set + `save()` using the already-computed current count, which is compatible with the integer cast.
- Un-skipped and implemented two real success-path tests (`renewListing` returns `success => true`, extends `expires_at` by 30 days, increments `renewal_count`) covering both the active future-expiry branch and the expired-from-now branch, so a regression on either bug now fails CI.

## Pre-Deployment Checklist
- [ ] `npx tsc --noEmit` passes in `react-frontend/` (no frontend changes)
- [ ] `npm run build` succeeds in `react-frontend/` (no frontend changes)
- [x] PHP syntax check passes (`php -l` on all three modified PHP files)
- [x] New DELETE/UPDATE queries include `AND tenant_id = ?` for tenant-scoped tables (renewal still scopes the initial fetch by `tenant_id`; `save()` keys on the already tenant-scoped model)
- [x] No `data.data ??` patterns introduced
- [x] No new `as any` type assertions without justification

## Test Plan
Run the un-skipped service test in the PHP container:

```bash
docker exec nexus-php-app php vendor/bin/phpunit tests/Laravel/Unit/Services/ListingExpiryServiceTest.php --no-coverage
```

Expected: all cases pass, including `test_renew_listing_success_extends_expiry_and_increments_count` (active future-expiry → expiry extended by 30 days, `renewal_count` 2→3) and `test_renew_listing_expired_listing_renews_from_now` (expired → reactivated, expiry ~30 days from now, `renewal_count` 0→1).

> Note: the test suite requires the project's MariaDB-backed container; it was not executable in the ephemeral CI sandbox used to author this change (no `vendor/` and no MariaDB), so it must be run via the canonical `docker exec` command above. All three modified PHP files pass `php -l`.

---
Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011WgQ7aiovytd9gdVFEsPf1)_