### PR TITLE
fix(listings): persist moderation audit fields on Listing model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Documentation now covers every module and follows the Diátaxis framework.** Added maintained, code-verified guides for all remaining modules (marketplace, courses, podcasts, blog & resources, social feed, AI chat, ideation & challenges, organisations, monetization, connections & reviews, identity verification) — 24 module guides in total — plus explanation docs for internationalisation ([docs/I18N.md](docs/I18N.md)), the database and migrations ([docs/DATABASE.md](docs/DATABASE.md)), and the CI pipeline ([docs/CI.md](docs/CI.md)), a [RELEASES.md](RELEASES.md) versioning policy, a "How the documentation is organised" Diátaxis index, and a markdownlint configuration.
 - **A hosted documentation site and documentation CI gates.** The docs now build into a searchable MkDocs Material site with an interactive Redoc API reference (deployed to GitHub Pages), and CI gained documentation quality gates: markdownlint (Markdown structure), Redocly (OpenAPI contract validity), and a MkDocs build check.
 
+### Fixed
+
+- **Marketplace moderation decisions now keep their audit trail.** When an admin flagged, approved, or rejected a listing, the rejection reason, the reviewing admin, and the review timestamp were being silently dropped instead of saved — so the record of *who* reviewed a listing, *when*, and *why* it was rejected was lost. Those moderation details are now persisted correctly.
+
 ## [1.5.3] - 2026-06-23
 
 ### Added

--- a/app/Models/Listing.php
+++ b/app/Models/Listing.php
@@ -49,6 +49,9 @@ class Listing extends Model
         'save_count',
         'is_featured',
         'featured_until',
+        'rejection_reason',
+        'reviewed_by',
+        'reviewed_at',
     ];
 
     /**

--- a/tests/Laravel/Unit/Services/ListingModerationServiceTest.php
+++ b/tests/Laravel/Unit/Services/ListingModerationServiceTest.php
@@ -82,11 +82,8 @@ class ListingModerationServiceTest extends TestCase
 
         $row = DB::table('listings')->where('id', $listingId)->first();
         $this->assertSame('pending_review', $row->moderation_status);
-        // NOTE: suspected source bug — `rejection_reason` is absent from Listing::$fillable,
-        // so $listing->update(['rejection_reason' => ...]) is silently discarded by Eloquent
-        // mass-assignment protection. The reason is never persisted. Fix: add 'rejection_reason'
-        // (and 'reviewed_by', 'reviewed_at') to Listing::$fillable in app/Models/Listing.php.
-        $this->assertNull($row->rejection_reason);
+        // `rejection_reason` is now in Listing::$fillable, so the flagged reason persists.
+        $this->assertSame('Suspicious content', $row->rejection_reason);
     }
 
     /**
@@ -99,10 +96,8 @@ class ListingModerationServiceTest extends TestCase
         $this->service->flag($this->tenantId, $listingId, $this->userId, '  Too vague   ');
 
         $row = DB::table('listings')->where('id', $listingId)->first();
-        // NOTE: suspected source bug — `rejection_reason` is not in Listing::$fillable, so the
-        // trimmed value is never written. Asserts actual current behaviour (null). See note in
-        // test_flag_sets_pending_review_and_reason for the full explanation.
-        $this->assertNull($row->rejection_reason);
+        // The reason is trimmed before being persisted to the now-fillable column.
+        $this->assertSame('Too vague', $row->rejection_reason);
     }
 
     /**
@@ -143,12 +138,10 @@ class ListingModerationServiceTest extends TestCase
         $row = DB::table('listings')->where('id', $listingId)->first();
         $this->assertSame('active', $row->status);
         $this->assertSame('approved', $row->moderation_status);
-        // NOTE: suspected source bug — `reviewed_by` and `reviewed_at` are absent from
-        // Listing::$fillable, so the approve() call to $listing->update([...]) silently
-        // discards those fields. Fix: add 'reviewed_by', 'reviewed_at', and 'rejection_reason'
-        // to Listing::$fillable in app/Models/Listing.php.
-        $this->assertNull($row->reviewed_by);
-        $this->assertNull($row->reviewed_at);
+        // `reviewed_by` / `reviewed_at` are now fillable, so the moderation audit trail persists.
+        $this->assertSame($this->adminId, (int) $row->reviewed_by);
+        $this->assertNotNull($row->reviewed_at);
+        // approve() explicitly clears any prior rejection reason.
         $this->assertNull($row->rejection_reason);
     }
 
@@ -206,12 +199,10 @@ class ListingModerationServiceTest extends TestCase
         $row = DB::table('listings')->where('id', $listingId)->first();
         $this->assertSame('rejected', $row->status);
         $this->assertSame('rejected', $row->moderation_status);
-        // NOTE: suspected source bug — `rejection_reason`, `reviewed_by`, and `reviewed_at` are
-        // absent from Listing::$fillable, so $listing->update([...]) in reject() silently discards
-        // all three fields. Fix: add them to Listing::$fillable in app/Models/Listing.php.
-        $this->assertNull($row->rejection_reason);
-        $this->assertNull($row->reviewed_by);
-        $this->assertNull($row->reviewed_at);
+        // All three moderation fields are now fillable, so the audit trail persists.
+        $this->assertSame('Violates community standards', $row->rejection_reason);
+        $this->assertSame($this->adminId, (int) $row->reviewed_by);
+        $this->assertNotNull($row->reviewed_at);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add `rejection_reason`, `reviewed_by`, and `reviewed_at` to `Listing::$fillable` so marketplace/listing moderation decisions actually persist their audit trail.
- Restore the real assertions in `ListingModerationServiceTest` that previously documented (and locked in) the buggy `null` behaviour.
- Add a `CHANGELOG.md` entry under `[Unreleased] → Fixed`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## Contributor Terms
- [x] I have read and agree to `CONTRIBUTOR_TERMS.md`, including the licence grant, patent grant, ownership/employer-permission confirmation, third-party-code restrictions, and AI-disclosure requirements.
- [x] I confirm I own this contribution or am authorised to submit it on behalf of the person or organisation that owns it.
- [x] I have disclosed meaningful AI-generated or AI-assisted contributions in this PR, or this PR contains no meaningful AI-generated or AI-assisted contribution.

**Third-Party Material Disclosure:** None

**AI Contribution Disclosure:** Authored with Claude Code (Anthropic) — diagnosis, the `$fillable` fix, the restored test assertions, and the changelog entry.

## Root Cause Analysis (required for bug fixes)
**What was the bug?**
Listing moderation decisions silently lost their audit trail. When an admin flagged, approved, or rejected a listing, the rejection reason (`rejection_reason`), the reviewing admin (`reviewed_by`), and the review timestamp (`reviewed_at`) were never written to the database, even though the code appeared to set them.

**Root Cause:**
`ListingModerationService::flag()`, `approve()`, and `reject()` write those columns via `$listing->update([...])` (mass assignment). The columns exist in the `listings` table, but they were missing from `Listing::$fillable`. Eloquent's mass-assignment protection silently strips any key not in `$fillable` — no error, no warning — so the three moderation fields were dropped on every write.

**Why wasn't it caught earlier?**
The existing unit tests actually asserted the *buggy* behaviour (`assertNull($row->rejection_reason)`, etc.) with `// NOTE:` comments flagging the suspected cause, so the test suite was green while the bug was live. There was no test asserting the values should persist.

**Prevention:**
- The three fields are now in `Listing::$fillable` (`reviewed_at` was already cast to `datetime`).
- `ListingModerationServiceTest` now asserts the values actually persist (reason text, `reviewed_by === admin id`, `reviewed_at` not null) — converting the tests from "documents the bug" into a real regression guard against future `$fillable` omissions.

## Pre-Deployment Checklist
- [ ] `npx tsc --noEmit` passes in `react-frontend/` — n/a (no frontend changes)
- [ ] `npm run build` succeeds in `react-frontend/` — n/a (no frontend changes)
- [x] PHP syntax check passes (`php -l` on all changed files)
- [x] New DELETE/UPDATE queries include `AND tenant_id = ?` for tenant-scoped tables — n/a (no new queries; service already scopes by `tenant_id`)
- [x] No `data.data ??` patterns introduced
- [x] No new `as any` type assertions without justification
- [x] No locale files changed

## Test Plan
Replicated the CI bootstrap locally (MariaDB 10.11 + `database/schema/mysql-schema.sql` + seeded tenants 1/2) and ran the targeted suite:

```
MAIL_MAILER=array vendor/bin/phpunit \
  tests/Laravel/Unit/Services/ListingModerationServiceTest.php --no-coverage
→ OK (22 tests, 57 assertions)
```

Also verified there is no mass-assignment exposure: the user-facing update path (`ListingService::…->fill(collect($data)->only($allowed)->all())`) uses an explicit `$allowed` whitelist that does **not** include the moderation fields, so they remain settable only server-side by `ListingModerationService`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lvgmef4wWqeEjE6aN6qWYG)_