### PR TITLE
fix(jobs): stamp tenant_id on job-alert subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Documentation now covers every module and follows the Diátaxis framework.** Added maintained, code-verified guides for all remaining modules (marketplace, courses, podcasts, blog & resources, social feed, AI chat, ideation & challenges, organisations, monetization, connections & reviews, identity verification) — 24 module guides in total — plus explanation docs for internationalisation ([docs/I18N.md](docs/I18N.md)), the database and migrations ([docs/DATABASE.md](docs/DATABASE.md)), and the CI pipeline ([docs/CI.md](docs/CI.md)), a [RELEASES.md](RELEASES.md) versioning policy, a "How the documentation is organised" Diátaxis index, and a markdownlint configuration.
 - **A hosted documentation site and documentation CI gates.** The docs now build into a searchable MkDocs Material site with an interactive Redoc API reference (deployed to GitHub Pages), and CI gained documentation quality gates: markdownlint (Markdown structure), Redocly (OpenAPI contract validity), and a MkDocs build check.
 
+### Fixed
+
+- **Job alert subscriptions could become invisible and unmanageable.** Creating a job-alert subscription did not stamp it with the member's community, so the alert could be saved against the wrong tenant — after which it never appeared in the member's alert list and could not be paused, resumed, or deleted. Alerts are now always tagged with the correct community on creation.
+
 ## [1.5.3] - 2026-06-23
 
 ### Added

--- a/app/Services/JobVacancyService.php
+++ b/app/Services/JobVacancyService.php
@@ -1493,6 +1493,7 @@ class JobVacancyService
 
         try {
             $alert = JobAlert::create([
+                'tenant_id' => TenantContext::getId(),
                 'user_id' => $userId,
                 'keywords' => isset($data['keywords']) ? (mb_substr(trim($data['keywords']), 0, 500) ?: null) : null,
                 'categories' => isset($data['categories']) ? (mb_substr(trim($data['categories']), 0, 500) ?: null) : null,

--- a/tests/Laravel/Unit/Services/JobVacancyServiceTest.php
+++ b/tests/Laravel/Unit/Services/JobVacancyServiceTest.php
@@ -654,30 +654,29 @@ class JobVacancyServiceTest extends TestCase
         $this->assertIsInt($alertId);
         $this->assertGreaterThan(0, $alertId);
 
-        // NOTE: source bug — subscribeAlert() omits tenant_id from JobAlert::create(),
-        // so the row is saved with tenant_id=0 (DB default), not the current tenant.
-        // We query the raw table (bypassing HasTenantScope) to confirm the row exists.
+        // subscribeAlert() now sets tenant_id explicitly, so the row is scoped to the
+        // active tenant and is reachable by every other HasTenantScope-scoped query.
         $row = DB::table('job_alerts')->where('id', $alertId)->first();
         $this->assertNotNull($row);
         $this->assertSame((string) $userId, (string) $row->user_id);
         $this->assertSame(1, (int) $row->is_active);
-        // Confirm the tenant_id bug:
-        $this->assertSame(0, (int) $row->tenant_id, 'NOTE: subscribeAlert() bug — tenant_id=0 instead of '.self::TENANT_ID);
+        $this->assertSame(self::TENANT_ID, (int) $row->tenant_id);
+        $this->assertSame('PHP Laravel', $row->keywords);
     }
 
     public function test_getAlerts_returns_alerts_for_user(): void
     {
-        // NOTE: because subscribeAlert() stores tenant_id=0, and getAlerts() uses
-        // JobAlert::where('user_id', ...) which applies HasTenantScope (tenant=2),
-        // the newly-created alert is invisible to getAlerts(). We instead verify
-        // the call returns an array (the model-level behaviour is consistent).
-        $userId = $this->insertUser();
-        $this->svc->subscribeAlert($userId, ['keywords' => 'testing']);
+        $userId  = $this->insertUser();
+        $alertId = $this->svc->subscribeAlert($userId, ['keywords' => 'testing']);
 
         $alerts = $this->svc->getAlerts($userId);
 
         $this->assertIsArray($alerts);
-        // Alert NOT present because of tenant_id=0 mismatch (source bug confirmed above)
+        $this->assertCount(1, $alerts);
+        $this->assertSame($alertId, $alerts[0]['id']);
+        $this->assertSame($userId, $alerts[0]['user_id']);
+        $this->assertTrue($alerts[0]['is_active']);
+        $this->assertSame('testing', $alerts[0]['keywords']);
     }
 
     public function test_unsubscribeAlert_deactivates_alert(): void
@@ -685,15 +684,11 @@ class JobVacancyServiceTest extends TestCase
         $userId  = $this->insertUser();
         $alertId = $this->svc->subscribeAlert($userId, ['keywords' => 'nurse']);
 
-        // NOTE: unsubscribeAlert() uses JobAlert::where('id', ...)->where('user_id', ...)
-        // which applies HasTenantScope (tenant_id=2). The row has tenant_id=0 (source bug
-        // in subscribeAlert — see test_subscribeAlert_creates_alert_and_returns_id).
-        // The update silently matches 0 rows; the row remains is_active=1.
         $this->svc->unsubscribeAlert($alertId, $userId);
 
         $row = DB::table('job_alerts')->where('id', $alertId)->first();
-        // Row is NOT deactivated because HasTenantScope filters it out (tenant_id mismatch).
-        $this->assertSame(1, (int) $row->is_active, 'NOTE: unsubscribeAlert() cannot reach rows saved with wrong tenant_id');
+        $this->assertNotNull($row);
+        $this->assertSame(0, (int) $row->is_active);
     }
 
     public function test_resubscribeAlert_reactivates_alert(): void
@@ -701,13 +696,13 @@ class JobVacancyServiceTest extends TestCase
         $userId  = $this->insertUser();
         $alertId = $this->svc->subscribeAlert($userId, ['keywords' => 'teacher']);
 
-        // NOTE: same tenant_id=0 bug applies here. unsubscribeAlert() does nothing,
-        // so the row remains is_active=1 before and after resubscribeAlert() too.
-        $this->svc->unsubscribeAlert($alertId, $userId); // no-op due to bug
-        $this->svc->resubscribeAlert($alertId, $userId); // no-op due to bug
+        $this->svc->unsubscribeAlert($alertId, $userId);
+        $this->assertSame(0, (int) DB::table('job_alerts')->where('id', $alertId)->value('is_active'));
+
+        $this->svc->resubscribeAlert($alertId, $userId);
 
         $row = DB::table('job_alerts')->where('id', $alertId)->first();
-        $this->assertSame(1, (int) $row->is_active, 'NOTE: both (un)subscribe calls are no-ops due to tenant_id mismatch');
+        $this->assertSame(1, (int) $row->is_active);
     }
 
     public function test_deleteAlert_removes_alert_row(): void
@@ -715,19 +710,10 @@ class JobVacancyServiceTest extends TestCase
         $userId  = $this->insertUser();
         $alertId = $this->svc->subscribeAlert($userId, ['keywords' => 'delete me']);
 
-        // deleteAlert uses JobAlert::where('id',...)->where('user_id',...)->delete().
-        // JobAlert has HasTenantScope, so the global scope adds tenant_id=2 — but the
-        // row has tenant_id=0 (source bug). The delete silently matches 0 rows, and
-        // the alert row persists.
-        // NOTE: This confirms the source bug: deleteAlert() cannot delete alerts it
-        // created because the tenant_id mismatch prevents the scope from matching.
         $this->svc->deleteAlert($alertId, $userId);
 
         $row = DB::table('job_alerts')->where('id', $alertId)->first();
-        // Row still exists due to HasTenantScope filtering on wrong tenant_id.
-        // When the bug in subscribeAlert() is fixed (add tenant_id to create call),
-        // this assertion should be changed to assertNull($row).
-        $this->assertNotNull($row, 'NOTE: Alert row persists due to tenant_id=0 bug in subscribeAlert()');
+        $this->assertNull($row);
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary
- `JobVacancyService::subscribeAlert()` now sets `tenant_id` explicitly on `JobAlert::create()`, matching every other create-path in the service (`create()`, `apply()`, `saveJob()`).
- Restored the real job-alert lifecycle assertions in `tests/Laravel/Unit/Services/JobVacancyServiceTest.php` (subscribe → `getAlerts()` returns it → `unsubscribe`/`resubscribe`/`delete` actually mutate it), replacing the placeholder assertions that documented the buggy no-op behaviour.
- Added a `### Fixed` CHANGELOG entry under `[Unreleased]`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## Contributor Terms
- [x] I have read and agree to `CONTRIBUTOR_TERMS.md`, including the licence grant, patent grant, ownership/employer-permission confirmation, third-party-code restrictions, and AI-disclosure requirements.
- [x] I confirm I own this contribution or am authorised to submit it on behalf of the person or organisation that owns it.
- [x] I have disclosed meaningful AI-generated or AI-assisted contributions in this PR, or this PR contains no meaningful AI-generated or AI-assisted contribution.

**Third-Party Material Disclosure:** None

**AI Contribution Disclosure:** Authored with Claude Code (Anthropic) — diagnosis of the tenant-scoping bug, the one-line source fix, the test rewrite, and this PR description.

## Root Cause Analysis (required for bug fixes)
**What was the bug?**
Job-alert subscriptions created via `subscribeAlert()` could be saved against the wrong tenant. Once mis-stamped, the alert never showed up in `getAlerts()` and could not be paused (`unsubscribeAlert`), resumed (`resubscribeAlert`) or removed (`deleteAlert`) — every one of those tenant-scoped operations silently matched zero rows.

**Root Cause:**
`subscribeAlert()` was the only create-path in `JobVacancyService` that omitted `tenant_id` from `JobAlert::create()`, relying on the `HasTenantScope` `creating` **model-event hook** to fill it in. That hook is an event listener, so it does not run whenever model events are suppressed (`Event::fake()` in tests, `saveQuietly()`, `withoutEvents()`). The `job_alerts.tenant_id` column is `NOT NULL` with **no explicit default**, so in MySQL non-strict mode (`'strict' => false`) the omitted column is written as `0`. Meanwhile `TenantScope` is a **query scope**, not an event — it always appends `WHERE tenant_id = <active>` — so every subsequent read/update/delete filters to the real tenant and never matches the `tenant_id = 0` row.

**Why wasn't it caught earlier?**
The service leaned on an implicit, event-driven side effect for a tenant-isolation invariant instead of setting `tenant_id` explicitly like its sibling methods. The existing tests had been written to *assert the buggy no-op behaviour* (with `// NOTE:` comments) rather than the intended behaviour, so they were green while masking the defect.

**Prevention:**
- Set `tenant_id` explicitly on create — no longer dependent on model events firing.
- The five alert lifecycle tests now assert the **correct** behaviour. Verified as a true regression guard: with the source fix reverted all five fail (alert saved with `tenant_id=0`, `getAlerts()` returns 0 rows, un/resubscribe/delete no-op); with the fix applied all 48 tests in the file pass.

## Translation Review (required when non-English locale files change)
**Translation Status:** N/A — no locale files changed.

## Pre-Deployment Checklist
- [ ] `npx tsc --noEmit` passes in `react-frontend/` — N/A (no frontend changes)
- [ ] `npm run build` succeeds in `react-frontend/` — N/A (no frontend changes)
- [x] PHP syntax check passes (`php -l` clean on both edited files)
- [x] New DELETE/UPDATE queries include `AND tenant_id = ?` for tenant-scoped tables — the fix restores correct `tenant_id` scoping on `job_alerts`
- [x] No `data.data ??` patterns introduced
- [x] No new `as any` type assertions
- [x] No locale files changed

## Test Plan
```
docker exec -e MAIL_MAILER=array nexus-php-app \
  php vendor/bin/phpunit tests/Laravel/Unit/Services/JobVacancyServiceTest.php --no-coverage
```
Result: `OK (48 tests, 139 assertions)`. Negative control (fix reverted) → the 5 alert tests fail, confirming they guard the regression.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAYf6929HTFMai7Qsuhn1P)_