### PR TITLE
fix(ai): Surface job vacancies from the AI search tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Documentation now covers every module and follows the Diátaxis framework.** Added maintained, code-verified guides for all remaining modules (marketplace, courses, podcasts, blog & resources, social feed, AI chat, ideation & challenges, organisations, monetization, connections & reviews, identity verification) — 24 module guides in total — plus explanation docs for internationalisation ([docs/I18N.md](docs/I18N.md)), the database and migrations ([docs/DATABASE.md](docs/DATABASE.md)), and the CI pipeline ([docs/CI.md](docs/CI.md)), a [RELEASES.md](RELEASES.md) versioning policy, a "How the documentation is organised" Diátaxis index, and a markdownlint configuration.
 - **A hosted documentation site and documentation CI gates.** The docs now build into a searchable MkDocs Material site with an interactive Redoc API reference (deployed to GitHub Pages), and CI gained documentation quality gates: markdownlint (Markdown structure), Redocly (OpenAPI contract validity), and a MkDocs build check.
 
+### Fixed
+
+- **The AI assistant can now find job vacancies again.** Asking the community assistant about jobs returned nothing because its job-search lookup filtered on a status value that no longer exists on the job board, so every search came back empty. It now matches open, publicly-visible vacancies correctly.
+
 ## [1.5.3] - 2026-06-23
 
 ### Added

--- a/app/Services/AI/Tools/SearchJobsTool.php
+++ b/app/Services/AI/Tools/SearchJobsTool.php
@@ -55,9 +55,13 @@ class SearchJobsTool extends AbstractTool
         $isRemote = $arguments['is_remote'] ?? null;
         $limit = $this->intArg($arguments, 'limit', 5, 1, 8);
 
+        // A publicly-visible vacancy is status='open' (the enum is
+        // open/closed/filled/draft — there is no 'active'), not under a
+        // moderation hold, and not past its expiry. Mirrors the public_only
+        // scope in JobVacancyService::getAll().
         $q = DB::table('job_vacancies')
             ->where('tenant_id', $tenantId)
-            ->where('status', 'active')
+            ->where('status', 'open')
             ->where(function ($q) {
                 $q->whereNull('moderation_status')->orWhere('moderation_status', 'approved');
             })

--- a/tests/Laravel/Unit/Services/AI/Tools/SearchJobsToolTest.php
+++ b/tests/Laravel/Unit/Services/AI/Tools/SearchJobsToolTest.php
@@ -19,14 +19,9 @@ use Illuminate\Support\Facades\Queue;
  * filter, remote filter, limit, moderation gating, expired-at exclusion,
  * salary formatting, and tenant scoping.
  *
- * NOTE: The job_vacancies table schema defines status as
- * enum('open','closed','filled','draft') — 'active' is NOT a valid value.
- * SearchJobsTool::execute() queries WHERE status = 'active', which can
- * never match any real row.  Tests that exercise the happy path seed rows
- * with status = 'open' but the tool will NOT return them because of this
- * mismatch.  Each such test documents the source bug and asserts the ACTUAL
- * (broken) behaviour so we detect the regression when the bug is fixed.
- * See NOTE comments inline.
+ * A publicly-visible vacancy is status='open' (the job_vacancies.status enum
+ * is open/closed/filled/draft), with no active moderation hold and not past
+ * its expiry — mirroring the public_only scope in JobVacancyService::getAll().
  */
 class SearchJobsToolTest extends \Tests\Laravel\TestCase
 {
@@ -63,9 +58,9 @@ class SearchJobsToolTest extends \Tests\Laravel\TestCase
     // ── helpers ───────────────────────────────────────────────────────────────
 
     /**
-     * Insert a job vacancy with the given status (schema enum: open/closed/filled/draft).
-     * NOTE: SearchJobsTool queries WHERE status='active'. Rows inserted here with
-     * status='open' will NOT be returned until the source bug is fixed.
+     * Insert a job vacancy. Defaults to status='open' (the schema enum is
+     * open/closed/filled/draft), which is the publicly-visible state the tool
+     * surfaces.
      */
     private function insertJob(array $overrides = []): int
     {
@@ -80,7 +75,7 @@ class SearchJobsToolTest extends \Tests\Laravel\TestCase
             'is_remote'         => 0,
             'type'              => 'paid',
             'commitment'        => 'flexible',
-            'status'            => 'active', // NOTE: 'active' is NOT in the enum; MariaDB strict mode will reject this
+            'status'            => 'open',
             'moderation_status' => null,
             'expired_at'        => null,
             'is_featured'       => 0,
@@ -90,9 +85,7 @@ class SearchJobsToolTest extends \Tests\Laravel\TestCase
     }
 
     /**
-     * Insert a job vacancy with the CORRECT enum status value ('open').
-     * These rows will NOT be returned by SearchJobsTool::execute() because
-     * it queries WHERE status='active'. This is the documented source bug.
+     * Insert a publicly-visible job vacancy (status='open').
      */
     private function insertOpenJob(array $overrides = []): int
     {
@@ -165,31 +158,51 @@ class SearchJobsToolTest extends \Tests\Laravel\TestCase
     }
 
     /**
-     * NOTE (SOURCE BUG): SearchJobsTool queries WHERE status='active', but
-     * job_vacancies.status enum is ('open','closed','filled','draft').
-     * 'active' is not a valid value. MariaDB in non-strict mode silently
-     * stores '' (empty string) for an invalid enum value; strict mode raises
-     * a data exception. Either way, no rows match WHERE status='active', so
-     * the tool always returns an empty result set regardless of seeded data.
-     *
-     * This test asserts the ACTUAL (broken) behaviour. When the bug is fixed
-     * (change the query to WHERE status='open', or alter the enum), this
-     * test should be updated to assert count >= 1.
+     * The tool surfaces publicly-visible (status='open') vacancies. Seed an
+     * open vacancy and confirm a keyword search returns it with the expected
+     * card shape. Guards against regressing to a status value that no longer
+     * matches the job_vacancies.status enum (open/closed/filled/draft).
      */
-    public function test_execute_returns_empty_due_to_status_active_bug_not_matching_enum(): void
+    public function test_execute_returns_open_vacancy_matching_query(): void
     {
         $keyword = 'developer' . uniqid();
-        // Insert with valid enum status 'open'
-        $this->insertOpenJob(['title' => "Senior {$keyword} role"]);
+        $jobId = $this->insertOpenJob([
+            'title'       => "Senior {$keyword} role",
+            'description' => 'Build great things with the team.',
+            'location'    => 'Dublin',
+        ]);
 
-        // NOTE: BUG — tool queries WHERE status='active'; enum has no 'active' value.
-        // Expected correct behaviour after fix: count >= 1. Actual: 0.
         $result = $this->tool->execute(['query' => $keyword], 1);
 
         $this->assertTrue($result['ok']);
-        // Asserting ACTUAL broken behaviour — update when source bug is fixed:
-        $this->assertSame(0, count($result['results']),
-            'NOTE: SearchJobsTool uses WHERE status=\'active\' but enum only has open/closed/filled/draft — fix the tool query to WHERE status=\'open\'');
+        $this->assertSame('job', $result['card_type']);
+        $this->assertNull($result['error']);
+        $this->assertGreaterThanOrEqual(1, count($result['results']));
+
+        $ids = array_column($result['results'], 'id');
+        $this->assertContains($jobId, $ids, 'Open vacancy matching the query should be returned.');
+
+        $row = $result['results'][array_search($jobId, $ids, true)];
+        $this->assertSame("Senior {$keyword} role", $row['title']);
+        $this->assertSame('Dublin', $row['location']);
+        $this->assertStringContainsString('/jobs/' . $jobId, $row['url']);
+    }
+
+    /**
+     * Non-open statuses (closed/filled/draft) are not publicly visible and
+     * must be excluded.
+     */
+    public function test_execute_excludes_non_open_statuses(): void
+    {
+        $keyword = 'archivist' . uniqid();
+        $this->insertJob(['title' => "{$keyword} closed", 'status' => 'closed']);
+        $this->insertJob(['title' => "{$keyword} filled", 'status' => 'filled']);
+        $this->insertJob(['title' => "{$keyword} draft", 'status' => 'draft']);
+
+        $result = $this->tool->execute(['query' => $keyword], 1);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame([], $result['results']);
     }
 
     // ── execute: empty/no-query (browse all) ─────────────────────────────────
@@ -215,9 +228,8 @@ class SearchJobsToolTest extends \Tests\Laravel\TestCase
 
     public function test_limit_intarg_clamps_to_max_8(): void
     {
-        // We test the intArg clamping indirectly — result count cannot exceed 8
-        // (Since status bug means 0 results, we just verify no exception is thrown
-        // and result count does not exceed 8.)
+        // intArg clamps limit to a max of 8, so the result count can never
+        // exceed 8 regardless of the requested value.
         $result = $this->tool->execute(['query' => '', 'limit' => 100], 1);
 
         $this->assertTrue($result['ok']);
@@ -235,10 +247,8 @@ class SearchJobsToolTest extends \Tests\Laravel\TestCase
     // ── execute: result structure when rows exist ─────────────────────────────
 
     /**
-     * To actually test result structure we need status='active' to match.
-     * We work around the source bug by directly inserting with status='active'
-     * (stored as '' by MariaDB non-strict) and accepting it might not match.
-     * Instead we verify the tool NEVER crashes on empty results.
+     * The result envelope always exposes the same keys, even when no rows
+     * match.
      */
     public function test_execute_result_structure_has_ok_summary_results_card_type_error(): void
     {
@@ -286,7 +296,7 @@ class SearchJobsToolTest extends \Tests\Laravel\TestCase
     public function test_execute_does_not_include_rejected_moderation(): void
     {
         $keyword = 'accountant' . uniqid();
-        // Even if status bug is fixed, rejected moderation should still exclude
+        // An open vacancy with rejected moderation must still be excluded.
         DB::table('job_vacancies')->insert([
             'tenant_id'         => self::TENANT_ID,
             'user_id'           => $this->ownerUserId,
@@ -302,7 +312,7 @@ class SearchJobsToolTest extends \Tests\Laravel\TestCase
         $result = $this->tool->execute(['query' => $keyword], 1);
 
         $this->assertTrue($result['ok']);
-        // Should be empty: 'open' ≠ 'active' bug + rejected moderation both exclude
+        // Rejected moderation excludes the row even though status is 'open'.
         $this->assertSame([], $result['results']);
     }
 
@@ -333,15 +343,18 @@ class SearchJobsToolTest extends \Tests\Laravel\TestCase
     public function test_execute_does_not_return_jobs_from_another_tenant(): void
     {
         $keyword = 'plumber' . uniqid();
+        // Open + approved in another tenant — only tenant scoping should
+        // keep it out of the current tenant's results.
         DB::table('job_vacancies')->insert([
-            'tenant_id'   => 999,
-            'user_id'     => $this->ownerUserId,
-            'title'       => "{$keyword} needed",
-            'description' => 'Should not appear',
-            'type'        => 'paid',
-            'commitment'  => 'flexible',
-            'status'      => 'active',
-            'created_at'  => now(),
+            'tenant_id'         => 999,
+            'user_id'           => $this->ownerUserId,
+            'title'             => "{$keyword} needed",
+            'description'       => 'Should not appear',
+            'type'              => 'paid',
+            'commitment'        => 'flexible',
+            'status'            => 'open',
+            'moderation_status' => null,
+            'created_at'        => now(),
         ]);
 
         TenantContext::setById(self::TENANT_ID);


### PR DESCRIPTION
## Summary
- `SearchJobsTool` filtered `job_vacancies` on `status = 'active'`, but the column is `enum('open','closed','filled','draft')` — `'active'` can never match, so the AI assistant's `search_jobs` tool returned **zero** results for every query and could never surface a vacancy.
- Changed the filter to `status = 'open'`, matching the `public_only` scope in `JobVacancyService::getAll()`. The moderation (`moderation_status` null/approved) and expiry (`expired_at`) checks were already correct and are unchanged.
- Replaced the test that documented and asserted the broken empty-result behaviour with one that seeds an `open` vacancy and asserts the tool returns it, plus a test confirming non-open statuses (`closed`/`filled`/`draft`) are excluded.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## Contributor Terms
- [x] I have read and agree to `CONTRIBUTOR_TERMS.md`, including the licence grant, patent grant, ownership/employer-permission confirmation, third-party-code restrictions, and AI-disclosure requirements.
- [x] I confirm I own this contribution or am authorised to submit it on behalf of the person or organisation that owns it.
- [x] I have disclosed meaningful AI-generated or AI-assisted contributions in this PR, or this PR contains no meaningful AI-generated or AI-assisted contribution.

**Third-Party Material Disclosure:** None

**AI Contribution Disclosure:** Claude Code (Claude) — diagnosed the status/enum mismatch, applied the one-line query fix, and rewrote the affected unit tests.

## Root Cause Analysis (required for bug fixes)
**What was the bug?**
The AI community assistant's `search_jobs` tool returned no job vacancies for any query, so the chatbot could never recommend open roles even when matching vacancies existed.

**Root Cause:**
The query filtered on `WHERE status = 'active'`, but `job_vacancies.status` is `enum('open','closed','filled','draft')` — there is no `'active'` member. The likely history is a copy of a status convention from another table (e.g. `users.status = 'active'`) that does not apply to the job board, where a live, publicly-visible vacancy is `'open'`. The predicate matched nothing on every run.

**Why wasn't it caught earlier?**
The only test covering the happy path explicitly asserted the *broken* empty-result behaviour (`test_execute_returns_empty_due_to_status_active_bug_not_matching_enum`) with a `// NOTE:` comment, so CI stayed green while the feature was dead. There was no test seeding an `open` vacancy and asserting it is returned.

**Prevention:**
Added `test_execute_returns_open_vacancy_matching_query` (seeds an `open` vacancy and asserts the tool returns it with the expected card shape) and `test_execute_excludes_non_open_statuses` (confirms `closed`/`filled`/`draft` are excluded). These would fail immediately if the status predicate ever regresses to a value outside the enum. The fix is also anchored to the single canonical definition of a publicly-visible vacancy (`JobVacancyService::getAll()`'s `public_only` scope).

## Pre-Deployment Checklist
- [ ] `npx tsc --noEmit` passes in `react-frontend/` — N/A (no frontend changes)
- [ ] `npm run build` succeeds in `react-frontend/` — N/A (no frontend changes)
- [x] PHP syntax check passes (`php -l` clean on the tool and test)
- [x] New DELETE/UPDATE queries include `AND tenant_id = ?` — N/A (read-only SELECT; already tenant-scoped)
- [x] No `data.data ??` patterns introduced
- [x] No new `as any` type assertions without justification
- [x] If locale files changed, i18n checks still pass — N/A (no locale changes)

## Test Plan
Ran the target suite against MariaDB with the full schema loaded:

```
php vendor/bin/phpunit tests/Laravel/Unit/Services/AI/Tools/SearchJobsToolTest.php --no-coverage
# OK (22 tests, 51 assertions)
```

Confirmed the `job_vacancies.status` enum is `open/closed/filled/draft` (no `active`), and that the new happy-path test returns the seeded open vacancy (which the old `status='active'` query could never satisfy).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UANTRwiEGTyDz9NmwAeaLK)_