### PR TITLE
fix(verein): skip already-members in club CSV import instead of aborting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Bulk club-member (Verein) CSV import no longer aborts the whole batch when a row is already a member.** A CSV that included someone who was already an active member of the club was being flagged as a hard validation error, so the entire import failed with "CSV contains invalid rows" and none of the valid rows were imported. Existing members are now treated as a skippable info state: they are reported as already-members in the preview, quietly skipped (and counted as "skipped") on import, and the remaining valid rows are imported as expected. Genuinely bad rows (invalid email, duplicate within the file) still block the import as before.
 - **Three Regional Analytics dashboard sections that always showed "data unavailable" now work.** The Demographics (age groups), Volunteer breakdown (top organisations), and Help-request analysis sections each queried a column that doesn't exist, so every request errored out. They now read the correct columns (`users.date_of_birth`, `vol_logs.organization_id`) and group help requests by contact preference, counting a request as resolved once its status reaches `closed`.
 
 ### Added

--- a/app/Services/CaringCommunity/VereinMemberImportService.php
+++ b/app/Services/CaringCommunity/VereinMemberImportService.php
@@ -54,9 +54,13 @@ class VereinMemberImportService
                 : false;
 
             $action = $existingUser ? 'link_existing' : 'create';
+            // Being an existing active org member is a skippable info state, NOT a
+            // blocking error: import() silently skips these rows (counting them as
+            // "skipped") instead of aborting the whole batch. Do not push it into
+            // $errors. Genuine problems (bad email / in-file duplicate) still flip
+            // the row to 'invalid' in the check below and take precedence.
             if ($alreadyMember) {
                 $action = 'already_member';
-                $errors[] = __('api.verein_import_already_member');
             }
             if ($errors !== []) {
                 $action = 'invalid';
@@ -99,9 +103,11 @@ class VereinMemberImportService
     public function import(int $tenantId, int $organizationId, int $actorId, string $csv): array
     {
         $preview = $this->preview($tenantId, $organizationId, $csv);
+        // Only genuinely invalid rows (bad email / in-file duplicate) abort the
+        // import. 'already_member' rows are skipped gracefully in the loop below.
         $invalid = array_values(array_filter(
             $preview['items'],
-            fn (array $item): bool => $item['errors'] !== []
+            fn (array $item): bool => $item['action'] === 'invalid'
         ));
 
         if ($invalid !== []) {

--- a/tests/Laravel/Unit/Services/CaringCommunity/VereinMemberImportServiceTest.php
+++ b/tests/Laravel/Unit/Services/CaringCommunity/VereinMemberImportServiceTest.php
@@ -273,16 +273,11 @@ class VereinMemberImportServiceTest extends TestCase
         $this->assertNull($result['members'][0]['temporary_password']);
     }
 
-    public function test_preview_marks_existing_org_member_as_invalid_with_error(): void
+    public function test_preview_marks_existing_org_member_as_already_member_without_blocking_error(): void
     {
-        // NOTE: Source bug in VereinMemberImportService::preview() — when a user
-        // is already an active org member the code sets $action = 'already_member'
-        // then immediately adds an error and overwrites $action to 'invalid' (lines
-        // 57-63).  As a result import() always throws InvalidArgumentException for
-        // existing-member rows.  The import() skipped-counter logic at line 118
-        // checks for 'already_member' action but preview() never emits it.
-        // This test asserts the ACTUAL (buggy) behaviour so we detect if the bug
-        // is later fixed without a test update.
+        // An already-active org member is a skippable info state, not a hard error:
+        // preview() must classify the row as 'already_member' and must NOT push it
+        // into the blocking $errors array (otherwise import() aborts the batch).
         $email  = 'alreadymember.' . uniqid() . '@example.test';
         $userId = (int) DB::table('users')->insertGetId([
             'tenant_id'  => $this->testTenantId,
@@ -307,10 +302,66 @@ class VereinMemberImportServiceTest extends TestCase
         $csv    = $this->csv([[$email, 'Already', 'Member', 'member']]);
         $result = $this->service()->preview($this->testTenantId, $this->orgId, $csv);
 
-        // The action is overwritten to 'invalid' (not 'already_member') because
-        // the error-check at line 62-63 fires first — see NOTE above.
-        $this->assertSame('invalid', $result['items'][0]['action']);
-        $this->assertNotEmpty($result['items'][0]['errors']);
+        $this->assertSame('already_member', $result['items'][0]['action']);
+        $this->assertSame([], $result['items'][0]['errors']);
+        // It is an info/skip state, not a hard validation failure.
+        $this->assertSame(0, $result['summary']['invalid']);
+    }
+
+    public function test_import_skips_already_member_and_imports_valid_rows(): void
+    {
+        // Regression: a CSV that mixes an already-member row with valid rows must
+        // skip the already-member (skipped +1) and still import the rest, instead
+        // of throwing InvalidArgumentException and aborting the whole import.
+        $memberEmail = 'present.' . uniqid() . '@example.test';
+        $memberId    = (int) DB::table('users')->insertGetId([
+            'tenant_id'  => $this->testTenantId,
+            'name'       => 'Present Member',
+            'email'      => $memberEmail,
+            'role'       => 'member',
+            'status'     => 'active',
+            'is_approved' => 1,
+            'created_at' => now(),
+        ]);
+        DB::table('org_members')->insertOrIgnore([
+            'tenant_id'       => $this->testTenantId,
+            'organization_id' => $this->orgId,
+            'org_type'        => 'volunteer',
+            'user_id'         => $memberId,
+            'role'            => 'member',
+            'status'          => 'active',
+            'created_at'      => now(),
+        ]);
+
+        $newEmail = 'fresh.' . uniqid() . '@example.test';
+        $csv = $this->csv([
+            [$memberEmail, 'Present', 'Member', 'member'],
+            [$newEmail,    'Fresh',   'Recruit', 'member'],
+        ]);
+
+        $result = $this->service()->import($this->testTenantId, $this->orgId, $this->actorId, $csv);
+
+        // The already-member row is skipped, the new row is created.
+        $this->assertSame(1, $result['skipped']);
+        $this->assertSame(1, $result['created']);
+        $this->assertSame(0, $result['linked']);
+
+        // The valid row really landed in the database.
+        $createdUser = DB::table('users')
+            ->where('tenant_id', $this->testTenantId)
+            ->where('email', $newEmail)
+            ->first();
+        $this->assertNotNull($createdUser, 'Valid row should have been imported despite the already-member row.');
+        $this->assertDatabaseHas('org_members', [
+            'tenant_id'       => $this->testTenantId,
+            'organization_id' => $this->orgId,
+            'user_id'         => $createdUser->id,
+            'status'          => 'active',
+        ]);
+
+        // Only the freshly created user is returned in members; the skipped row is not.
+        $this->assertCount(1, $result['members']);
+        $this->assertSame($newEmail, $result['members'][0]['email']);
     }
 
     public function test_import_mixed_batch_returns_correct_counts(): void


### PR DESCRIPTION
## Summary
- Bulk club-member (Verein) CSV import no longer aborts the **whole** batch when a CSV row belongs to someone who is already an active org member.
- `preview()` now classifies an existing member as a skippable `already_member` info state (no blocking error); `import()` skips those rows (counting them as `skipped`) and imports the remaining valid rows.
- Genuinely invalid rows (bad email / duplicate within the file) still block the import exactly as before.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## Contributor Terms
- [x] I have read and agree to `CONTRIBUTOR_TERMS.md`, including the licence grant, patent grant, ownership/employer-permission confirmation, third-party-code restrictions, and AI-disclosure requirements.
- [x] I confirm I own this contribution or am authorised to submit it on behalf of the person or organisation that owns it.
- [x] I have disclosed meaningful AI-generated or AI-assisted contributions in this PR, or this PR contains no meaningful AI-generated or AI-assisted contribution.

**Third-Party Material Disclosure:** None

**AI Contribution Disclosure:** Claude Code (Claude) implemented the service fix, updated the unit test, and drafted this PR under the repository owner's direction.

## Root Cause Analysis (required for bug fixes)
**What was the bug?**
A CSV containing a member who already belonged to the club caused `VereinMemberImportService::import()` to throw `InvalidArgumentException("CSV contains invalid rows")` and abort the entire import — so none of the valid rows were imported.

**Root Cause:**
In `preview()` the existing-member branch set `$action = 'already_member'` but then *also* pushed a blocking validation error, and the subsequent `if ($errors !== []) { $action = 'invalid'; }` overwrote the action to `invalid`. `import()` then flagged the row as invalid and aborted. Worse, `import()`'s "skipped" counter only incremented on `action === 'already_member'` — a value `preview()` could never actually emit because it was always overwritten. So the already-member skip path was dead code and the failure path was the only reachable one.

**Why wasn't it caught earlier?**
The existing unit test (`test_preview_marks_existing_org_member_as_invalid_with_error`) documented the buggy behaviour as expected (with a `// NOTE:` admitting it was a known source bug), so it asserted the wrong contract and never failed. There was no test exercising `import()` with a mixed already-member + valid-row batch.

**Prevention:**
- `preview()` no longer pushes a blocking error for already-members; the `already_member` action is preserved as a skippable info state.
- `import()`'s abort check now filters on `action === 'invalid'` (genuine errors only), not "row has any errors".
- The misleading test was replaced with `test_preview_marks_existing_org_member_as_already_member_without_blocking_error` (asserts `already_member` + no errors + `summary.invalid === 0`) and a new regression test `test_import_skips_already_member_and_imports_valid_rows` (asserts `skipped === 1`, `created === 1`, the valid row lands in the DB, and the skipped row is not returned).

## Test Plan
```
docker exec -e MAIL_MAILER=array nexus-php-app \
  php vendor/bin/phpunit tests/Laravel/Unit/Services/CaringCommunity/VereinMemberImportServiceTest.php --no-coverage
```
Verified in this environment:
- `VereinMemberImportServiceTest` — **16 tests, 53 assertions, OK** (includes the 2 new/updated tests).
- `AdminCaringCommunityControllerTest` (verein import/admin endpoints) — **3 tests, 19 assertions, OK** (no regression).
- `php -l` clean on the changed service + test; `phpstan analyse` on the changed service reports **no errors**.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R55BUqSMKerimBEP3Yo6Hj

---
_Generated by [Claude Code](https://claude.ai/code/session_01R55BUqSMKerimBEP3Yo6Hj)_