### PR TITLE
fix(caring): correct Carbon v3 signed/float date math in SLA dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Three Regional Analytics dashboard sections that always showed "data unavailable" now work.** The Demographics (age groups), Volunteer breakdown (top organisations), and Help-request analysis sections each queried a column that doesn't exist, so every request errored out. They now read the correct columns (`users.date_of_birth`, `vol_logs.organization_id`) and group help requests by contact preference, counting a request as resolved once its status reaches `closed`.
+- **The Caring Community help-request SLA breach dashboard no longer crashes and now reports accurate turnaround.** An updated date library returned signed, fractional time differences where the dashboard expected whole positive numbers. As a result it threw an error the moment any help request was pending or in progress — taking the whole SLA dashboard down — and every recently-closed request reported a turnaround of zero, so they all looked "within SLA". The dashboard now loads reliably, ages requests correctly into on-track / at-risk / breached buckets against the tenant's SLA policy, and measures real resolution turnaround. The same signed-time-difference issue was also corrected in cron run-duration logging, the job "days posted" metric (admin and accessible frontends), and the social-feed "scheduled more than a year ahead" guard.
 
 ### Added
 

--- a/app/Http/Controllers/Api/JobVacanciesController.php
+++ b/app/Http/Controllers/Api/JobVacanciesController.php
@@ -2979,7 +2979,9 @@ class JobVacanciesController extends BaseApiController
         // Current job metrics
         $currentApps = $vacancy->applications_count ?? 0;
         $currentViews = $vacancy->views_count ?? 0;
-        $daysPosted = $vacancy->created_at ? now()->diffInDays($vacancy->created_at) : 0;
+        // Carbon v3 `diffInDays` is signed; measure created_at -> now (older ->
+        // newer) so days-posted is positive. The reversed form returned negative.
+        $daysPosted = $vacancy->created_at ? (int) $vacancy->created_at->diffInDays(now()) : 0;
 
         // Conversion rate (applications/views) for this job vs average
         $currentConversion = $currentViews > 0 ? round(($currentApps / $currentViews) * 100, 1) : 0;

--- a/app/Http/Controllers/GovukAlpha/Concerns/JobsParity.php
+++ b/app/Http/Controllers/GovukAlpha/Concerns/JobsParity.php
@@ -749,7 +749,9 @@ trait JobsParity
 
             $currentApps = (int) ($vacancy->applications_count ?? 0);
             $currentViews = (int) ($vacancy->views_count ?? 0);
-            $daysPosted = $vacancy->created_at ? (int) now()->diffInDays($vacancy->created_at) : 0;
+            // Carbon v3 `diffInDays` is signed; measure created_at -> now (older ->
+            // newer) so days-posted is positive. The reversed form returned negative.
+            $daysPosted = $vacancy->created_at ? (int) $vacancy->created_at->diffInDays(now()) : 0;
 
             $currentConversion = $currentViews > 0 ? round(($currentApps / $currentViews) * 100, 1) : 0.0;
             $avgConversion = $avgViews > 0 ? round(($avgApplications / $avgViews) * 100, 1) : 0.0;

--- a/app/Services/CaringCommunity/HelpRequestSlaService.php
+++ b/app/Services/CaringCommunity/HelpRequestSlaService.php
@@ -118,10 +118,11 @@ class HelpRequestSlaService
                 continue;
             }
 
-            $ageSec = max(0, $now->diffInSeconds($created, false));
-            // `diffInSeconds` returns a negative value when the second arg is
-            // before the first; we always want a positive age.
-            $ageSec = $created->lessThanOrEqualTo($now) ? $now->diffInSeconds($created) : 0;
+            // Carbon v3 `diffInSeconds` is SIGNED and returns a float. Measure
+            // older -> now so the elapsed age is positive, and clamp to
+            // non-negative so a future-dated row reads as age 0 rather than a
+            // negative age. (`$created->diffInSeconds($now)` > 0 when now > created.)
+            $ageSec = max(0.0, $created->diffInSeconds($now));
 
             $rowView = [
                 'id'             => (int) $row->id,
@@ -158,7 +159,11 @@ class HelpRequestSlaService
             // unless it's closed.
             if ($status === 'closed') {
                 if ($updated && $updated->greaterThanOrEqualTo($resolvedWindow)) {
-                    $turnaroundSec = max(0, $updated->diffInSeconds($created));
+                    // Carbon v3 `diffInSeconds` is SIGNED: measure created -> updated
+                    // (older -> newer) so the turnaround is positive. The previous
+                    // `$updated->diffInSeconds($created)` returned a negative value,
+                    // so `max(0, …)` collapsed every turnaround to 0.
+                    $turnaroundSec = max(0.0, $created->diffInSeconds($updated));
                     $rowView['turnaround_hours'] = round($turnaroundSec / 3600, 1);
                     $rowView['within_resolution_sla'] = $turnaroundSec <= $resolutionSec;
                     $recentlyResolved[] = $rowView;
@@ -208,7 +213,7 @@ class HelpRequestSlaService
         return [$summary, $openRequests, $recentlyResolved];
     }
 
-    private function bucket(int $ageSec, int $targetSec): string
+    private function bucket(float|int $ageSec, int $targetSec): string
     {
         if ($ageSec >= $targetSec) {
             return 'breached';

--- a/app/Services/CronJobService.php
+++ b/app/Services/CronJobService.php
@@ -48,7 +48,10 @@ class CronJobService
             Log::error("CronJobService: {$jobName} failed", ['error' => $errorMsg]);
         }
 
-        $duration = now()->diffInSeconds($startedAt);
+        // Carbon v3 `diffInSeconds` is signed: measure $startedAt -> now (older ->
+        // newer) so the run duration is a non-negative whole number of seconds.
+        // `now()->diffInSeconds($startedAt)` would return a negative float here.
+        $duration = max(0, (int) round($startedAt->diffInSeconds(now())));
 
         DB::table('cron_job_runs')->insert([
             'job_name'   => $jobName,

--- a/app/Services/FeedService.php
+++ b/app/Services/FeedService.php
@@ -1214,7 +1214,10 @@ class FeedService
                 $publishStatus = 'published';
                 $scheduledAt = null;
             }
-            if ($scheduledTime->diffInDays(now()) > 365) {
+            // Carbon v3 `diffInDays` is signed; for a future scheduled time measure
+            // now -> scheduledTime so the "more than a year ahead" guard is positive.
+            // The reversed form returned negative, so this check never fired.
+            if (now()->diffInDays($scheduledTime) > 365) {
                 throw new \InvalidArgumentException(__('api.feed_schedule_too_far'));
             }
         }

--- a/tests/Laravel/Feature/CaringCommunity/HelpRequestSlaDashboardTest.php
+++ b/tests/Laravel/Feature/CaringCommunity/HelpRequestSlaDashboardTest.php
@@ -201,51 +201,27 @@ class HelpRequestSlaDashboardTest extends TestCase
             'Fresh request',
         );
 
-        // ⚠ Bug discovered while writing this test (Carbon 3.x):
-        // HelpRequestSlaService::collect() at line 124 calls
-        //   $now->diffInSeconds($created)
-        // expecting the (positive) age in seconds, but Carbon 3 returns a
-        // FLOAT and reverses the sign convention from Carbon 2:
-        //   $past->diffInSeconds($now) = +N seconds
-        //   $now->diffInSeconds($past) = -N seconds (the service's call shape)
-        // Without `max(0, …)` the negative float is then handed to
-        // bucket(int $ageSec) and trips a TypeError. With it, every age would
-        // clamp to 0 and the breached/at_risk buckets would never trigger.
-        // Both bugs are pre-existing, so the test exercises the dashboard
-        // shape via expectException to verify the failure mode without
-        // silently green-lighting broken arithmetic.
+        // Carbon v3 regression guard: before the fix this call threw a TypeError
+        // (a float age was handed to bucket(int)) and inverted the age sign. The
+        // dashboard now ages requests correctly against the 24h first-response SLA.
         $service = app(HelpRequestSlaService::class);
+        $dashboard = $service->dashboard($this->testTenantId);
 
-        try {
-            $dashboard = $service->dashboard($this->testTenantId);
-            // If the upstream service is ever fixed (cast to int + abs), the
-            // dashboard call returns and we then assert the expected shape.
-            $this->assertSame(2, $dashboard['summary']['pending']);
-            $this->assertSame(1, $dashboard['summary']['first_response_breached']);
-            $this->assertSame(0, $dashboard['summary']['first_response_at_risk']);
+        $this->assertSame(2, $dashboard['summary']['pending']);
+        $this->assertSame(1, $dashboard['summary']['first_response_breached']);
+        $this->assertSame(0, $dashboard['summary']['first_response_at_risk']);
 
-            $this->assertCount(2, $dashboard['open_requests']);
+        $this->assertCount(2, $dashboard['open_requests']);
 
-            $first = $dashboard['open_requests'][0];
-            $this->assertSame($breachedId, (int) $first['id']);
-            $this->assertSame('breached', $first['bucket']);
-            $this->assertSame('first_response', $first['sla_dimension']);
-            $this->assertSame(24, (int) $first['sla_target_hours']);
+        $first = $dashboard['open_requests'][0];
+        $this->assertSame($breachedId, (int) $first['id']);
+        $this->assertSame('breached', $first['bucket']);
+        $this->assertSame('first_response', $first['sla_dimension']);
+        $this->assertSame(24, (int) $first['sla_target_hours']);
 
-            $second = $dashboard['open_requests'][1];
-            $this->assertSame($onTrackId, (int) $second['id']);
-            $this->assertSame('on_track', $second['bucket']);
-        } catch (\TypeError $e) {
-            // Pre-existing bug — Carbon 3 returns float from diffInSeconds and
-            // the service's $ageSec is fed to bucket(int).
-            $this->markTestSkipped(
-                'Pre-existing bug in HelpRequestSlaService: Carbon 3 diffInSeconds '
-                . 'returns a NEGATIVE FLOAT for $now->diffInSeconds($pastDate), which '
-                . 'breaks bucket(int $ageSec) (TypeError) and inverts age signs. '
-                . 'Service must be fixed to: $ageSec = (int) abs($now->diffInSeconds($created)). '
-                . "TypeError: {$e->getMessage()}"
-            );
-        }
+        $second = $dashboard['open_requests'][1];
+        $this->assertSame($onTrackId, (int) $second['id']);
+        $this->assertSame('on_track', $second['bucket']);
     }
 
     public function test_recently_resolved_shows_within_resolution_sla(): void
@@ -284,22 +260,18 @@ class HelpRequestSlaDashboardTest extends TestCase
         $this->assertSame($closedId, (int) $row['id']);
         $this->assertSame('closed', $row['status']);
 
-        // ⚠ Same Carbon 3 sign-flip bug as above — line 161:
-        //   $turnaroundSec = max(0, $updated->diffInSeconds($created));
-        // returns max(0, NEGATIVE) = 0, so turnaround is always reported as 0
-        // hours and within_resolution_sla is always true. We assert what the
-        // service actually produces today (turnaround = 0, within_sla = true)
-        // so the test passes deterministically while still exercising the
-        // recently_resolved code path.
+        // Turnaround = updated(-12h) − created(-36h) = 24h, within the 72h
+        // platform-default resolution SLA. (Regression guard for the Carbon v3
+        // signed-diff fix: the service now measures created → updated, so this
+        // reports the real 24h rather than the old, always-zero value.)
         $this->assertTrue(
             (bool) $row['within_resolution_sla'],
-            'Closed turnaround is reported within the 72h SLA window'
+            'Closed turnaround (24h) is within the 72h resolution SLA window'
         );
         $this->assertSame(
-            0.0,
+            24.0,
             (float) $row['turnaround_hours'],
-            'Pre-existing bug: Carbon 3 diffInSeconds reverses sign vs Carbon 2; '
-            . 'service clamps to 0 with max(0, …). When fixed, this should be ~24.0.'
+            'Turnaround must be the real 24h (updated −12h minus created −36h)'
         );
     }
 

--- a/tests/Laravel/Unit/Services/CaringCommunity/HelpRequestSlaServiceTest.php
+++ b/tests/Laravel/Unit/Services/CaringCommunity/HelpRequestSlaServiceTest.php
@@ -17,23 +17,26 @@ use Illuminate\Support\Facades\Schema;
 use Tests\Laravel\TestCase;
 
 /**
- * NOTE (source bug A): Carbon::diffInSeconds() returns float in Carbon v3 / PHP 8.2,
- * but HelpRequestSlaService::bucket() declares its first parameter as `int`. Any
- * call to dashboard() that processes pending or matched rows will throw:
- *   TypeError: bucket(): Argument #1 ($ageSec) must be of type int, float given
- * (HelpRequestSlaService.php:211, called from lines 140 and 176)
- * Fix: change `private function bucket(int $ageSec, ...)` to `float|int $ageSec`.
+ * Carbon-v3 SLA regression coverage for HelpRequestSlaService. Both source bugs
+ * below are now FIXED; these tests assert the CORRECT behaviour and act as
+ * regression guards against the signed/float Carbon-v3 diff semantics.
  *
- * NOTE (source bug B): In collect(), line 161:
- *   $turnaroundSec = max(0, $updated->diffInSeconds($created));
- * Carbon's diffInSeconds() is SIGNED; $updated->diffInSeconds($created) returns
- * a NEGATIVE float when $updated is AFTER $created (the normal case), so max(0, …)
- * always gives 0. This means:
- *   - $within_resolution_sla is always TRUE (0 ≤ any SLA window)
- *   - $resolved_within_window_24h increments for EVERY recently-closed row regardless of actual turnaround
- * Fix: use $created->diffInSeconds($updated) (reversed operands) or abs(…).
+ * FIXED bug A — Carbon::diffInSeconds() returns a SIGNED float in Carbon v3.
+ *   The age line `$now->diffInSeconds($created)` produced a NEGATIVE float, which
+ *   both threw `TypeError: bucket(): Argument #1 ($ageSec) must be of type int,
+ *   float given` and (once the type was widened) yielded a negative age that
+ *   mis-bucketed every breached request as on_track. Fixed by measuring
+ *   `max(0.0, $created->diffInSeconds($now))` (older → now, clamped) and widening
+ *   bucket()'s first parameter to `float|int`.
  *
- * Tests document ACTUAL behaviour for bug B. Tests that hit bug A are skipped.
+ * FIXED bug B — collect()'s turnaround line was
+ *   `$turnaroundSec = max(0, $updated->diffInSeconds($created));`
+ *   Carbon's diffInSeconds() is SIGNED, so `$updated->diffInSeconds($created)`
+ *   returned a NEGATIVE float when $updated is AFTER $created (the normal case),
+ *   collapsing every turnaround to max(0, negative) = 0. That made
+ *   within_resolution_sla always TRUE and resolved_within_window_24h increment for
+ *   every recently-closed row. Fixed by reversing the operands to
+ *   `max(0.0, $created->diffInSeconds($updated))` (older → newer).
  */
 class HelpRequestSlaServiceTest extends TestCase
 {
@@ -208,86 +211,147 @@ class HelpRequestSlaServiceTest extends TestCase
     }
 
     // ──────────────────────────────────────────────────────────────────────
-    // Source bug A demonstration — skipped tests (pending/matched → bucket() TypeError)
+    // Bucketing + age (FIXED bug A) — pending/matched rows now bucket correctly.
     //
-    // NOTE (source bug A): Carbon::diffInSeconds() → float passed to bucket(int $ageSec).
-    // Fix: `private function bucket(float|int $ageSec, int $targetSec)` in
-    //      app/Services/CaringCommunity/HelpRequestSlaService.php line 211.
+    // Default policy: first_response SLA = 24h, resolution SLA = 72h.
+    // RISK_RATIO_AT_RISK = 0.75 → at_risk threshold is 75% of the target window
+    // (18h for first response, 54h for resolution).
     // ──────────────────────────────────────────────────────────────────────
 
-    /** @group bug-float-ageSec */
     public function test_pending_request_well_within_sla_is_on_track(): void
     {
-        $this->markTestSkipped(
-            'SOURCE BUG A: bucket(int $ageSec) receives float from Carbon::diffInSeconds() — ' .
-            'TypeError at HelpRequestSlaService.php:211. Fix: widen type hint to float|int.'
-        );
+        // Age ≈ 1h, well under the 18h at_risk threshold.
+        $this->insertHelpRequest([
+            'status'     => 'pending',
+            'created_at' => now()->subHour(),
+        ]);
+
+        $result = $this->service()->dashboard($this->testTenantId);
+
+        $this->assertSame(1, $result['summary']['pending']);
+        $this->assertSame(0, $result['summary']['first_response_breached']);
+        $this->assertSame(0, $result['summary']['first_response_at_risk']);
+        $this->assertCount(1, $result['open_requests']);
+
+        $row = $result['open_requests'][0];
+        $this->assertSame('on_track', $row['bucket']);
+        $this->assertSame('first_response', $row['sla_dimension']);
+        $this->assertSame(24, $row['sla_target_hours']);
     }
 
-    /** @group bug-float-ageSec */
     public function test_pending_request_at_risk_above_75_percent_of_sla(): void
     {
-        $this->markTestSkipped(
-            'SOURCE BUG A: bucket(int $ageSec) receives float from Carbon::diffInSeconds() — ' .
-            'TypeError at HelpRequestSlaService.php:211. Fix: widen type hint to float|int.'
-        );
+        // Age ≈ 20h: ≥ 18h (75% of 24h) but < 24h → at_risk.
+        $this->insertHelpRequest([
+            'status'     => 'pending',
+            'created_at' => now()->subHours(20),
+        ]);
+
+        $result = $this->service()->dashboard($this->testTenantId);
+
+        $this->assertSame(1, $result['summary']['first_response_at_risk']);
+        $this->assertSame(0, $result['summary']['first_response_breached']);
+        $this->assertSame('at_risk', $result['open_requests'][0]['bucket']);
     }
 
-    /** @group bug-float-ageSec */
     public function test_pending_request_breached_when_older_than_sla(): void
     {
-        $this->markTestSkipped(
-            'SOURCE BUG A: bucket(int $ageSec) receives float from Carbon::diffInSeconds() — ' .
-            'TypeError at HelpRequestSlaService.php:211. Fix: widen type hint to float|int.'
-        );
+        // Age ≈ 30h ≥ 24h first-response SLA → breached.
+        $this->insertHelpRequest([
+            'status'     => 'pending',
+            'created_at' => now()->subHours(30),
+        ]);
+
+        $result = $this->service()->dashboard($this->testTenantId);
+
+        $this->assertSame(1, $result['summary']['first_response_breached']);
+        $this->assertSame(0, $result['summary']['first_response_at_risk']);
+
+        $row = $result['open_requests'][0];
+        $this->assertSame('breached', $row['bucket']);
+        $this->assertGreaterThanOrEqual(6.0, $row['sla_overage_hours']); // ≈ 30h - 24h
     }
 
-    /** @group bug-float-ageSec */
     public function test_matched_request_well_within_resolution_sla_is_on_track(): void
     {
-        $this->markTestSkipped(
-            'SOURCE BUG A: bucket(int $ageSec) receives float from Carbon::diffInSeconds() — ' .
-            'TypeError at HelpRequestSlaService.php:211. Fix: widen type hint to float|int.'
-        );
+        // Matched (in-progress) measured against the 72h resolution SLA.
+        // Age ≈ 10h, well under the 54h at_risk threshold.
+        $this->insertHelpRequest([
+            'status'     => 'matched',
+            'created_at' => now()->subHours(10),
+        ]);
+
+        $result = $this->service()->dashboard($this->testTenantId);
+
+        $this->assertSame(1, $result['summary']['in_progress']);
+        $this->assertSame(0, $result['summary']['resolution_breached']);
+        $this->assertSame(0, $result['summary']['resolution_at_risk']);
+
+        $row = $result['open_requests'][0];
+        $this->assertSame('on_track', $row['bucket']);
+        $this->assertSame('resolution', $row['sla_dimension']);
+        $this->assertSame(72, $row['sla_target_hours']);
     }
 
-    /** @group bug-float-ageSec */
     public function test_matched_request_breached_when_older_than_resolution_sla(): void
     {
-        $this->markTestSkipped(
-            'SOURCE BUG A: bucket(int $ageSec) receives float from Carbon::diffInSeconds() — ' .
-            'TypeError at HelpRequestSlaService.php:211. Fix: widen type hint to float|int.'
-        );
+        // Age ≈ 80h ≥ 72h resolution SLA → breached.
+        $this->insertHelpRequest([
+            'status'     => 'matched',
+            'created_at' => now()->subHours(80),
+        ]);
+
+        $result = $this->service()->dashboard($this->testTenantId);
+
+        $this->assertSame(1, $result['summary']['in_progress']);
+        $this->assertSame(1, $result['summary']['resolution_breached']);
+        $this->assertSame('breached', $result['open_requests'][0]['bucket']);
     }
 
-    /** @group bug-float-ageSec */
     public function test_open_requests_sorted_breached_before_at_risk_before_on_track(): void
     {
-        $this->markTestSkipped(
-            'SOURCE BUG A: bucket(int $ageSec) receives float from Carbon::diffInSeconds() — ' .
-            'TypeError at HelpRequestSlaService.php:211. Fix: widen type hint to float|int.'
-        );
+        $this->insertHelpRequest(['status' => 'pending', 'created_at' => now()->subHour()]);    // on_track
+        $this->insertHelpRequest(['status' => 'pending', 'created_at' => now()->subHours(20)]); // at_risk
+        $this->insertHelpRequest(['status' => 'pending', 'created_at' => now()->subHours(30)]); // breached
+
+        $result = $this->service()->dashboard($this->testTenantId);
+
+        $this->assertCount(3, $result['open_requests']);
+        $buckets = array_column($result['open_requests'], 'bucket');
+        $this->assertSame(['breached', 'at_risk', 'on_track'], $buckets);
     }
 
-    /** @group bug-float-ageSec */
     public function test_sla_breach_uses_tenant_policy_sla_not_platform_defaults(): void
     {
-        $this->markTestSkipped(
-            'SOURCE BUG A: bucket(int $ageSec) receives float from Carbon::diffInSeconds() — ' .
-            'TypeError at HelpRequestSlaService.php:211. Fix: widen type hint to float|int.'
-        );
+        // Tighten the first-response SLA to 2h via tenant policy.
+        app(OperatingPolicyService::class)->update($this->testTenantId, [
+            'sla_first_response_hours' => 2,
+            'sla_help_request_hours'   => 72,
+        ]);
+
+        // Age ≈ 3h: on_track under the 24h default, but breached under the 2h policy.
+        $this->insertHelpRequest([
+            'status'     => 'pending',
+            'created_at' => now()->subHours(3),
+        ]);
+
+        $result = $this->service()->dashboard($this->testTenantId);
+
+        $this->assertSame(2, $result['policy']['first_response_hours']);
+        $this->assertSame('tenant_policy', $result['policy']['source']);
+        $this->assertSame(1, $result['summary']['first_response_breached']);
+
+        $row = $result['open_requests'][0];
+        $this->assertSame('breached', $row['bucket']);
+        $this->assertSame(2, $row['sla_target_hours']);
     }
 
     // ──────────────────────────────────────────────────────────────────────
-    // Recently resolved — closed rows bypass bucket(), these tests run.
+    // Recently resolved — turnaround / within-SLA (FIXED bug B).
     //
-    // NOTE (source bug B): $updated->diffInSeconds($created) is SIGNED. When $updated
-    // is after $created (the normal case), it returns a NEGATIVE float. The code then
-    // does max(0, negative) = 0, so $turnaroundSec is ALWAYS 0. Consequence:
-    //   - within_resolution_sla is ALWAYS true (0 ≤ any SLA)
-    //   - resolved_within_window_24h increments for EVERY recently-closed row
-    // The tests below assert the ACTUAL (buggy) behaviour and are annotated.
-    // Fix: reverse operands to $created->diffInSeconds($updated), or use abs().
+    // With the signed-diff fix, $turnaroundSec is now the real elapsed
+    // created → updated time, so within_resolution_sla and
+    // resolved_within_window_24h reflect actual turnaround.
     // ──────────────────────────────────────────────────────────────────────
 
     public function test_closed_request_within_72h_appears_in_recently_resolved(): void
@@ -307,6 +371,11 @@ class HelpRequestSlaServiceTest extends TestCase
         $this->assertArrayHasKey('turnaround_hours', $row);
         $this->assertArrayHasKey('within_resolution_sla', $row);
         $this->assertSame('closed', $row['status']);
+
+        // Regression guard for bug B: created 48h ago, updated 1h ago → real
+        // turnaround ≈ 47h. The old signed-diff bug collapsed this to 0.0.
+        $this->assertEqualsWithDelta(47.0, $row['turnaround_hours'], 0.2);
+        $this->assertTrue($row['within_resolution_sla']); // 47h ≤ 72h SLA
     }
 
     public function test_closed_request_older_than_72h_does_not_appear_in_recently_resolved(): void
@@ -323,12 +392,8 @@ class HelpRequestSlaServiceTest extends TestCase
     }
 
     /**
-     * NOTE (source bug B): Due to the signed diffInSeconds bug, $turnaroundSec is
-     * always 0 (max(0, negative) = 0), so resolved_within_window_24h increments
-     * for EVERY recently-closed row, not just those with actual turnaround ≤ 24h.
-     * This test asserts the ACTUAL (buggy) behaviour: the counter IS incremented.
-     * Expected CORRECT behaviour (after fix): should also be 1 here (turnaround ≈ 2h ≤ 24h),
-     * so the bug does not change the assertion for this specific case.
+     * Turnaround ≈ 2h (created 3h ago, updated 1h ago) is ≤ 24h, so
+     * resolved_within_window_24h is incremented.
      */
     public function test_closed_within_24h_turnaround_increments_resolved_within_window_24h(): void
     {
@@ -340,21 +405,18 @@ class HelpRequestSlaServiceTest extends TestCase
 
         $result = $this->service()->dashboard($this->testTenantId);
 
-        // ACTUAL behaviour: increments because bug makes turnaroundSec=0 ≤ 86400.
-        // Correct behaviour would also be 1 here (2h ≤ 24h), so assertion is bug-safe.
         $this->assertSame(1, $result['summary']['resolved_within_window_24h']);
+        $this->assertEqualsWithDelta(2.0, $result['recently_resolved'][0]['turnaround_hours'], 0.2);
     }
 
     /**
-     * NOTE (source bug B): Due to the signed diffInSeconds bug, $turnaroundSec is
-     * always 0, so resolved_within_window_24h is ALWAYS incremented for recently-closed
-     * rows (within 72h window). This test asserts ACTUAL behaviour: counter = 1.
-     * Expected CORRECT behaviour after fix: counter = 0 (turnaround ≈ 48h > 24h).
+     * Regression guard for bug B: turnaround ≈ 48h (created 49h ago, updated 1h
+     * ago) is > 24h, so resolved_within_window_24h must NOT be incremented even
+     * though the row is still within the 72h recently-resolved window. Under the
+     * old signed-diff bug this wrongly counted as 1 (turnaround collapsed to 0).
      */
-    public function test_closed_turnaround_beyond_24h_does_not_increment_resolved_within_window_24h_bug_b(): void
+    public function test_closed_turnaround_beyond_24h_does_not_increment_resolved_within_window_24h(): void
     {
-        // Turnaround ≈ 48h > 24h, but updated recently (within 72h window).
-        // NOTE (source bug B): Actual result is 1 (not 0) due to max(0, negative)=0 bug.
         $this->insertHelpRequest([
             'status'     => 'closed',
             'created_at' => now()->subHours(49),
@@ -363,22 +425,20 @@ class HelpRequestSlaServiceTest extends TestCase
 
         $result = $this->service()->dashboard($this->testTenantId);
 
-        // ACTUAL (buggy) behaviour: 1 because turnaroundSec wrongly computes as 0.
-        $this->assertSame(1, $result['summary']['resolved_within_window_24h']);
+        // Real turnaround ≈ 48h > 24h → counter stays 0.
+        $this->assertSame(0, $result['summary']['resolved_within_window_24h']);
 
         // Row still appears in recently_resolved (correct — updated within 72h).
         $this->assertCount(1, $result['recently_resolved']);
+        $this->assertEqualsWithDelta(48.0, $result['recently_resolved'][0]['turnaround_hours'], 0.2);
     }
 
     /**
-     * NOTE (source bug B): within_resolution_sla is ALWAYS true because turnaroundSec=0
-     * (from max(0, negative signed diff)). Test asserts actual behaviour.
-     * Expected CORRECT behaviour after fix: true (24h turnaround ≤ 72h SLA).
-     * Both agree here, so this test is bug-safe.
+     * Default resolution SLA = 72h. Turnaround ≈ 24h (created 25h ago, updated 1h
+     * ago) is within SLA → within_resolution_sla is true.
      */
     public function test_closed_request_within_resolution_sla_sets_within_resolution_sla_true(): void
     {
-        // Default resolution SLA = 72h. Turnaround ≈ 24h → within SLA.
         $this->insertHelpRequest([
             'status'     => 'closed',
             'created_at' => now()->subHours(25),
@@ -388,19 +448,18 @@ class HelpRequestSlaServiceTest extends TestCase
         $result = $this->service()->dashboard($this->testTenantId);
 
         $this->assertCount(1, $result['recently_resolved']);
-        // ACTUAL and CORRECT behaviour agree: true (both buggy 0h and real 24h are ≤ 72h SLA).
+        $this->assertEqualsWithDelta(24.0, $result['recently_resolved'][0]['turnaround_hours'], 0.2);
         $this->assertTrue($result['recently_resolved'][0]['within_resolution_sla']);
     }
 
     /**
-     * NOTE (source bug B): within_resolution_sla should be FALSE for a 73h turnaround
-     * exceeding the 72h SLA, but due to the signed diffInSeconds bug, turnaroundSec=0
-     * so within_resolution_sla is always TRUE. Test asserts ACTUAL (buggy) behaviour.
-     * Expected CORRECT behaviour after fix: false.
+     * Regression guard for bug B: turnaround ≈ 73h (created 74h ago, updated 1h
+     * ago) exceeds the 72h resolution SLA, so within_resolution_sla must be FALSE.
+     * Under the old signed-diff bug turnaround collapsed to 0 and this wrongly
+     * read true.
      */
-    public function test_closed_request_outside_resolution_sla_within_resolution_sla_is_bugged_true(): void
+    public function test_closed_request_outside_resolution_sla_sets_within_resolution_sla_false(): void
     {
-        // Turnaround ≈ 73h > 72h default SLA → should be false, but bug makes it true.
         $this->insertHelpRequest([
             'status'     => 'closed',
             'created_at' => now()->subHours(74),
@@ -410,11 +469,8 @@ class HelpRequestSlaServiceTest extends TestCase
         $result = $this->service()->dashboard($this->testTenantId);
 
         $this->assertCount(1, $result['recently_resolved']);
-
-        // NOTE (source bug B): within_resolution_sla is TRUE instead of FALSE because
-        // $turnaroundSec = max(0, $updated->diffInSeconds($created)) = max(0, negative) = 0.
-        // Fix: use $created->diffInSeconds($updated) (reversed) or abs().
-        $this->assertTrue($result['recently_resolved'][0]['within_resolution_sla']);
+        $this->assertEqualsWithDelta(73.0, $result['recently_resolved'][0]['turnaround_hours'], 0.2);
+        $this->assertFalse($result['recently_resolved'][0]['within_resolution_sla']);
     }
 
     // ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fix the Caring Community help-request **SLA breach dashboard**, which threw a `TypeError` (taking the whole dashboard down) the moment any request was pending/in-progress, and reported a turnaround of `0` for every recently-closed request (so all closures looked "within SLA").
- Root cause is Carbon v3's `diffInSeconds()` being **signed and float-returning**, where the code assumed Carbon v2's unsigned-int semantics. Restored the 7 previously-skipped bucket/age tests and the turnaround/within-SLA assertions.
- Swept the codebase for the same regression and corrected it in cron run-duration logging, the job "days posted" metric (admin + accessible frontends), and the social-feed "scheduled too far ahead" guard.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## Contributor Terms
- [x] I have read and agree to `CONTRIBUTOR_TERMS.md`, including the licence grant, patent grant, ownership/employer-permission confirmation, third-party-code restrictions, and AI-disclosure requirements.
- [x] I confirm I own this contribution or am authorised to submit it on behalf of the person or organisation that owns it.
- [x] I have disclosed meaningful AI-generated or AI-assisted contributions in this PR, or this PR contains no meaningful AI-generated or AI-assisted contribution.

**Third-Party Material Disclosure:** None

**AI Contribution Disclosure:** Authored with Claude Code (Anthropic). Used to diagnose the Carbon v3 signed/float regression, apply the source fixes, restore the skipped test assertions, and audit other `diffIn*` call sites. All changes were verified against real Carbon 3.11.4 behaviour.

## Root Cause Analysis (required for bug fixes)
**What was the bug?**
`HelpRequestSlaService::dashboard()` threw `TypeError: bucket(): Argument #1 ($ageSec) must be of type int, float given` as soon as a tenant had any pending or in-progress help request, so the SLA dashboard was completely broken in production. Separately, every recently-closed request reported `turnaround_hours = 0` and `within_resolution_sla = true`, and `resolved_within_window_24h` counted every closed row regardless of real turnaround.

**Root Cause:**
The platform upgraded to `nesbot/carbon` v3 (3.11.4). In Carbon v3, `diffInSeconds()` (and the other `diffIn*` methods) became **signed** and **return a float**, whereas Carbon v2 returned an **unsigned int** by default. The service was written against v2 semantics:
- `bucket(int $ageSec, …)` received a float → `TypeError`.
- Age was `$now->diffInSeconds($created)` = `created − now`, which is **negative** because `$created` is in the past (so even with the type widened, every request would mis-bucket as `on_track`).
- Turnaround was `max(0, $updated->diffInSeconds($created))` = `max(0, negative)` = **always 0**, because `$updated` is after `$created`.

**Why wasn't it caught earlier?**
No test exercised `dashboard()` with live pending/in-progress/closed rows (the only existing coverage hit empty or already-excluded rows), and `bucket()`'s `int` type hint plus the `max(0, …)` clamp silently absorbed the wrong values rather than failing loudly. PHPStan did not flag the int/float mismatch on the private method call.

**Prevention:**
- Restored 7 bucket/age tests (pending/matched on-track/at-risk/breached, bucket sort order, tenant-policy SLA override) and corrected the turnaround / within-SLA tests to assert real, signed-diff-correct values — these now fail if the operands are reversed again.
- Added explicit regression guards on `turnaround_hours` (e.g. asserting ≈47h, not 0) so a future reversion is caught immediately.
- Documented the Carbon v3 signed/float behaviour inline at every fixed call site.
- Audited the whole codebase for the same pattern; remaining `diffIn*` call sites were confirmed to use the safe older→newer order or `abs()`/`max()` clamps.

## Translation Review (required when non-English locale files change)
**Translation Status:** N/A — no locale files changed.

**Translation Reviewer:** N/A

**Translation Notes:** This change touches no `lang/` or `react-frontend/public/locales/` files; the social-feed guard reuses the existing `api.feed_schedule_too_far` key.

## Pre-Deployment Checklist
- [ ] `npx tsc --noEmit` passes in `react-frontend/` — N/A (no frontend/TS changes)
- [ ] `npm run build` succeeds in `react-frontend/` — N/A (no frontend changes)
- [x] PHP syntax check passes (`php -l` clean on all 6 edited PHP files)
- [x] New DELETE/UPDATE queries include `AND tenant_id = ?` for tenant-scoped tables — N/A (read-only service; no new writes)
- [x] No `data.data ??` patterns introduced
- [x] No new `as any` type assertions without justification
- [x] If locale files changed, i18n checks still pass — N/A (no locale changes)

## Test Plan
Run the restored unit tests in the Docker PHP environment (requires the `nexus_test` MariaDB the suite depends on):

```bash
docker exec -e MAIL_MAILER=array nexus-php-app \
  php vendor/bin/phpunit \
  tests/Laravel/Unit/Services/CaringCommunity/HelpRequestSlaServiceTest.php --no-coverage
```

> Note: this remote session has no Docker daemon or `nexus_test` DB, so the DB-backed suite could not be executed here. Each scenario's expected values were instead verified by faithfully simulating the fixed `collect()`/`bucket()` logic against real Carbon 3.11.4, and all 6 edited PHP files pass `php -l`. The full suite + PHPStan should be run in the standard Docker/CI environment before merge.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXjpG1UQvMjVhrgMHBzFaP

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXjpG1UQvMjVhrgMHBzFaP)_